### PR TITLE
reload view when empty result in refinement list

### DIFF
--- a/Sources/Concrete/ViewModel/RefinementMenuViewModel.swift
+++ b/Sources/Concrete/ViewModel/RefinementMenuViewModel.swift
@@ -185,6 +185,8 @@ extension RefinementMenuViewModel: ResultingDelegate {
         
         guard let facetCounts = results.facets(name: attribute) else {
             print("No facet counts found for attribute: \(attribute)")
+            facetResults = []
+            view?.reloadRefinements()
             return
         }
         


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Bug where refinement list was not being reloaded when no facet results, and if the refinement list was in the same view controller as other widgets 

Bug submitted from [discourse ](https://discourse.algolia.com/t/refinementcollectionwidget-facets-not-updating-when-params-added-to-searcher/6661/5).

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Reload refinements when that's the case. 

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

