### PR TITLE
Patch 7.0.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,6 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-brightgreen.svg)](https://github.com/algolia/instantsearch-ios/)
 [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://swift.org/package-manager/)
 [![Mac Catalyst compatible](https://img.shields.io/badge/Catalyst-compatible-brightgreen.svg)](https://developer.apple.com/documentation/xcode/creating_a_mac_version_of_your_ipad_app/)
-[![Build Status](https://app.bitrise.io/app/780bdbbea54f2932/status.svg?token=f1LS-kRIdMjWWzHBdZCMFg&branch=bitrise)](https://app.bitrise.io/app/780bdbbea54f2932)
 [![Licence](http://img.shields.io/cocoapods/l/InstantSearch.svg?style=flat)](https://opensource.org/licenses/Apache-2.0)
 
 By [Algolia](http://algolia.com).

--- a/Sources/InstantSearchCore/Hits/HitsConnector.swift
+++ b/Sources/InstantSearchCore/Hits/HitsConnector.swift
@@ -43,7 +43,7 @@ public class HitsConnector<Hit: Codable>: Connection {
 public extension HitsConnector {
 
   convenience init(searcher: SingleIndexSearcher,
-                   interactor: HitsInteractor<Hit>,
+                   interactor: HitsInteractor<Hit> = .init(),
                    filterState: FilterState? = .none) {
     self.init(searcher: searcher,
               interactor: interactor,
@@ -54,7 +54,7 @@ public extension HitsConnector {
   convenience init(appID: ApplicationID,
                    apiKey: APIKey,
                    indexName: IndexName,
-                   interactor: HitsInteractor<Hit>,
+                   interactor: HitsInteractor<Hit> = .init(),
                    filterState: FilterState? = .none) {
     let searcher = SingleIndexSearcher(appID: appID,
                                        apiKey: apiKey,


### PR DESCRIPTION
- Weaken the dependency requirements to minor versions for Insights in the Cartfile and for Swift API Client in the podspec (ensures seamless integration of Client 8.0.1 with Xcode 12 support)
- Add default HitsInteractor instances as parameters in the HitsConnector initializers which simplifies 