### PR TITLE
Integrated Click Analytics to InstantSearch widgets/viewModels.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "algolia/instantsearch-core-swift" ~> 4.0
+github "algolia/instantsearch-ios-insights" ~> 2.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "algolia/algoliasearch-client-swift" "6.1.1"
+github "algolia/algoliasearch-client-swift" "6.2.0"
 github "algolia/instantsearch-core-swift" "4.0.0"
+github "algolia/instantsearch-ios-insights" "2.0.0"

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
     s.subspec "UI" do |ss|
         ss.source_files = 'Sources/**/*.{swift}'
         ss.dependency 'InstantSearchCore', '~> 4.0'
+	ss.dependency 'InstantSearchInsights', '~> 2.0'
     end
 
     s.subspec "Core" do |ss|

--- a/Sources/Concrete/Controller/HitsController.swift
+++ b/Sources/Concrete/Controller/HitsController.swift
@@ -86,8 +86,8 @@ extension HitsController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let hit = viewModel.hitForRow(at: indexPath)
         
-        tableDelegate?.tableView(tableView, didSelectRowAt: indexPath, containing: hit)
         viewModel.captureClickAnalyticsForHit(at: indexPath)
+        tableDelegate?.tableView(tableView, didSelectRowAt: indexPath, containing: hit)
     }
 }
 

--- a/Sources/Concrete/Controller/HitsController.swift
+++ b/Sources/Concrete/Controller/HitsController.swift
@@ -131,6 +131,7 @@ extension HitsController: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let hit = viewModel.hitForRow(at: indexPath)
         
+        viewModel.captureClickAnalyticsForHit(at: indexPath)
         collectionDelegate?.collectionView(collectionView, didSelectItemAt: indexPath, containing: hit)
     }
 }

--- a/Sources/Concrete/Controller/HitsController.swift
+++ b/Sources/Concrete/Controller/HitsController.swift
@@ -87,6 +87,7 @@ extension HitsController: UITableViewDelegate {
         let hit = viewModel.hitForRow(at: indexPath)
         
         tableDelegate?.tableView(tableView, didSelectRowAt: indexPath, containing: hit)
+        viewModel.captureClickAnalyticsForHit(at: indexPath)
     }
 }
 

--- a/Sources/Concrete/View/HitsCollectionWidget.swift
+++ b/Sources/Concrete/View/HitsCollectionWidget.swift
@@ -22,21 +22,21 @@ import InstantSearchCore
     @IBInspectable public var index: String = Constants.Defaults.index
     @IBInspectable public var variant: String = Constants.Defaults.variant
     
-    @IBInspectable public var isClickAnalyticsOn: Bool
+    @IBInspectable public var enableClickAnalytics: Bool
     @IBInspectable public var hitClickEventName: String?
     
     public var viewModel: HitsViewModelDelegate
     
     public override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         viewModel = HitsViewModel()
-        isClickAnalyticsOn = false
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
         super.init(frame: frame, collectionViewLayout: layout)
         viewModel.view = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = HitsViewModel()
-        isClickAnalyticsOn = false
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
         super.init(coder: aDecoder)
         viewModel.view = self
     }

--- a/Sources/Concrete/View/HitsCollectionWidget.swift
+++ b/Sources/Concrete/View/HitsCollectionWidget.swift
@@ -22,16 +22,21 @@ import InstantSearchCore
     @IBInspectable public var index: String = Constants.Defaults.index
     @IBInspectable public var variant: String = Constants.Defaults.variant
     
+    @IBInspectable public var isClickAnalyticsOn: Bool
+    @IBInspectable public var hitClickEventName: String?
+    
     public var viewModel: HitsViewModelDelegate
     
     public override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         viewModel = HitsViewModel()
+        isClickAnalyticsOn = false
         super.init(frame: frame, collectionViewLayout: layout)
         viewModel.view = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = HitsViewModel()
+        isClickAnalyticsOn = false
         super.init(coder: aDecoder)
         viewModel.view = self
     }

--- a/Sources/Concrete/View/HitsTableWidget.swift
+++ b/Sources/Concrete/View/HitsTableWidget.swift
@@ -21,16 +21,21 @@ import UIKit
     @IBInspectable public var index: String = Constants.Defaults.index
     @IBInspectable public var variant: String = Constants.Defaults.variant
     
+    @IBInspectable public var isClickAnalyticsOn: Bool
+    @IBInspectable public var hitClickEventName: String?
+    
     public var viewModel: HitsViewModelDelegate
     
-  public override init(frame: CGRect, style: UITableView.Style) {
+    public override init(frame: CGRect, style: UITableView.Style) {
         viewModel = HitsViewModel()
+        isClickAnalyticsOn = false
         super.init(frame: frame, style: style)
         viewModel.view = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = HitsViewModel()
+        isClickAnalyticsOn = false
         super.init(coder: aDecoder)
         viewModel.view = self
     }

--- a/Sources/Concrete/View/HitsTableWidget.swift
+++ b/Sources/Concrete/View/HitsTableWidget.swift
@@ -21,21 +21,21 @@ import UIKit
     @IBInspectable public var index: String = Constants.Defaults.index
     @IBInspectable public var variant: String = Constants.Defaults.variant
     
-    @IBInspectable public var isClickAnalyticsOn: Bool
+    @IBInspectable public var enableClickAnalytics: Bool
     @IBInspectable public var hitClickEventName: String?
     
     public var viewModel: HitsViewModelDelegate
     
     public override init(frame: CGRect, style: UITableView.Style) {
         viewModel = HitsViewModel()
-        isClickAnalyticsOn = false
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
         super.init(frame: frame, style: style)
         viewModel.view = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = HitsViewModel()
-        isClickAnalyticsOn = false
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
         super.init(coder: aDecoder)
         viewModel.view = self
     }

--- a/Sources/Concrete/View/MultiHitsCollectionWidget.swift
+++ b/Sources/Concrete/View/MultiHitsCollectionWidget.swift
@@ -20,7 +20,7 @@ import UIKit
 /// Widget that displays the search results of multi index. Built over a `UITableView`.
 @objcMembers public class MultiHitsCollectionWidget: UICollectionView, MultiHitsViewDelegate, AlgoliaWidget {
     
-    public var isClickAnalyticsOn: Bool
+    public var enableClickAnalytics: Bool
     
     private var hitClickEventNames: [Int: String]
     
@@ -28,7 +28,7 @@ import UIKit
         return hitClickEventNames[section]
     }
     
-    public func setHitClickEventName(_ eventName: String, forSection section: Int) {
+    public func setHitClick(eventName: String, forSection section: Int) {
         hitClickEventNames[section] = eventName
     }
     
@@ -71,7 +71,7 @@ import UIKit
     
     public override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         viewModel = MultiHitsViewModel()
-        isClickAnalyticsOn = false
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
         hitClickEventNames = [:]
         super.init(frame: frame, collectionViewLayout: layout)
         viewModel.view = self
@@ -79,7 +79,7 @@ import UIKit
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = MultiHitsViewModel()
-        isClickAnalyticsOn = false
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
         hitClickEventNames = [:]
         super.init(coder: aDecoder)
         viewModel.view = self

--- a/Sources/Concrete/View/MultiHitsCollectionWidget.swift
+++ b/Sources/Concrete/View/MultiHitsCollectionWidget.swift
@@ -20,6 +20,18 @@ import UIKit
 /// Widget that displays the search results of multi index. Built over a `UITableView`.
 @objcMembers public class MultiHitsCollectionWidget: UICollectionView, MultiHitsViewDelegate, AlgoliaWidget {
     
+    public var isClickAnalyticsOn: Bool
+    
+    private var hitClickEventNames: [Int: String]
+    
+    public func hitClickEventName(forSection section: Int) -> String? {
+        return hitClickEventNames[section]
+    }
+    
+    public func setHitClickEventName(_ eventName: String, forSection section: Int) {
+        hitClickEventNames[section] = eventName
+    }
+    
     @IBInspectable public var showItemsOnEmptyQuery: Bool = Constants.Defaults.showItemsOnEmptyQuery
     
     @IBInspectable public var hitsPerSection: String = String(Constants.Defaults.hitsPerPage) {
@@ -59,12 +71,16 @@ import UIKit
     
     public override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         viewModel = MultiHitsViewModel()
+        isClickAnalyticsOn = false
+        hitClickEventNames = [:]
         super.init(frame: frame, collectionViewLayout: layout)
         viewModel.view = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = MultiHitsViewModel()
+        isClickAnalyticsOn = false
+        hitClickEventNames = [:]
         super.init(coder: aDecoder)
         viewModel.view = self
     }

--- a/Sources/Concrete/View/MultiHitsCollectionWidget.swift
+++ b/Sources/Concrete/View/MultiHitsCollectionWidget.swift
@@ -28,7 +28,7 @@ import UIKit
         return hitClickEventNames[section]
     }
     
-    public func setHitClick(eventName: String, forSection section: Int) {
+    public func setHitClick(eventName: String?, forSection section: Int) {
         hitClickEventNames[section] = eventName
     }
     

--- a/Sources/Concrete/View/MultiHitsTableWidget.swift
+++ b/Sources/Concrete/View/MultiHitsTableWidget.swift
@@ -13,15 +13,15 @@ import UIKit
 /// Widget that displays the search results of multi index. Built over a `UITableView`.
 @objcMembers public class MultiHitsTableWidget: UITableView, MultiHitsViewDelegate, AlgoliaWidget {
     
-    public var isClickAnalyticsOn: Bool = false
+    public var enableClickAnalytics: Bool
     
-    private var hitClickEventNames: [Int: String] = [:]
+    private var hitClickEventNames: [Int: String]
     
     public func hitClickEventName(forSection section: Int) -> String? {
         return hitClickEventNames[section]
     }
     
-    public func setHitClickEventName(_ eventName: String, forSection section: Int) {
+    public func setHitClick(eventName: String, forSection section: Int) {
         hitClickEventNames[section] = eventName
     }
     
@@ -68,12 +68,16 @@ import UIKit
     
   public override init(frame: CGRect, style: UITableView.Style) {
         viewModel = MultiHitsViewModel()
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
+    	hitClickEventNames = [:]
         super.init(frame: frame, style: style)
         viewModel.view = self
     }
     
     public required init?(coder aDecoder: NSCoder) {
         viewModel = MultiHitsViewModel()
+        enableClickAnalytics = Constants.Defaults.enableClickAnalytics
+        hitClickEventNames = [:]
         super.init(coder: aDecoder)
         viewModel.view = self
     }

--- a/Sources/Concrete/View/MultiHitsTableWidget.swift
+++ b/Sources/Concrete/View/MultiHitsTableWidget.swift
@@ -13,6 +13,18 @@ import UIKit
 /// Widget that displays the search results of multi index. Built over a `UITableView`.
 @objcMembers public class MultiHitsTableWidget: UITableView, MultiHitsViewDelegate, AlgoliaWidget {
     
+    public var isClickAnalyticsOn: Bool = false
+    
+    private var hitClickEventNames: [Int: String] = [:]
+    
+    public func hitClickEventName(forSection section: Int) -> String? {
+        return hitClickEventNames[section]
+    }
+    
+    public func setHitClickEventName(_ eventName: String, forSection section: Int) {
+        hitClickEventNames[section] = eventName
+    }
+    
     @IBInspectable public var showItemsOnEmptyQuery: Bool = Constants.Defaults.showItemsOnEmptyQuery
     
     @IBInspectable public var hitsPerSection: String = String(Constants.Defaults.hitsPerPage) {

--- a/Sources/Concrete/View/MultiHitsTableWidget.swift
+++ b/Sources/Concrete/View/MultiHitsTableWidget.swift
@@ -21,7 +21,7 @@ import UIKit
         return hitClickEventNames[section]
     }
     
-    public func setHitClick(eventName: String, forSection section: Int) {
+    public func setHitClick(eventName: String?, forSection section: Int) {
         hitClickEventNames[section] = eventName
     }
     

--- a/Sources/Concrete/ViewModel/HitsViewModel.swift
+++ b/Sources/Concrete/ViewModel/HitsViewModel.swift
@@ -135,9 +135,16 @@ import InstantSearchInsights
         let hit = hitForRow(at: indexPath)
         let position = indexPath.row + 1
         
+        let indexName: String
+        
+        if let viewIndexName = view?.index, viewIndexName.isEmpty {
+            indexName = viewIndexName
+        } else {
+            indexName = resultsManager.indexName
+        }
+        
         if
             let queryID = queryID,
-            let indexName = view?.index,
             let eventName = view?.hitClickEventName,
             let objectID = hit["objectID"] as? String {
             clickAnalyticsDelegate?.clickedAfterSearch(eventName: eventName,

--- a/Sources/Concrete/ViewModel/HitsViewModel.swift
+++ b/Sources/Concrete/ViewModel/HitsViewModel.swift
@@ -42,8 +42,8 @@ import InstantSearchInsights
         return resultsManager.results?.queryID
     }
     
-    public var isClickAnalyticsOn: Bool {
-        return view?.isClickAnalyticsOn ?? Constants.Defaults.isClickAnalyticsOn
+    public var enableClickAnalytics: Bool {
+        return view?.enableClickAnalytics ?? Constants.Defaults.enableClickAnalytics
     }
 
     // TODO: Those should be settable in the long run, same idea as when we do a private _var and var everywhere. Note that they can always create a virtual view that is not added to the UI, that has all the necessary properties set. 
@@ -130,7 +130,7 @@ import InstantSearchInsights
     
     public func captureClickAnalyticsForHit(at indexPath: IndexPath) {
         
-        guard isClickAnalyticsOn else { return }
+        guard enableClickAnalytics else { return }
         
         let hit = hitForRow(at: indexPath)
         let position = indexPath.row + 1

--- a/Sources/Concrete/ViewModel/MultiHitsViewModel.swift
+++ b/Sources/Concrete/ViewModel/MultiHitsViewModel.swift
@@ -180,10 +180,17 @@ import InstantSearchCore
         let hit = hitForRow(at: indexPath)
         let position = indexPath.row + 1
         let queryID = queryIDForHits(in: indexPath.section)
-
+        
+        let indexName: String
+        
+        if let viewIndexName = view?.indicesArray[indexPath.section] {
+            indexName = viewIndexName
+        } else {
+            indexName = resultsManagers[indexPath.section].indexName
+        }
+        
         if
             let queryID = queryID,
-            let indexName = view?.indicesArray[indexPath.section],
             let eventName = view?.hitClickEventName(forSection: indexPath.section),
             let objectID = hit["objectID"] as? String {
             clickAnalyticsDelegate?.clickedAfterSearch(eventName: eventName,

--- a/Sources/Concrete/ViewModel/MultiHitsViewModel.swift
+++ b/Sources/Concrete/ViewModel/MultiHitsViewModel.swift
@@ -44,8 +44,8 @@ import InstantSearchCore
 
     }
     
-    public var isClickAnalyticsOn: Bool {
-        return view?.isClickAnalyticsOn ?? Constants.Defaults.isClickAnalyticsOn
+    public var enableClickAnalytics: Bool {
+        return view?.enableClickAnalytics ?? Constants.Defaults.enableClickAnalytics
     }
     
     public var hitsPerSectionArray: [UInt] {
@@ -175,7 +175,7 @@ import InstantSearchCore
     
     public func captureClickAnalyticsForHit(at indexPath: IndexPath) {
 
-        guard isClickAnalyticsOn else { return }
+        guard enableClickAnalytics else { return }
 
         let hit = hitForRow(at: indexPath)
         let position = indexPath.row + 1

--- a/Sources/InstantSearch.swift
+++ b/Sources/InstantSearch.swift
@@ -35,12 +35,25 @@ import UIKit
     //private var multiIndexRefinableDelegates: [IndexId: [String: WeakSet<RefinableDelegate>]] = [:]
     
     /// The Searchers used in the case of multi-indexing.
-    public var searchers: [SearcherId: Searcher]
+    public var searchers: [SearcherId: Searcher] {
+        didSet {
+            searchers.values.forEach { searcher in
+                searcher.params.clickAnalytics = true
+            }
+        }
+    }
     
     /// The Searcher used in the case of single-indexing.
     /// + NOTE: It is safer to use the getSearcher() method
     /// + WARNING: Don't use this in the case of configuring with multi-index.
-    public var searcher: Searcher!
+    public var searcher: Searcher! {
+        didSet {
+            guard let searcher = searcher else {
+                return
+            }
+            searcher.params.clickAnalytics = true
+        }
+    }
   
     public var history: LocalHistory = {
       // Store the history in a `history.dat` file inside the `Application Support` directory.
@@ -136,6 +149,7 @@ import UIKit
         let index = client.index(withName: index)
         let searcher = Searcher(index: index)
         configure(searcher: searcher)
+        searcher.params.clickAnalytics = true
         Insights.register(appId: appID, apiKey: apiKey)
     }
     

--- a/Sources/InstantSearch.swift
+++ b/Sources/InstantSearch.swift
@@ -9,6 +9,7 @@
 import Foundation
 @_exported import InstantSearchCore
 @_exported import InstantSearchClient
+@_exported import InstantSearchInsights
 import UIKit
 
 /// Main class used for interacting with the InstantSearch library.
@@ -135,6 +136,7 @@ import UIKit
         let index = client.index(withName: index)
         let searcher = Searcher(index: index)
         configure(searcher: searcher)
+        Insights.register(appId: appID, apiKey: apiKey)
     }
     
     // Helper method to configure the searcher, assign the searcher delegate to the InstantSearch reference,

--- a/Sources/Models and Helpers/Constants.swift
+++ b/Sources/Models and Helpers/Constants.swift
@@ -21,6 +21,10 @@ struct Constants {
         static let remainingItemsBeforeLoading: UInt = 5
         static let showItemsOnEmptyQuery: Bool = true
         
+        // Analytics
+        static let isClickAnalyticsOn = false
+        static let hitClickEventName = "result clicked"
+        
         // Refinement, Numeric Control, Facet Control
         static let attribute = ""
         

--- a/Sources/Models and Helpers/Constants.swift
+++ b/Sources/Models and Helpers/Constants.swift
@@ -22,7 +22,7 @@ struct Constants {
         static let showItemsOnEmptyQuery: Bool = true
         
         // Analytics
-        static let isClickAnalyticsOn = false
+        static let enableClickAnalytics = false
         static let hitClickEventName = "result clicked"
         
         // Refinement, Numeric Control, Facet Control

--- a/Sources/Models and Helpers/SearchResultsManageable.swift
+++ b/Sources/Models and Helpers/SearchResultsManageable.swift
@@ -1,0 +1,28 @@
+//
+//  SearchResultsManageable.swift
+//  InstantSearch
+//
+//  Created by Vladislav Fitc on 18/02/2019.
+//
+
+import Foundation
+
+public protocol SearchResultsManageable {
+    
+    var indexName: String { get }
+    var variant: String { get }
+    var params: InstantSearchCore.SearchParameters { get }
+    var results: InstantSearchCore.SearchResults? { get }
+    func loadMore()
+    
+}
+
+extension SearchResultsManageable {
+    
+    var hits: [[String: Any]] {
+        return results?.allHits ?? []
+    }
+    
+}
+
+extension Searcher: SearchResultsManageable {}

--- a/Sources/Protocols/View-ViewModel/HitsViewDelegate.swift
+++ b/Sources/Protocols/View-ViewModel/HitsViewDelegate.swift
@@ -33,7 +33,7 @@ import Foundation
     var showItemsOnEmptyQuery: Bool { get set }
     
     /// Whetever or not Click Analytics activated for this widget
-    var isClickAnalyticsOn: Bool { get set }
+    var enableClickAnalytics: Bool { get set }
     
     /// Analytics event name for hit click used by Insights
     var hitClickEventName: String? { get set }

--- a/Sources/Protocols/View-ViewModel/HitsViewDelegate.swift
+++ b/Sources/Protocols/View-ViewModel/HitsViewDelegate.swift
@@ -31,4 +31,11 @@ import Foundation
     
     /// Whether the show items when the query string is empty or not.
     var showItemsOnEmptyQuery: Bool { get set }
+    
+    /// Whetever or not Click Analytics activated for this widget
+    var isClickAnalyticsOn: Bool { get set }
+    
+    /// Analytics event name for hit click used by Insights
+    var hitClickEventName: String? { get set }
+    
 }

--- a/Sources/Protocols/View-ViewModel/MultiHitsViewDelegate.swift
+++ b/Sources/Protocols/View-ViewModel/MultiHitsViewDelegate.swift
@@ -23,11 +23,11 @@ import Foundation
     var showItemsOnEmptyQuery: Bool { get set }
     
     /// Whetever or not Click Analytics activated for this widget
-    var isClickAnalyticsOn: Bool { get set }
+    var enableClickAnalytics: Bool { get set }
     
     /// Analytics event name for hit click used by Insights
     func hitClickEventName(forSection section: Int) -> String?
     
     /// Setter of event name for hit click used by Insights in specified section
-    func setHitClickEventName(_ eventName: String, forSection section: Int)
+    func setHitClick(eventName: String, forSection section: Int)
 }

--- a/Sources/Protocols/View-ViewModel/MultiHitsViewDelegate.swift
+++ b/Sources/Protocols/View-ViewModel/MultiHitsViewDelegate.swift
@@ -21,4 +21,13 @@ import Foundation
     
     /// Whether the show items when the query string is empty or not.
     var showItemsOnEmptyQuery: Bool { get set }
+    
+    /// Whetever or not Click Analytics activated for this widget
+    var isClickAnalyticsOn: Bool { get set }
+    
+    /// Analytics event name for hit click used by Insights
+    func hitClickEventName(forSection section: Int) -> String?
+    
+    /// Setter of event name for hit click used by Insights in specified section
+    func setHitClickEventName(_ eventName: String, forSection section: Int)
 }

--- a/Sources/Protocols/View-ViewModel/MultiHitsViewDelegate.swift
+++ b/Sources/Protocols/View-ViewModel/MultiHitsViewDelegate.swift
@@ -29,5 +29,5 @@ import Foundation
     func hitClickEventName(forSection section: Int) -> String?
     
     /// Setter of event name for hit click used by Insights in specified section
-    func setHitClick(eventName: String, forSection section: Int)
+    func setHitClick(eventName: String?, forSection section: Int)
 }

--- a/Sources/Protocols/ViewModel-Binder/ClickAnalyticsDelegate.swift
+++ b/Sources/Protocols/ViewModel-Binder/ClickAnalyticsDelegate.swift
@@ -1,0 +1,35 @@
+//
+//  ClickAnalyticsDelegate.swift
+//  InstantSearch
+//
+//  Created by Vladislav Fitc on 18/02/2019.
+//
+
+import Foundation
+import InstantSearchInsights
+
+public protocol ClickAnalyticsDelegate: class {
+    
+    func clickedAfterSearch(eventName: String,
+                            indexName: String,
+                            objectID: String,
+                            position: Int,
+                            queryID: String)
+    
+}
+
+extension Insights: ClickAnalyticsDelegate {
+    
+    public func clickedAfterSearch(eventName: String,
+                                   indexName: String,
+                                   objectID: String,
+                                   position: Int,
+                                   queryID: String) {
+        clickedAfterSearch(eventName: eventName,
+                           indexName: indexName,
+                           objectID: objectID,
+                           position: position,
+                           queryID: queryID,
+                           userToken: .none)
+    }
+}

--- a/Sources/Protocols/ViewModel-View/HitsViewModelDelegate.swift
+++ b/Sources/Protocols/ViewModel-View/HitsViewModelDelegate.swift
@@ -16,9 +16,16 @@ import Foundation
     /// View associated with the WidgetVM.
     var view: HitsViewDelegate? { get set }
     
+    /// Query idenitifer of last result
+    var queryID: String? { get }
+        
     /// Query the number of Rows to show.
     func numberOfRows() -> Int
     
     /// Query the hit to show for a row at a specific indexPath.
     func hitForRow(at indexPath: IndexPath) -> [String: Any]
+
+    /// Captures Click Analytics event
+    func captureClickAnalyticsForHit(at indexPath: IndexPath)
+    
 }

--- a/Sources/Protocols/ViewModel-View/MultiHitsViewModelDelegate.swift
+++ b/Sources/Protocols/ViewModel-View/MultiHitsViewModelDelegate.swift
@@ -22,4 +22,11 @@ import Foundation
     
     /// Query the hit to show for a row at a specific indexPath.
     func hitForRow(at indexPath: IndexPath) -> [String: Any]
+    
+    /// Query identifier of last result in specified section
+    func queryIDForHits(in section: Int) -> String?
+    
+    /// Captures Click Analytics event
+    func captureClickAnalyticsForHit(at indexPath: IndexPath)
+
 }

--- a/Tests/AnalyticsTests.swift
+++ b/Tests/AnalyticsTests.swift
@@ -1,0 +1,320 @@
+//
+//  AnalyticsTests.swift
+//  InstantSearch
+//
+//  Created by Vladislav Fitc on 19/02/2019.
+//
+
+import XCTest
+@testable import InstantSearch
+import InstantSearchCore
+import InstantSearchClient
+
+class AnalyticsTests: XCTestCase {
+    
+    func testTableWidgetnCAEventCapturing() {
+        
+        let exp = expectation(description: #function)
+        
+        let widget = HitsTableWidget(frame: .zero)
+        
+        widget.isClickAnalyticsOn = true
+        widget.index = "testIndex"
+        widget.hitClickEventName = "testEventName"
+        
+        let viewModel = HitsViewModel(view: widget)
+        let caTestHelper = TestClickAnalyticsHelper()
+        
+        caTestHelper.handler = { eventName, indexName, objectID, position, queryID in
+            XCTAssertEqual(eventName, "testEventName")
+            XCTAssertEqual(indexName, "testIndex")
+            XCTAssertEqual(objectID, "testObjectID")
+            XCTAssertEqual(position, 1)
+            XCTAssertEqual(queryID, "testQueryID")
+            exp.fulfill()
+        }
+        
+        viewModel.clickAnalyticsDelegate = caTestHelper
+        let params = SearchParameters()
+        let results = try! SearchResults(content: ["nbHits": 1 ,
+                                                   "hits": [["objectID": "testObjectID"]],
+                                                   "queryID": "testQueryID"],
+                                         disjunctiveFacets: [])
+        let searchResultsManager = TestSearchResultsManager(indexName: "testIndex",
+                                                            variant: "testVariant",
+                                                            params: params,
+                                                            results: results)
+        viewModel.configure(with: searchResultsManager)
+        viewModel.captureClickAnalyticsForHit(at: IndexPath(row: 0, section: 0))
+        
+        waitForExpectations(timeout: 2, handler: .none)
+        
+    }
+    
+    func testCollectionWidgetCAEventCapturing() {
+        
+        let exp = expectation(description: #function)
+        
+        let widget = HitsCollectionWidget(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        
+        widget.isClickAnalyticsOn = true
+        widget.index = "testIndex"
+        widget.hitClickEventName = "testEventName"
+        
+        let viewModel = HitsViewModel(view: widget)
+        let caTestHelper = TestClickAnalyticsHelper()
+        
+        caTestHelper.handler = { eventName, indexName, objectID, position, queryID in
+            XCTAssertEqual(eventName, "testEventName")
+            XCTAssertEqual(indexName, "testIndex")
+            XCTAssertEqual(objectID, "testObjectID")
+            XCTAssertEqual(position, 1)
+            XCTAssertEqual(queryID, "testQueryID")
+            exp.fulfill()
+        }
+        
+        viewModel.clickAnalyticsDelegate = caTestHelper
+        let params = SearchParameters()
+        let results = try! SearchResults(content: ["nbHits": 1 ,
+                                                   "hits": [["objectID": "testObjectID"]],
+                                                   "queryID": "testQueryID"],
+                                         disjunctiveFacets: [])
+        let searchResultsManager = TestSearchResultsManager(indexName: "testIndex",
+                                                            variant: "testVariant",
+                                                            params: params,
+                                                            results: results)
+        viewModel.configure(with: searchResultsManager)
+        viewModel.captureClickAnalyticsForHit(at: IndexPath(row: 0, section: 0))
+        
+        waitForExpectations(timeout: 2, handler: .none)
+        
+    }
+    
+    func testTableWidgetMultiHitCAEventCapturing() {
+        
+        let exp = expectation(description: #function)
+        exp.expectedFulfillmentCount = 2
+        
+        let widget = MultiHitsTableWidget(frame: .zero)
+        
+        widget.isClickAnalyticsOn = true
+        widget.indicesArray = ["testIndex1", "testIndex2"]
+        widget.setHitClickEventName("testEventName1", forSection: 0)
+        widget.setHitClickEventName("testEventName2", forSection: 1)
+        
+        let viewModel = MultiHitsViewModel(view: widget)
+        viewModel.searcherIds = [
+            SearcherId(index: "testIndex1", variant: "testVariant1"),
+            SearcherId(index: "testIndex2", variant: "testVariant2")
+        ]
+        
+        let caTestHelper = TestClickAnalyticsHelper()
+        
+        caTestHelper.handler = { eventName, indexName, objectID, position, queryID in
+            switch eventName {
+            case "testEventName1":
+                XCTAssertEqual(indexName, "testIndex1")
+                XCTAssertEqual(objectID, "testObjectID1")
+                XCTAssertEqual(position, 1)
+                XCTAssertEqual(queryID, "testQueryID1")
+                
+            case "testEventName2":
+                XCTAssertEqual(eventName, "testEventName2")
+                XCTAssertEqual(indexName, "testIndex2")
+                XCTAssertEqual(objectID, "testObjectID2")
+                XCTAssertEqual(position, 1)
+                
+            default:
+                XCTFail("Unexpected event name: \(eventName)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        viewModel.clickAnalyticsDelegate = caTestHelper
+        
+        let params = SearchParameters()
+        let results1 = try! SearchResults(content: ["nbHits": 1,
+                                                    "hits": [["objectID": "testObjectID1"]],
+                                                    "queryID": "testQueryID1"],
+                                          disjunctiveFacets: [])
+        
+        let results2 = try! SearchResults(content: ["nbHits": 1,
+                                                    "hits": [["objectID": "testObjectID2"]],
+                                                    "queryID": "testQueryID2"],
+                                          disjunctiveFacets: [])
+        
+        let searchResultsManager1 = TestSearchResultsManager(indexName: "testIndex1",
+                                                             variant: "testVariant1",
+                                                             params: params,
+                                                             results: results1)
+        
+        let searchResultsManager2 = TestSearchResultsManager(indexName: "testIndex2",
+                                                             variant: "testVariant2",
+                                                             params: params,
+                                                             results: results2)
+        
+        viewModel.configure(with: [searchResultsManager1, searchResultsManager2])
+        
+        viewModel.captureClickAnalyticsForHit(at: IndexPath(row: 0, section: 0))
+        viewModel.captureClickAnalyticsForHit(at: IndexPath(row: 0, section: 1))
+        
+        waitForExpectations(timeout: 2, handler: .none)
+        
+        
+    }
+    
+    func testCollectionWidgetMultiHitCAEventCapturing() {
+        
+        let exp = expectation(description: #function)
+        exp.expectedFulfillmentCount = 2
+        
+        let widget = MultiHitsCollectionWidget(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        
+        widget.isClickAnalyticsOn = true
+        widget.indicesArray = ["testIndex1", "testIndex2"]
+        widget.setHitClickEventName("testEventName1", forSection: 0)
+        widget.setHitClickEventName("testEventName2", forSection: 1)
+        
+        let viewModel = MultiHitsViewModel(view: widget)
+        viewModel.searcherIds = [
+            SearcherId(index: "testIndex1", variant: "testVariant1"),
+            SearcherId(index: "testIndex2", variant: "testVariant2")
+        ]
+        
+        let caTestHelper = TestClickAnalyticsHelper()
+        
+        caTestHelper.handler = { eventName, indexName, objectID, position, queryID in
+            switch eventName {
+            case "testEventName1":
+                XCTAssertEqual(indexName, "testIndex1")
+                XCTAssertEqual(objectID, "testObjectID1")
+                XCTAssertEqual(position, 1)
+                XCTAssertEqual(queryID, "testQueryID1")
+                
+            case "testEventName2":
+                XCTAssertEqual(eventName, "testEventName2")
+                XCTAssertEqual(indexName, "testIndex2")
+                XCTAssertEqual(objectID, "testObjectID2")
+                XCTAssertEqual(position, 1)
+                
+            default:
+                XCTFail("Unexpected event name: \(eventName)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        viewModel.clickAnalyticsDelegate = caTestHelper
+        
+        let params = SearchParameters()
+        let results1 = try! SearchResults(content: ["nbHits": 1,
+                                                    "hits": [["objectID": "testObjectID1"]],
+                                                    "queryID": "testQueryID1"],
+                                          disjunctiveFacets: [])
+        
+        let results2 = try! SearchResults(content: ["nbHits": 1,
+                                                    "hits": [["objectID": "testObjectID2"]],
+                                                    "queryID": "testQueryID2"],
+                                          disjunctiveFacets: [])
+        
+        let searchResultsManager1 = TestSearchResultsManager(indexName: "testIndex1",
+                                                             variant: "testVariant1",
+                                                             params: params,
+                                                             results: results1)
+        
+        let searchResultsManager2 = TestSearchResultsManager(indexName: "testIndex2",
+                                                             variant: "testVariant2",
+                                                             params: params,
+                                                             results: results2)
+        
+        viewModel.configure(with: [searchResultsManager1, searchResultsManager2])
+        
+        viewModel.captureClickAnalyticsForHit(at: IndexPath(row: 0, section: 0))
+        viewModel.captureClickAnalyticsForHit(at: IndexPath(row: 0, section: 1))
+        
+        waitForExpectations(timeout: 2, handler: .none)
+        
+    }
+    
+    func testHitsControllerCACapturing() {
+        
+        let exp = expectation(description: #function)
+        
+        let widget = HitsTableWidget(frame: .zero)
+        
+        widget.isClickAnalyticsOn = true
+        widget.index = "testIndex"
+        widget.hitClickEventName = "testEventName"
+        
+        let viewModel = HitsViewModel(view: widget)
+        widget.viewModel = viewModel
+        let caTestHelper = TestClickAnalyticsHelper()
+        
+        caTestHelper.handler = { eventName, indexName, objectID, position, queryID in
+            XCTAssertEqual(eventName, "testEventName")
+            XCTAssertEqual(indexName, "testIndex")
+            XCTAssertEqual(objectID, "testObjectID")
+            XCTAssertEqual(position, 1)
+            XCTAssertEqual(queryID, "testQueryID")
+            exp.fulfill()
+        }
+        
+        viewModel.clickAnalyticsDelegate = caTestHelper
+        let params = SearchParameters()
+        let results = try! SearchResults(content: ["nbHits": 1 ,
+                                                   "hits": [["objectID": "testObjectID"]],
+                                                   "queryID": "testQueryID"],
+                                         disjunctiveFacets: [])
+        let searchResultsManager = TestSearchResultsManager(indexName: "testIndex",
+                                                            variant: "testVariant",
+                                                            params: params,
+                                                            results: results)
+        viewModel.configure(with: searchResultsManager)
+        
+        let hitsController = HitsController(table: widget)
+        
+        let indexPath = IndexPath(row: 0, section: 0)
+        
+        hitsController.tableView(widget, didSelectRowAt: indexPath)
+        
+        waitForExpectations(timeout: 2, handler: .none)
+        
+    }
+    
+}
+
+class TestSearchResultsManager: SearchResultsManageable {
+    
+    let indexName: String
+    let variant: String
+    let params: InstantSearchCore.SearchParameters
+    let results: InstantSearchCore.SearchResults?
+    
+    init(indexName: String,
+         variant: String,
+         params: InstantSearchCore.SearchParameters,
+         results: InstantSearchCore.SearchResults?) {
+        self.indexName = indexName
+        self.variant = variant
+        self.params = params
+        self.results = results
+    }
+    
+    func loadMore() {}
+    
+}
+
+class TestClickAnalyticsHelper: ClickAnalyticsDelegate {
+    
+    var handler: ((String, String, String, Int, String) -> Void)?
+    
+    func clickedAfterSearch(eventName: String,
+                            indexName: String,
+                            objectID: String,
+                            position: Int,
+                            queryID: String) {
+        handler?(eventName, indexName, objectID, position, queryID)
+    }
+    
+}

--- a/Tests/AnalyticsTests.swift
+++ b/Tests/AnalyticsTests.swift
@@ -18,7 +18,7 @@ class AnalyticsTests: XCTestCase {
         
         let widget = HitsTableWidget(frame: .zero)
         
-        widget.isClickAnalyticsOn = true
+        widget.enableClickAnalytics = true
         widget.index = "testIndex"
         widget.hitClickEventName = "testEventName"
         
@@ -57,7 +57,7 @@ class AnalyticsTests: XCTestCase {
         
         let widget = HitsCollectionWidget(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         
-        widget.isClickAnalyticsOn = true
+        widget.enableClickAnalytics = true
         widget.index = "testIndex"
         widget.hitClickEventName = "testEventName"
         
@@ -97,10 +97,10 @@ class AnalyticsTests: XCTestCase {
         
         let widget = MultiHitsTableWidget(frame: .zero)
         
-        widget.isClickAnalyticsOn = true
+        widget.enableClickAnalytics = true
         widget.indicesArray = ["testIndex1", "testIndex2"]
-        widget.setHitClickEventName("testEventName1", forSection: 0)
-        widget.setHitClickEventName("testEventName2", forSection: 1)
+        widget.setHitClick(eventName: "testEventName1", forSection: 0)
+        widget.setHitClick(eventName: "testEventName2", forSection: 1)
         
         let viewModel = MultiHitsViewModel(view: widget)
         viewModel.searcherIds = [
@@ -171,10 +171,10 @@ class AnalyticsTests: XCTestCase {
         
         let widget = MultiHitsCollectionWidget(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         
-        widget.isClickAnalyticsOn = true
+        widget.enableClickAnalytics = true
         widget.indicesArray = ["testIndex1", "testIndex2"]
-        widget.setHitClickEventName("testEventName1", forSection: 0)
-        widget.setHitClickEventName("testEventName2", forSection: 1)
+        widget.setHitClick(eventName: "testEventName1", forSection: 0)
+        widget.setHitClick(eventName: "testEventName2", forSection: 1)
         
         let viewModel = MultiHitsViewModel(view: widget)
         viewModel.searcherIds = [
@@ -243,7 +243,7 @@ class AnalyticsTests: XCTestCase {
         
         let widget = HitsTableWidget(frame: .zero)
         
-        widget.isClickAnalyticsOn = true
+        widget.enableClickAnalytics = true
         widget.index = "testIndex"
         widget.hitClickEventName = "testEventName"
         

--- a/Tests/AnalyticsTests.swift
+++ b/Tests/AnalyticsTests.swift
@@ -237,7 +237,7 @@ class AnalyticsTests: XCTestCase {
         
     }
     
-    func testHitsControllerCACapturing() {
+    func testHitsControllerTableWidgetCACapturing() {
         
         let exp = expectation(description: #function)
         
@@ -281,6 +281,52 @@ class AnalyticsTests: XCTestCase {
         waitForExpectations(timeout: 2, handler: .none)
         
     }
+    
+    func testHitsControllerCollectionWidgetCACapturing() {
+     
+        let exp = expectation(description: #function)
+        
+        let widget = HitsCollectionWidget(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        
+        widget.enableClickAnalytics = true
+        widget.index = "testIndex"
+        widget.hitClickEventName = "testEventName"
+        
+        let viewModel = HitsViewModel(view: widget)
+        widget.viewModel = viewModel
+        let caTestHelper = TestClickAnalyticsHelper()
+        
+        caTestHelper.handler = { eventName, indexName, objectID, position, queryID in
+            XCTAssertEqual(eventName, "testEventName")
+            XCTAssertEqual(indexName, "testIndex")
+            XCTAssertEqual(objectID, "testObjectID")
+            XCTAssertEqual(position, 1)
+            XCTAssertEqual(queryID, "testQueryID")
+            exp.fulfill()
+        }
+        
+        viewModel.clickAnalyticsDelegate = caTestHelper
+        let params = SearchParameters()
+        let results = try! SearchResults(content: ["nbHits": 1 ,
+                                                   "hits": [["objectID": "testObjectID"]],
+                                                   "queryID": "testQueryID"],
+                                         disjunctiveFacets: [])
+        let searchResultsManager = TestSearchResultsManager(indexName: "testIndex",
+                                                            variant: "testVariant",
+                                                            params: params,
+                                                            results: results)
+        viewModel.configure(with: searchResultsManager)
+        
+        let hitsController = HitsController(collection: widget)
+        
+        let indexPath = IndexPath(row: 0, section: 0)
+        
+        hitsController.collectionView(widget, didSelectItemAt: indexPath)
+        
+        waitForExpectations(timeout: 2, handler: .none)
+        
+    }
+
     
 }
 

--- a/Tests/WidgetTests.swift
+++ b/Tests/WidgetTests.swift
@@ -286,4 +286,8 @@ class WidgetTests: XCTestCase {
         // Make sure params.hitsPerPage was correctly set by just adding the hits widget.
         XCTAssertEqual(hitsTableWidget.viewModel.numberOfRows(), 0)
     }
+    
+   
+    
 }
+

--- a/instantsearch.xcodeproj/project.pbxproj
+++ b/instantsearch.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		287D0A6E1C4B73BD004566D6 /* WidgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287D0A6D1C4B73BD004566D6 /* WidgetTests.swift */; };
 		28F828881C494B2C00330CF4 /* InstantSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28F8287D1C494B2C00330CF4 /* InstantSearch.framework */; };
+		AF263882221C5BE50038483D /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF263880221C5BB80038483D /* AnalyticsTests.swift */; };
+		AF75602C22171775008C5DDF /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF75602B22171774008C5DDF /* InstantSearchInsights.framework */; };
+		AF75602E221AC6B9008C5DDF /* ClickAnalyticsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75602D221AC6B9008C5DDF /* ClickAnalyticsDelegate.swift */; };
+		AF756030221B25E7008C5DDF /* SearchResultsManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF75602F221B25E7008C5DDF /* SearchResultsManageable.swift */; };
 		E21DE94F1F2F7DB400EFC4F5 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21DE94E1F2F7DB400EFC4F5 /* InstantSearchCore.framework */; };
 		E2231E951EC9DC0D002FCF82 /* ConfigureInstantSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2231E931EC9DBC4002FCF82 /* ConfigureInstantSearchTests.swift */; };
 		E2231E971EC9F5A7002FCF82 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2231E961EC9F5A7002FCF82 /* Constants.swift */; };
@@ -111,6 +115,10 @@
 		28F8287D1C494B2C00330CF4 /* InstantSearch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = InstantSearch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		28F828821C494B2C00330CF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		28F828871C494B2C00330CF4 /* InstantSearchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InstantSearchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AF263880221C5BB80038483D /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
+		AF75602B22171774008C5DDF /* InstantSearchInsights.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = InstantSearchInsights.framework; path = Carthage/Build/iOS/InstantSearchInsights.framework; sourceTree = "<group>"; };
+		AF75602D221AC6B9008C5DDF /* ClickAnalyticsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClickAnalyticsDelegate.swift; sourceTree = "<group>"; };
+		AF75602F221B25E7008C5DDF /* SearchResultsManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsManageable.swift; sourceTree = "<group>"; };
 		E21DE94E1F2F7DB400EFC4F5 /* InstantSearchCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = InstantSearchCore.framework; path = Carthage/Build/iOS/InstantSearchCore.framework; sourceTree = "<group>"; };
 		E21DE9501F2F7DCA00EFC4F5 /* AlgoliaSearch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlgoliaSearch.framework; path = Carthage/Build/iOS/AlgoliaSearch.framework; sourceTree = "<group>"; };
 		E2231E931EC9DBC4002FCF82 /* ConfigureInstantSearchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureInstantSearchTests.swift; sourceTree = "<group>"; };
@@ -199,6 +207,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF75602C22171775008C5DDF /* InstantSearchInsights.framework in Frameworks */,
 				E2F2073B20B6E3F60066AF12 /* InstantSearchClient.framework in Frameworks */,
 				E21DE94F1F2F7DB400EFC4F5 /* InstantSearchCore.framework in Frameworks */,
 			);
@@ -251,6 +260,7 @@
 				E2AFE5641ED49B2C00B6A5A7 /* Helpers */,
 				E25FB0A21ECF550C006B8CED /* Info.plist */,
 				287D0A6D1C4B73BD004566D6 /* WidgetTests.swift */,
+				AF263880221C5BB80038483D /* AnalyticsTests.swift */,
 				E25FB0791ECD86E8006B8CED /* RefinementMenuViewModelTests.swift */,
 				E2231E931EC9DBC4002FCF82 /* ConfigureInstantSearchTests.swift */,
 				E2A476F81EC5DEDE007CA367 /* ObjectiveCBridgingTests.m */,
@@ -277,6 +287,7 @@
 		E21DE94D1F2F7DB400EFC4F5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AF75602B22171774008C5DDF /* InstantSearchInsights.framework */,
 				E2F2073A20B6E3F60066AF12 /* InstantSearchClient.framework */,
 				E21DE9501F2F7DCA00EFC4F5 /* AlgoliaSearch.framework */,
 				E21DE94E1F2F7DB400EFC4F5 /* InstantSearchCore.framework */,
@@ -425,6 +436,7 @@
 				E27A7BE91E955612005B2506 /* ResettableDelegate.swift */,
 				E27A7BEB1E9556C6005B2506 /* ResultingDelegate.swift */,
 				E27C16401E9394250091D79E /* SearchableViewModel.swift */,
+				AF75602D221AC6B9008C5DDF /* ClickAnalyticsDelegate.swift */,
 			);
 			path = "ViewModel-Binder";
 			sourceTree = "<group>";
@@ -471,6 +483,7 @@
 				E2231E961EC9F5A7002FCF82 /* Constants.swift */,
 				E27C16411E9394250091D79E /* Helpers.swift */,
 				E27A7BF01E97931E005B2506 /* ViewModelFetcher.swift */,
+				AF75602F221B25E7008C5DDF /* SearchResultsManageable.swift */,
 			);
 			path = "Models and Helpers";
 			sourceTree = "<group>";
@@ -641,13 +654,14 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/InstantSearchClient.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/InstantSearchCore.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/InstantSearchInsights.framework",
 			);
 			name = "Carthage Copy Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -688,6 +702,7 @@
 				E27141CA1E9E237200959294 /* StatsButtonWidget.swift in Sources */,
 				E25F5CE11FCEF450002C8A8D /* MultiHitsViewDelegate.swift in Sources */,
 				E27B67DB1ED314100001FFA7 /* RefinementViewDelegate.swift in Sources */,
+				AF75602E221AC6B9008C5DDF /* ClickAnalyticsDelegate.swift in Sources */,
 				E2738FC11E9BDA31002C002D /* StatsViewDelegate.swift in Sources */,
 				E27C16441E9394250091D79E /* SliderWidget.swift in Sources */,
 				E25F5C911FCEF3FA002C8A8D /* MultiHitsController.swift in Sources */,
@@ -701,6 +716,7 @@
 				E233BBFF1EBA43F500F5F5E1 /* OneValueSwitchWidget.swift in Sources */,
 				E25F5C8A1FCEF3DA002C8A8D /* MultiHitsCollectionWidget.swift in Sources */,
 				E233BC051EBB78D400F5F5E1 /* FacetControlViewDelegate.swift in Sources */,
+				AF756030221B25E7008C5DDF /* SearchResultsManageable.swift in Sources */,
 				E27C164A1E9394250091D79E /* ActivityIndicatorView.swift in Sources */,
 				E27141D51E9F764100959294 /* HitsTableViewController.swift in Sources */,
 				E2231E971EC9F5A7002FCF82 /* Constants.swift in Sources */,
@@ -728,6 +744,7 @@
 			files = (
 				E2231E951EC9DC0D002FCF82 /* ConfigureInstantSearchTests.swift in Sources */,
 				287D0A6E1C4B73BD004566D6 /* WidgetTests.swift in Sources */,
+				AF263882221C5BE50038483D /* AnalyticsTests.swift in Sources */,
 				E2A476FA1EC5DFC1007CA367 /* ObjectiveCBridgingTests.m in Sources */,
 				E2AFE5661ED49B3900B6A5A7 /* FatalError.swift in Sources */,
 				E2A476FE1EC60BD7007CA367 /* CustomWidget.m in Sources */,


### PR DESCRIPTION
Now Click Analytics is integrated in hits widgets as well as in multi-hits widgets. 
User just need to set `isClickAnalyticsOn` to true and `hitClickEventName` fields of widget. 
In case of usage of HitsController, events will be sent automatically.
In case of usage of ViewModel separately, a ViewModel method `captureClickAnalyticsForHit(at indexPath: IndexPath)` must be triggered manually.