### PR TITLE
doc(menu): fix API Reference 404

### DIFF
--- a/docgen/src/data/communityHeader.json
+++ b/docgen/src/data/communityHeader.json
@@ -85,7 +85,7 @@
       },
       {
         "name": "API Reference",
-        "url": "reference/"
+        "url": "https://community.algolia.com/algoliasearch-client-swift"
       },
       {
         "name": "Troubleshooting",

--- a/docgen/src/data/communityHeader.json
+++ b/docgen/src/data/communityHeader.json
@@ -114,7 +114,7 @@
   },
   {
     "name": "API Reference",
-    "url": "reference/"
+    "url": "https://community.algolia.com/algoliasearch-client-swift"
   },
   {
     "name": "Troubleshooting",


### PR DESCRIPTION
The link to the API Reference in the [community website documentation](https://community.algolia.com/instantsearch-ios/) is broken:

<img width="272" alt="screen shot 2018-10-30 at 3 11 57 pm" src="https://user-images.githubusercontent.com/783964/47724072-31774b80-dc56-11e8-8b7e-dd73e5274b3a.png">


<img width="997" alt="screen shot 2018-10-30 at 1 23 17 pm" src="https://user-images.githubusercontent.com/783964/47724027-1e647b80-dc56-11e8-848c-c6d766c9dbde.png">
