### PR TITLE
fix: Connections memory leaks

### DIFF
--- a/Sources/InstantSearchCore/FilterState/Accessors/GroupAccessor.swift
+++ b/Sources/InstantSearchCore/FilterState/Accessors/GroupAccessor.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol FiltersContainer: class {
-  var filters: FiltersReadable & FiltersWritable & FilterGroupsConvertible & HierarchicalManageable { get set }
+  var filters: FilterState.Storage { get set }
 }
 
 extension FiltersContainer {
@@ -33,11 +33,18 @@ extension FiltersContainer {
 }
 
 public class ReadOnlyFiltersContainer {
+  
+  class StorageContainer: FiltersContainer {
+    var filters: FilterState.Storage
+    init(filterState: FilterState) {
+      self.filters = filterState.filters
+    }
+  }
 
   let filtersContainer: FiltersContainer
 
-  init(filtersContainer: FiltersContainer) {
-    self.filtersContainer = filtersContainer
+  init(filterState: FilterState) {
+    self.filtersContainer = StorageContainer(filterState: filterState)
   }
 
   public subscript<F: FilterType>(and groupName: String) -> ReadOnlyGroupAccessor<F> {

--- a/Sources/InstantSearchCore/FilterState/FilterState+Commands.swift
+++ b/Sources/InstantSearchCore/FilterState/FilterState+Commands.swift
@@ -151,7 +151,7 @@ public extension FilterState {
 
   func notify(_ commands: Command...) {
     commands.forEach { $0.command.execute(on: self) }
-    onChange.fire(ReadOnlyFiltersContainer(filtersContainer: self))
+    onChange.fire(ReadOnlyFiltersContainer(filterState: self))
   }
 
 }

--- a/Sources/InstantSearchCore/FilterState/FilterState.swift
+++ b/Sources/InstantSearchCore/FilterState/FilterState.swift
@@ -12,9 +12,11 @@ import Foundation
  Encapsulates search filters providing a convenient interface to manage them
  */
 public class FilterState {
+  
+  typealias Storage = FiltersReadable & FiltersWritable & FilterGroupsConvertible & HierarchicalManageable
 
   /// Filters container
-  var filters: FiltersReadable & FiltersWritable & FilterGroupsConvertible & HierarchicalManageable
+  var filters: Storage
 
   /// Triggered when an error occured during search query execution
   /// - Parameter: a tuple of query and error
@@ -40,7 +42,7 @@ public class FilterState {
 
   /// Force trigger onChange event
   public func notifyChange() {
-    onChange.fire(ReadOnlyFiltersContainer(filtersContainer: self))
+    onChange.fire(ReadOnlyFiltersContainer(filterState: self))
   }
 
   /// Subscript providing access to a conjunctive group with specified name

--- a/Sources/InstantSearchCore/Segmented/SelectableFilterInteractor+FilterState.swift
+++ b/Sources/InstantSearchCore/Segmented/SelectableFilterInteractor+FilterState.swift
@@ -81,7 +81,7 @@ public struct SelectableFilterInteractorFilterStateConnection<Filter: FilterType
       interactor.selected = interactor.items.first(where: { accessor.contains($0.value) })?.key
     }
 
-    onChange(interactor, ReadOnlyFiltersContainer(filtersContainer: filterState))
+    onChange(interactor, ReadOnlyFiltersContainer(filterState: filterState))
 
     filterState.onChange.subscribePast(with: interactor, callback: onChange)
   }

--- a/Sources/InstantSearchCore/Toggle/ToggleFilter+FilterState.swift
+++ b/Sources/InstantSearchCore/Toggle/ToggleFilter+FilterState.swift
@@ -54,7 +54,7 @@ public extension ToggleFilter {
         interactor.isSelected = accessor.contains(interactor.item)
       }
 
-      onChange(interactor, ReadOnlyFiltersContainer(filtersContainer: filterState))
+      onChange(interactor, ReadOnlyFiltersContainer(filterState: filterState))
 
       filterState.onChange.subscribePast(with: interactor, callback: onChange)
     }

--- a/Tests/InstantSearchCoreTests/Unit/CurrentFilters/CurrentFiltersControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/CurrentFilters/CurrentFiltersControllerConnectionTests.swift
@@ -11,9 +11,28 @@ import Foundation
 import XCTest
 
 class CurrentFiltersControllerConnectionTests: XCTestCase {
-
+ 
   let attribute: Attribute = "Test Attribute"
   let groupName = "Test group"
+  
+  weak var disposableInteractor: CurrentFiltersInteractor?
+  weak var disposableController: TestCurrentFiltersController?
+  
+  func testLeak() {
+    let interactor = CurrentFiltersInteractor()
+    let controller = TestCurrentFiltersController()
+    
+    disposableInteractor = interactor
+    disposableController = controller
+
+    let connection = CurrentFiltersInteractor.ControllerConnection(interactor: interactor, controller: controller)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableController, "Leaked controller")
+  }
 
   func testConnect() {
 

--- a/Tests/InstantSearchCoreTests/Unit/CurrentFilters/CurrentFiltersFilterStateConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/CurrentFilters/CurrentFiltersFilterStateConnectionTests.swift
@@ -14,6 +14,26 @@ class CurrentFiltersFilterStateConnectionTests: XCTestCase {
 
   let groupName = "Test group"
   let filter = Filter.Facet(attribute: "Test Attribute", stringValue: "facet")
+  
+  weak var disposableInteractor: CurrentFiltersInteractor?
+  weak var disposableFilterState: FilterState?
+  
+  func testLeak() {
+    let interactor = CurrentFiltersInteractor()
+    let filterState = FilterState()
+    
+    disposableInteractor = interactor
+    disposableFilterState = filterState
+
+    let connection = CurrentFiltersInteractor.FilterStateConnection(interactor: interactor,
+                                                     filterState: filterState)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableFilterState, "Leaked filterState")
+  }
 
   func testConnect() {
     let interactor = CurrentFiltersInteractor()

--- a/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListControllerConnectionTests.swift
@@ -17,7 +17,10 @@ class FacetListControllerConnectionTests: XCTestCase {
 
   let facets: [Facet] = .init(prefix: "f", count: 3)
   let facetsWithAddition: [Facet] = .init(prefix: "f", count: 4)
-
+  
+  weak var disposableInteractor: FacetListInteractor?
+  weak var disposableController: TestFacetListController?
+  
   func testConnect() {
 
     let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
@@ -136,6 +139,20 @@ class FacetListControllerConnectionTests: XCTestCase {
 
     waitForExpectations(timeout: 5, handler: .none)
 
+  }
+  
+  func testLeak() {
+    let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
+    let controller = TestFacetListController()
+    self.disposableInteractor = interactor
+    self.disposableController = controller
+    let connection = FacetList.ControllerConnection(facetListInteractor: interactor, controller: controller, presenter: FacetListPresenter())
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor)
+    XCTAssertNil(disposableController)
   }
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListControllerConnectionTests.swift
@@ -21,6 +21,22 @@ class FacetListControllerConnectionTests: XCTestCase {
   weak var disposableInteractor: FacetListInteractor?
   weak var disposableController: TestFacetListController?
   
+  func testLeak() {
+    let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
+    let controller = TestFacetListController()
+    
+    disposableInteractor = interactor
+    disposableController = controller
+    
+    let connection = FacetList.ControllerConnection(facetListInteractor: interactor, controller: controller, presenter: FacetListPresenter())
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor)
+    XCTAssertNil(disposableController)
+  }
+  
   func testConnect() {
 
     let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
@@ -139,20 +155,6 @@ class FacetListControllerConnectionTests: XCTestCase {
 
     waitForExpectations(timeout: 5, handler: .none)
 
-  }
-  
-  func testLeak() {
-    let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
-    let controller = TestFacetListController()
-    self.disposableInteractor = interactor
-    self.disposableController = controller
-    let connection = FacetList.ControllerConnection(facetListInteractor: interactor, controller: controller, presenter: FacetListPresenter())
-    connection.connect()
-  }
-  
-  override func tearDown() {
-    XCTAssertNil(disposableInteractor)
-    XCTAssertNil(disposableController)
   }
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListFacetSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListFacetSearcherConnectionTests.swift
@@ -17,6 +17,25 @@ class FacetListFacetSearcherConnectionTests: XCTestCase {
   var results: FacetSearcher.SearchResult {
     return try! FacetSearcher.SearchResult(json: ["facetHits": try! JSON(facets), "exhaustiveFacetsCount": true, "processingTimeMS": 1])
   }
+  
+  weak var disposableInteractor: FacetListInteractor?
+  weak var disposableSearcher: FacetSearcher?
+  
+  func testLeak() {
+    let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
+    let searcher = FacetSearcher(appID: "", apiKey: "", indexName: "", facetName: "facet")
+
+    disposableInteractor = interactor
+    disposableSearcher = searcher
+    
+    let connection = FacetListInteractor.FacetSearcherConnection(interactor: interactor, searcher: searcher)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableSearcher, "Leaked searcher")
+  }
 
   func testConnect() {
 

--- a/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListFilterStateConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListFilterStateConnectionTests.swift
@@ -15,6 +15,29 @@ class FacetListFilterStateConnectionTests: XCTestCase {
   let attribute: Attribute = "Test Attribute"
   let groupName = "Test group"
   let facets: [Facet] = .init(prefix: "v", count: 4)
+  
+  weak var disposableInteractor: FacetListInteractor?
+  weak var disposableFilterState: FilterState?
+  
+  func testLeak() {
+    let interactor = FacetListInteractor(facets: facets, selectionMode: .single)
+    let filterState = FilterState()
+    
+    disposableInteractor = interactor
+    disposableFilterState = filterState
+
+    let connection = FacetList.FilterStateConnection(interactor: interactor,
+                                                     filterState: filterState,
+                                                     attribute: attribute,
+                                                     operator: .and,
+                                                     groupName: groupName)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableFilterState, "Leaked filterState")
+  }
 
   func testConnect() {
     let interactor = FacetListInteractor(facets: facets, selectionMode: .single)

--- a/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListSingleIndexSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/FacetList/FacetListSingleIndexSearcherConnectionTests.swift
@@ -14,6 +14,25 @@ class FacetListSingleIndexSearcherConnectionTests: XCTestCase {
 
   let attribute: Attribute = "Test Attribute"
   let facets: [Facet] = .init(prefix: "v", count: 3)
+  
+  weak var disposableSearcher: SingleIndexSearcher?
+  weak var disposableInteractor: FacetListInteractor?
+  
+  func testLeak() {
+    let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "")
+    let interactor = FacetListInteractor()
+    
+    disposableSearcher = searcher
+    disposableInteractor = interactor
+
+    let connection = FacetListInteractor.SingleIndexSearcherConnection(facetListInteractor: interactor, searcher: searcher, attribute: attribute)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableSearcher, "Leaked searcher")
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+  }
 
   func testConnect() {
     let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "")

--- a/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorControllerConnectionTests.swift
@@ -17,6 +17,25 @@ class HitsInteractorControllerConnectionTests: XCTestCase {
           paginationController: .init(),
     infiniteScrollingController: TestInfiniteScrollingController())
   }
+  
+  weak var disposableController: TestHitsController<JSON>?
+  weak var disposableInteractor: HitsInteractor<JSON>?
+  
+  func testLeak() {
+    let interactor = self.interactor
+    let controller = TestHitsController<JSON>()
+
+    disposableController = controller
+    disposableInteractor = interactor
+    
+    let connection = HitsInteractor.ControllerConnection(interactor: interactor, controller: controller)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableController, "Leaked controller")
+  }
 
   func testConnect() {
 

--- a/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorFilterStateConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorFilterStateConnectionTests.swift
@@ -21,6 +21,27 @@ class HitsInteractorFilterStateConnectionTests: XCTestCase {
   var filterState: FilterState {
     return .init()
   }
+  
+  weak var disposableInteractor: HitsInteractor<JSON>?
+  weak var disposableFilterState: FilterState?
+  
+  func testLeak() {
+    let interactor = self.interactor
+    let filterState = self.filterState
+    
+    disposableInteractor = interactor
+    disposableFilterState = filterState
+
+    let connection = HitsInteractorFilterStateConnection(interactor: interactor,
+                                                         filterState: filterState)
+
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableFilterState, "Leaked filterState")
+  }
 
   func testConnection() {
     let interactor = self.interactor

--- a/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorSearcherConnectionTests.swift
@@ -12,6 +12,9 @@ import AlgoliaSearchClient
 import XCTest
 
 class HitsInteractorSearcherConnectionTests: XCTestCase {
+  
+  weak var disposableInteractor: HitsInteractor<JSON>?
+  weak var disposableSearcher: SingleIndexSearcher?
 
   func getInteractor(with infiniteScrollingController: InfiniteScrollable) -> HitsInteractor<JSON> {
 
@@ -25,6 +28,27 @@ class HitsInteractorSearcherConnectionTests: XCTestCase {
                                     infiniteScrollingController: infiniteScrollingController)
 
     return interactor
+  }
+  
+  func testLeak() {
+    let infiniteScrollingController = TestInfiniteScrollingController()
+    infiniteScrollingController.pendingPages = [0, 2]
+
+    let searcher = SingleIndexSearcher(client: SearchClient(appID: "", apiKey: ""), indexName: "")
+    let interactor = getInteractor(with: infiniteScrollingController)
+
+    disposableInteractor = interactor
+    disposableSearcher = searcher
+    
+    let connection: Connection = HitsInteractor.SingleIndexSearcherConnection(interactor: interactor,
+                                                                              searcher: searcher)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableSearcher, "Leaked searcher")
   }
 
   func testConnect() {

--- a/Tests/InstantSearchCoreTests/Unit/MultiSourceHitsReloaderTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/MultiSourceHitsReloaderTests.swift
@@ -1,5 +1,5 @@
 //
-//  MultiSearchConnectionTests.swift
+//  MultiSourceHitsReloaderTests.swift
 //  InstantSearchCore
 //
 //  Created by Vladislav Fitc on 11/12/2019.

--- a/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputControllerConnectionTests.swift
@@ -11,6 +11,25 @@ import XCTest
 @testable import InstantSearchCore
 
 class QueryInputControllerConnectionTests: XCTestCase {
+  
+  weak var disposableInteractor: QueryInputInteractor?
+  weak var disposableController: TestQueryInputController?
+  
+  func testLeak() {
+    let controller = TestQueryInputController()
+    let interactor = QueryInputInteractor()
+    
+    disposableController = controller
+    disposableInteractor = interactor
+    
+    let connection = QueryInputInteractor.ControllerConnection(interactor: interactor, controller: controller)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableInteractor, "Leaked controller")
+  }
 
   func testConnect() {
 

--- a/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputSearcherConnectionTests.swift
@@ -11,7 +11,22 @@ import XCTest
 @testable import InstantSearchCore
 
 class QueryInputSearcherConnectionTests: XCTestCase {
-
+  
+  weak var disposableSearcher: TestSearcher?
+  weak var disposableInteractor: QueryInputInteractor?
+  
+  func testLeak() {
+    let searcher = TestSearcher()
+    let interactor = QueryInputInteractor()
+    let connection = QueryInputInteractor.SearcherConnection(interactor: interactor, searcher: searcher, searchTriggeringMode: .searchAsYouType)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableSearcher, "Leaked searcher")
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+  }
+  
   func testSearchAsYouTypeConnect() {
     let searcher = TestSearcher()
     let interactor = QueryInputInteractor()
@@ -116,5 +131,5 @@ class QueryInputSearcherConnectionTests: XCTestCase {
     waitForExpectations(timeout: 5, handler: nil)
 
   }
-
+  
 }


### PR DESCRIPTION
- Fix leaks occurring after connections establishment between  `FacetListInteractor` - `FilterState` - `FacetListController` (IFM-554)
- Fix leak occurring while `FilterState`  captures itself in consequence of the `onChange` event triggering
- Add unit tests checking if InstantSearch components leaked as a result of their connection