### PR TITLE
refac(pod): introduce clear 3 api layers in CocoaPods

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "algolia/algoliasearch-client-swift" "5.1.0"
+github "algolia/algoliasearch-client-swift" "5.1.6"
 github "algolia/instantsearch-core-swift" "3.2.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "algolia/algoliasearch-client-swift" "5.1.6"
-github "algolia/instantsearch-core-swift" "3.2.1"
+github "algolia/algoliasearch-client-swift" "5.1.9"
+github "algolia/instantsearch-core-swift" "3.2.2"

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-    s.name             = "InstantSearch-iOS"
+    s.name             = "InstantSearch"
     s.module_name      = 'InstantSearch'
     s.version          = "2.1.1"
     s.summary          = "A library of widgets and helpers to build instant-search applications on iOS."
@@ -10,10 +10,18 @@ Pod::Spec.new do |s|
     s.social_media_url = 'https://twitter.com/algolia'
     s.ios.deployment_target = '8.0'
     s.requires_arc = true
+    s.default_subspec = "Widgets"
 
-    s.source_files = [
-        'Sources/**/*.{swift}'
-    ]
+    s.subspec "Widgets" do |ss|
+        ss.source_files = 'Sources/**/*.{swift}'
+        ss.dependency 'InstantSearch-Core-Swift', '~> 3.2'
+    end
 
-    s.dependency 'InstantSearch-Core-Swift', '~> 3.2'
+    s.subspec "Core" do |ss|
+        ss.dependency 'InstantSearch-Core-Swift', '~> 3.2'
+    end
+
+    s.subspec "Client" do |ss|
+        ss.dependency 'AlgoliaSearch-Client-Swift', '~> 5.0'
+    end
 end

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -10,18 +10,18 @@ Pod::Spec.new do |s|
     s.social_media_url = 'https://twitter.com/algolia'
     s.ios.deployment_target = '8.0'
     s.requires_arc = true
-    s.default_subspec = "Widgets"
+    s.default_subspec = "UI"
 
-    s.subspec "Widgets" do |ss|
+    s.subspec "UI" do |ss|
         ss.source_files = 'Sources/**/*.{swift}'
-        ss.dependency 'InstantSearch-Core-Swift', '~> 3.2'
+        ss.dependency 'InstantSearchCore', '~> 3.2'
     end
 
     s.subspec "Core" do |ss|
-        ss.dependency 'InstantSearch-Core-Swift', '~> 3.2'
+        ss.dependency 'InstantSearchCore', '~> 3.2'
     end
 
     s.subspec "Client" do |ss|
-        ss.dependency 'AlgoliaSearch-Client-Swift', '~> 5.0'
+        ss.dependency 'InstantSearchClient', '~> 5.0'
     end
 end

--- a/InstantSearch.xcodeproj/xcshareddata/xcschemes/InstantSearch.xcscheme
+++ b/InstantSearch.xcodeproj/xcshareddata/xcschemes/InstantSearch.xcscheme
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       disableMainThreadChecker = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 <img src="https://img.shields.io/badge/platform-iOS-blue.svg?style=flat" alt="Platform iOS" />
 <a href="https://developer.apple.com/swift"><img src="https://img.shields.io/badge/Swift-4.0-blue.svg" alt="Swift 4 compatible" /></a>
 <a href="https://developer.apple.com/documentation/objectivec"><img src="https://img.shields.io/badge/Objective--C-compatible-blue.svg" alt="Objective-C compatible" /></a>
-<a href="https://cocoapods.org/pods/XLActionController"><img src="https://img.shields.io/cocoapods/v/InstantSearch-iOS.svg" alt="CocoaPods compatible" /></a>
+<a href="https://cocoapods.org/pods/XLActionController"><img src="https://img.shields.io/cocoapods/v/InstantSearch.svg" alt="CocoaPods compatible" /></a>
 <a href="https://raw.githubusercontent.com/algolia/InstantSearch/master/LICENSE"><img src="http://img.shields.io/badge/license-MIT-blue.svg?style=flat" alt="License: MIT" /></a>
 </p>
 
@@ -36,7 +36,10 @@ You can see InstantSearch iOS in action in our [Examples repository][ecommerce-u
 To install InstantSearch, simply add the following line to your Podfile:
 
 ```ruby
-pod 'InstantSearch-iOS', '~> 2.0.0'
+pod 'InstantSearch', '~> 2.0.0'
+# pod 'InstantSearch/Widgets' for access to everything
+# pod 'InstantSearch/Core' for access to everything except the UI widgets
+# pod 'InstantSearch/Client' for access only to the API Client
 ```
 
 Then, run the following command:

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ By [Algolia](http://algolia.com).
 
 InstantSearch family: **InstantSearch iOS** | [InstantSearch Android][instantsearch-android-github] | [React InstantSearch][react-instantsearch-github] | [InstantSearch.js][instantsearch-js-github].
 
-**InstantSearch iOS** is a library providing widgets and helpers to help you build the best instant-search experience on iOS with Algolia. It is built on top of Algolia's [Swift API Client](https://github.com/algolia/algoliasearch-client-swift) to provide you a high-level solution to quickly build various search interfaces.
+**InstantSearch iOS** is a framework providing widgets and helpers to help you build the best instant-search experience on iOS with Algolia. It is built on top of Algolia's [Swift API Client](https://github.com/algolia/algoliasearch-client-swift) library to provide you a high-level solution to quickly build various search interfaces.
 
 <!-- <img src="Example/InstantSearch.gif" width="300"/> -->
 
@@ -36,7 +36,7 @@ You can see InstantSearch iOS in action in our [Examples repository][ecommerce-u
 To install InstantSearch, simply add the following line to your Podfile:
 
 ```ruby
-pod 'InstantSearch', '~> 2.0.0'
+pod 'InstantSearch', '~> 2.0'
 # pod 'InstantSearch/Widgets' for access to everything
 # pod 'InstantSearch/Core' for access to everything except the UI widgets
 # pod 'InstantSearch/Client' for access only to the API Client
@@ -54,9 +54,17 @@ $ pod update
 
 To install InstantSearch, simply add the following line to your Cartfile:
 
-```ogdl
-github "algolia/instantsearch-ios" ~> 2.0
+```ruby
+github "algolia/instantsearch-ios" ~> 2.0 # for access to everything
+# github "algolia/instantsearch-core-swift" for access to everything except the UI widgets
+# github "algolia/algoliasearch-client-swift" for access only to the API Client
 ```
+
+#### SwiftPM 
+
+The API client is the only library of the framework available on SwiftPM.
+
+To install the API Client, add `.package(url:"https://github.com/algolia/algoliasearch-client-swift", from: "5.0.0")` to your package dependencies array in Package.swift, then add `AlgoliaSearch` to your target dependencies.
 
 ## Documentation
 

--- a/Sources/InstantSearch.swift
+++ b/Sources/InstantSearch.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 @_exported import InstantSearchCore
-@_exported import AlgoliaSearch
+@_exported import InstantSearchClient
 import UIKit
 
 /// Main class used for interacting with the InstantSearch library.

--- a/Sources/InstantSearch.swift
+++ b/Sources/InstantSearch.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import InstantSearchCore
-import AlgoliaSearch
+@_exported import InstantSearchCore
+@_exported import AlgoliaSearch
 import UIKit
 
 /// Main class used for interacting with the InstantSearch library.

--- a/Tests/ConfigureInstantSearchTests.swift
+++ b/Tests/ConfigureInstantSearchTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import InstantSearch
 import InstantSearchCore
-import AlgoliaSearch
+import InstantSearchClient
 
 class ConfigureInstantSearchTests: XCTestCase {
     

--- a/Tests/ObjectiveCBridgingTests.m
+++ b/Tests/ObjectiveCBridgingTests.m
@@ -9,7 +9,7 @@
 #import <XCTest/XCTest.h>
 
 @import InstantSearch;
-@import AlgoliaSearch;
+@import InstantSearchClient;
 @import InstantSearchCore;
 
 /// Verifies that all the features are accessible from Objective-C.

--- a/Tests/WidgetTests.swift
+++ b/Tests/WidgetTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import InstantSearch
 import InstantSearchCore
-import AlgoliaSearch
+import InstantSearchClient
 
 class WidgetTests: XCTestCase {
     

--- a/docgen/src/getting-started-programmatic.md
+++ b/docgen/src/getting-started-programmatic.md
@@ -37,7 +37,7 @@ We will use CocoaPods for adding the dependency to `InstantSearch`.
 
 - If you don't have CocoaPods installed on your machine, open your terminal and run `sudo gem install cocoapods`.
 - Go to the root of your project then type `pod init`. A `Podfile` will be created for you.
-- Open your `Podfile` and add `pod 'InstantSearch-iOS'` below your target.
+- Open your `Podfile` and add `pod 'InstantSearch'` below your target.
 - On your terminal, run `pod update`.
 - Close you Xcode project and then at the root of your project, open `projectName.xcworkspace`.
 

--- a/docgen/src/getting-started.md
+++ b/docgen/src/getting-started.md
@@ -37,7 +37,7 @@ We will use CocoaPods for adding the dependency to `InstantSearch`.
 
 - If you don't have CocoaPods installed on your machine, open your terminal and run `sudo gem install cocoapods`.
 - Go to the root of your project then type `pod init`. A `Podfile` will be created for you.
-- Open your `Podfile` and add `pod 'InstantSearch-iOS'` below your target.
+- Open your `Podfile` and add `pod 'InstantSearch'` below your target.
 - On your terminal, run `pod update`.
 - Close you Xcode project and then at the root of your project, open `projectName.xcworkspace`.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,12 +37,12 @@ lane :deploy do |options|
 	)
 	new_build_number = version_bump_podspec(
 		bump_type: options[:type],
-		path: "InstantSearch-iOS.podspec"
+		path: "InstantSearch.podspec"
 	)
 
 	#puts changelog_from_git_commits
 	git_commit(
-		path: ["InstantSearch-iOS.podspec", "Sources/Info.plist" ,"Tests/Info.plist", "InstantSearchTestsHost/Info.plist"], 
+		path: ["InstantSearch.podspec", "Sources/Info.plist" ,"Tests/Info.plist", "InstantSearchTestsHost/Info.plist"], 
 		message: "Version #{new_build_number}"
 	)
 	add_git_tag(
@@ -51,7 +51,7 @@ lane :deploy do |options|
 	)
 	push_to_git_remote(remote: "origin")
 	pod_push(
-		path: "InstantSearch-iOS.podspec",
+		path: "InstantSearch.podspec",
 		allow_warnings: true
 	)
 

--- a/instantsearch.xcodeproj/project.pbxproj
+++ b/instantsearch.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		287D0A6E1C4B73BD004566D6 /* WidgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287D0A6D1C4B73BD004566D6 /* WidgetTests.swift */; };
 		28F828881C494B2C00330CF4 /* InstantSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28F8287D1C494B2C00330CF4 /* InstantSearch.framework */; };
 		E21DE94F1F2F7DB400EFC4F5 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21DE94E1F2F7DB400EFC4F5 /* InstantSearchCore.framework */; };
-		E21DE9511F2F7DCA00EFC4F5 /* AlgoliaSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21DE9501F2F7DCA00EFC4F5 /* AlgoliaSearch.framework */; };
 		E2231E951EC9DC0D002FCF82 /* ConfigureInstantSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2231E931EC9DBC4002FCF82 /* ConfigureInstantSearchTests.swift */; };
 		E2231E971EC9F5A7002FCF82 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2231E961EC9F5A7002FCF82 /* Constants.swift */; };
 		E233BBFD1EBA18C200F5F5E1 /* SwitchWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = E233BBFC1EBA18C200F5F5E1 /* SwitchWidget.swift */; };
@@ -88,7 +87,8 @@
 		E2D589101FBB279200526C33 /* SearchViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5890F1FBB279200526C33 /* SearchViewDelegate.swift */; };
 		E2D589121FBB295700526C33 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D589111FBB295700526C33 /* SearchViewModel.swift */; };
 		E2E060571F717A7B0026358B /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21DE94E1F2F7DB400EFC4F5 /* InstantSearchCore.framework */; };
-		E2E060581F717A810026358B /* AlgoliaSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21DE9501F2F7DCA00EFC4F5 /* AlgoliaSearch.framework */; };
+		E2F2073B20B6E3F60066AF12 /* InstantSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2F2073A20B6E3F60066AF12 /* InstantSearchClient.framework */; };
+		E2F2073C20B6E42C0066AF12 /* InstantSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2F2073A20B6E3F60066AF12 /* InstantSearchClient.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -194,6 +194,7 @@
 		E2D5890D1FBB266B00526C33 /* SearchViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelDelegate.swift; sourceTree = "<group>"; };
 		E2D5890F1FBB279200526C33 /* SearchViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewDelegate.swift; sourceTree = "<group>"; };
 		E2D589111FBB295700526C33 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		E2F2073A20B6E3F60066AF12 /* InstantSearchClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = InstantSearchClient.framework; path = Carthage/Build/iOS/InstantSearchClient.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,8 +202,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2F2073B20B6E3F60066AF12 /* InstantSearchClient.framework in Frameworks */,
 				E21DE94F1F2F7DB400EFC4F5 /* InstantSearchCore.framework in Frameworks */,
-				E21DE9511F2F7DCA00EFC4F5 /* AlgoliaSearch.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -210,9 +211,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2F2073C20B6E42C0066AF12 /* InstantSearchClient.framework in Frameworks */,
 				28F828881C494B2C00330CF4 /* InstantSearch.framework in Frameworks */,
 				E2E060571F717A7B0026358B /* InstantSearchCore.framework in Frameworks */,
-				E2E060581F717A810026358B /* AlgoliaSearch.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -279,6 +280,7 @@
 		E21DE94D1F2F7DB400EFC4F5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E2F2073A20B6E3F60066AF12 /* InstantSearchClient.framework */,
 				E21DE9501F2F7DCA00EFC4F5 /* AlgoliaSearch.framework */,
 				E21DE94E1F2F7DB400EFC4F5 /* InstantSearchCore.framework */,
 			);
@@ -642,7 +644,7 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/AlgoliaSearch.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/InstantSearchClient.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/InstantSearchCore.framework",
 			);
 			name = "Carthage Copy Frameworks";


### PR DESCRIPTION
```
pod 'InstantSearch', '~> 2.0.0' // default for everything (equivalent to /UI)
pod 'InstantSearch/UI' // for access to everything
pod 'InstantSearch/Core' // for access to everything except the UI widgets
pod 'InstantSearch/Client' //for access only to the API Client
```

Note also that we're renaming our pod InstantSearch-iOS to InstantSearch since it makes more sense

@robertmogos @PLNech @mthuret  would love your opinion on the final naming of `/UI` `/Core` `/Client` since they won't change in the future.