### PR TITLE
chore(docgen): mark as documentation for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docgen/* linguist-documentation


### PR DESCRIPTION
Normally the documentation doesn't count in the top bar with regard to languages being used, but we use `docgen` as a folder name, so it doesn't get picked up automatically. This PR fixes that.