### PR TITLE
Remove patch version dependency from Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "algolia/instantsearch-core-swift" ~> 6.5.1
-github "apple/swift-log" ~> 1.2.0
+github "algolia/instantsearch-core-swift" ~> 6.5
+github "apple/swift-log" ~> 1.2


### PR DESCRIPTION
This fix removes patch version from dependencies described in the Cartfile. 
As a result, InstantSearch will always install last minor versions of its dependencies. 