### PR TITLE
Advanced connectors & lightweight Hits controllers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "InstantSearch",
     platforms: [
-          .iOS(.v8),
+          .iOS(.v9),
           .macOS(.v10_10),
           .watchOS(.v2),
           .tvOS(.v9)

--- a/Sources/InstantSearch/AdvancedConnectors/MultiIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/MultiIndexSearchConnector+UIKit.swift
@@ -1,0 +1,47 @@
+//
+//  MultiIndexSearchConnector+UIKit.swift
+//  
+//
+//  Created by Vladislav Fitc on 30/07/2020.
+//
+
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
+#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
+import UIKit
+
+public extension MultiIndexSearchConnector {
+  
+  @available(iOS 13.0, *)
+  init<HC: MultiIndexHitsController>(searcher: MultiIndexSearcher,
+                                     indexModules: [MultiIndexHitsConnector.IndexModule],
+                                     searchController: UISearchController,
+                                     hitsController: HC) {
+    let queryInputInteractor = QueryInputInteractor()
+    let textFieldController = TextFieldController(searchBar: searchController.searchBar)
+    self.init(searcher: searcher,
+              indexModules: indexModules,
+              hitsController: hitsController,
+              queryInputInteractor: queryInputInteractor,
+              queryInputController: textFieldController)
+  }
+  
+  @available(iOS 13.0, *)
+  init<HC: MultiIndexHitsController>(appID: ApplicationID,
+                                     apiKey: APIKey,
+                                     indexModules: [MultiIndexHitsConnector.IndexModule],
+                                     searchController: UISearchController,
+                                     hitsController: HC) {
+    let searcher = MultiIndexSearcher(appID: appID,
+                                      apiKey: apiKey,
+                                      indexNames: indexModules.map(\.indexName))
+    self.init(searcher: searcher,
+              indexModules: indexModules,
+              searchController: searchController,
+              hitsController: hitsController)
+  }
+  
+}
+
+#endif

--- a/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
@@ -1,0 +1,51 @@
+//
+//  SingleIndexSearchConnector+UIKit.swift
+//  
+//
+//  Created by Vladislav Fitc on 30/07/2020.
+//
+
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
+#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
+import UIKit
+
+public extension SingleIndexSearchConnector {
+  
+  @available(iOS 13.0, *)
+  init<HC: HitsController>(searcher: SingleIndexSearcher,
+                           searchController: UISearchController,
+                           hitsInteractor: HitsInteractor = .init(),
+                           hitsController: HC,
+                           filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor {
+    let queryInputInteractor = QueryInputInteractor()
+    let textFieldController = TextFieldController(searchBar: searchController.searchBar)
+    self.init(searcher: searcher,
+              queryInputInteractor: queryInputInteractor,
+              queryInputController: textFieldController,
+              hitsInteractor: hitsInteractor,
+              hitsController: hitsController,
+              filterState: filterState)
+  }
+  
+  @available(iOS 13.0, *)
+  init<HC: HitsController>(appID: ApplicationID,
+                           apiKey: APIKey,
+                           indexName: IndexName,
+                           searchController: UISearchController,
+                           hitsInteractor: HitsInteractor = .init(),
+                           hitsController: HC,
+                           filterState: FilterState? = nil) where HC.DataSource == HitsInteractor {
+    let searcher = SingleIndexSearcher(appID: appID,
+                                       apiKey: apiKey,
+                                       indexName: indexName)
+    self.init(searcher: searcher,
+              searchController: searchController,
+              hitsInteractor: hitsInteractor,
+              hitsController: hitsController,
+              filterState: filterState)
+  }
+  
+}
+#endif

--- a/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
@@ -16,9 +16,9 @@ public extension SingleIndexSearchConnector {
   @available(iOS 13.0, *)
   init<HC: HitsController>(searcher: SingleIndexSearcher,
                            searchController: UISearchController,
-                           hitsInteractor: HitsInteractor = .init(),
+                           hitsInteractor: HitsInteractor<Record> = .init(),
                            hitsController: HC,
-                           filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor {
+                           filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor<Record> {
     let queryInputInteractor = QueryInputInteractor()
     let textFieldController = TextFieldController(searchBar: searchController.searchBar)
     self.init(searcher: searcher,
@@ -34,9 +34,9 @@ public extension SingleIndexSearchConnector {
                            apiKey: APIKey,
                            indexName: IndexName,
                            searchController: UISearchController,
-                           hitsInteractor: HitsInteractor = .init(),
+                           hitsInteractor: HitsInteractor<Record> = .init(),
                            hitsController: HC,
-                           filterState: FilterState? = nil) where HC.DataSource == HitsInteractor {
+                           filterState: FilterState? = nil) where HC.DataSource == HitsInteractor<Record> {
     let searcher = SingleIndexSearcher(appID: appID,
                                        apiKey: apiKey,
                                        indexName: indexName)

--- a/Sources/InstantSearch/Hits/CellConfigurable.swift
+++ b/Sources/InstantSearch/Hits/CellConfigurable.swift
@@ -18,7 +18,7 @@ public protocol CellConfigurable {
   static var cellIdentifier: String { get }
 }
 
-extension CellConfigurable {
+public extension CellConfigurable {
   static var cellIdentifier: String { return "\(Self.self)" }
 }
 
@@ -28,7 +28,7 @@ public protocol TableViewCellConfigurable: CellConfigurable {
   func configure(_ cell: Cell)
 }
 
-extension TableViewCellConfigurable {
+public extension TableViewCellConfigurable {
   var cellHeight: CGFloat { return 44 }
 }
 

--- a/Sources/InstantSearch/Hits/CellConfigurable.swift
+++ b/Sources/InstantSearch/Hits/CellConfigurable.swift
@@ -12,27 +12,27 @@ import InstantSearchCore
 #if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
 import UIKit
 
-public protocol CellConfigurator {
+public protocol CellConfigurable {
   associatedtype Model: Codable
   init(model: Model, indexPath: IndexPath)
   static var cellIdentifier: String { get }
 }
 
-extension CellConfigurator {
+extension CellConfigurable {
   static var cellIdentifier: String { return "\(Self.self)" }
 }
 
-public protocol TableViewCellConfigurator: CellConfigurator {
+public protocol TableViewCellConfigurable: CellConfigurable {
   associatedtype Cell: UITableViewCell
   var cellHeight: CGFloat { get }
   func configure(_ cell: Cell)
 }
 
-extension TableViewCellConfigurator {
+extension TableViewCellConfigurable {
   var cellHeight: CGFloat { return 44 }
 }
 
-public protocol CollectionViewCellConfigurator: CellConfigurator {
+public protocol CollectionViewCellConfigurable: CellConfigurable {
   associatedtype Cell: UICollectionViewCell
   var cellSize: CGSize { get }
   func configure(_ cell: Cell)

--- a/Sources/InstantSearch/Hits/CellConfigurable.swift
+++ b/Sources/InstantSearch/Hits/CellConfigurable.swift
@@ -6,7 +6,10 @@
 //  Copyright © 2020 Algolia. All rights reserved.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
+#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
 import UIKit
 
 public protocol CellConfigurator {
@@ -34,3 +37,4 @@ public protocol CollectionViewCellConfigurator: CellConfigurator {
   var cellSize: CGSize { get }
   func configure(_ cell: Cell)
 }
+#endif

--- a/Sources/InstantSearch/Hits/CellConfigurator.swift
+++ b/Sources/InstantSearch/Hits/CellConfigurator.swift
@@ -1,0 +1,36 @@
+//
+//  CellConfigurator.swift
+//  DemoDirectory
+//
+//  Created by Vladislav Fitc on 29/07/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public protocol CellConfigurator {
+  associatedtype Model: Codable
+  init(model: Model, indexPath: IndexPath)
+  static var cellIdentifier: String { get }
+}
+
+extension CellConfigurator {
+  static var cellIdentifier: String { return "\(Self.self)" }
+}
+
+public protocol TableViewCellConfigurator: CellConfigurator {
+  associatedtype Cell: UITableViewCell
+  var cellHeight: CGFloat { get }
+  func configure(_ cell: Cell)
+}
+
+extension TableViewCellConfigurator {
+  var cellHeight: CGFloat { return 44 }
+}
+
+public protocol CollectionViewCellConfigurator: CellConfigurator {
+  associatedtype Cell: UICollectionViewCell
+  var cellSize: CGSize { get }
+  func configure(_ cell: Cell)
+}

--- a/Sources/InstantSearch/Hits/CollectionView/HitsCollectionViewController.swift
+++ b/Sources/InstantSearch/Hits/CollectionView/HitsCollectionViewController.swift
@@ -1,0 +1,41 @@
+//
+//  HitsCollectionViewController.swift
+//  DemoDirectory
+//
+//  Created by Vladislav Fitc on 29/07/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import InstantSearch
+
+open class HitsCollectionViewController<CellConfigurator: CollectionViewCellConfigurator>: UICollectionViewController, UICollectionViewDelegateFlowLayout, HitsController {
+  
+  public var hitsSource: HitsInteractor<CellConfigurator.Model>?
+
+  open override func viewDidLoad() {
+    super.viewDidLoad()
+    collectionView.register(CellConfigurator.Cell.self, forCellWithReuseIdentifier: CellConfigurator.cellIdentifier)
+  }
+  
+  open override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return hitsSource?.numberOfHits() ?? 0
+  }
+  
+  open override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    return collectionView.dequeueReusableCell(withReuseIdentifier: CellConfigurator.cellIdentifier, for: indexPath)
+  }
+  
+  open override func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    guard let cell = cell as? CellConfigurator.Cell else { return }
+    guard let model = hitsSource?.hit(atIndex: indexPath.row) else { return }
+    CellConfigurator(model: model, indexPath: indexPath).configure(cell)
+  }
+  
+  public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    guard let model = hitsSource?.hit(atIndex: indexPath.row) else { return .zero }
+    return CellConfigurator(model: model, indexPath: indexPath).cellSize
+  }
+    
+}

--- a/Sources/InstantSearch/Hits/CollectionView/HitsCollectionViewController.swift
+++ b/Sources/InstantSearch/Hits/CollectionView/HitsCollectionViewController.swift
@@ -12,7 +12,7 @@ import InstantSearchCore
 #if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
 import UIKit
 
-open class HitsCollectionViewController<CellConfigurator: CollectionViewCellConfigurator>: UICollectionViewController, UICollectionViewDelegateFlowLayout, HitsController {
+open class HitsCollectionViewController<CellConfigurator: CollectionViewCellConfigurable>: UICollectionViewController, UICollectionViewDelegateFlowLayout, HitsController {
   
   public var hitsSource: HitsInteractor<CellConfigurator.Model>?
 

--- a/Sources/InstantSearch/Hits/CollectionView/HitsCollectionViewController.swift
+++ b/Sources/InstantSearch/Hits/CollectionView/HitsCollectionViewController.swift
@@ -6,9 +6,11 @@
 //  Copyright © 2020 Algolia. All rights reserved.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
+#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
 import UIKit
-import InstantSearch
 
 open class HitsCollectionViewController<CellConfigurator: CollectionViewCellConfigurator>: UICollectionViewController, UICollectionViewDelegateFlowLayout, HitsController {
   
@@ -39,3 +41,4 @@ open class HitsCollectionViewController<CellConfigurator: CollectionViewCellConf
   }
     
 }
+#endif

--- a/Sources/InstantSearch/Hits/TableView/HitsTableViewController.swift
+++ b/Sources/InstantSearch/Hits/TableView/HitsTableViewController.swift
@@ -1,0 +1,41 @@
+//
+//  HitsTableViewController.swift
+//  DemoDirectory
+//
+//  Created by Vladislav Fitc on 29/07/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import InstantSearch
+
+open class HitsTableViewController<CellConfigurator: TableViewCellConfigurator>: UITableViewController, HitsController {
+    
+  public var hitsSource: HitsInteractor<CellConfigurator.Model>?
+  
+  open override func viewDidLoad() {
+    super.viewDidLoad()
+    tableView.register(CellConfigurator.Cell.self, forCellReuseIdentifier: CellConfigurator.cellIdentifier)
+  }
+
+  open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return hitsSource?.numberOfHits() ?? 0
+  }
+  
+  open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    return tableView.dequeueReusableCell(withIdentifier: CellConfigurator.cellIdentifier, for: indexPath)
+  }
+  
+  open override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+    guard let cell = cell as? CellConfigurator.Cell else { return }
+    guard let model = hitsSource?.hit(atIndex: indexPath.row) else { return }
+    CellConfigurator(model: model, indexPath: indexPath).configure(cell)
+  }
+  
+  open override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    guard let model = hitsSource?.hit(atIndex: indexPath.row) else { return 0 }
+    return CellConfigurator(model: model, indexPath: indexPath).cellHeight
+  }
+  
+}

--- a/Sources/InstantSearch/Hits/TableView/HitsTableViewController.swift
+++ b/Sources/InstantSearch/Hits/TableView/HitsTableViewController.swift
@@ -12,7 +12,7 @@ import InstantSearchCore
 #if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
 import UIKit
 
-open class HitsTableViewController<CellConfigurator: TableViewCellConfigurator>: UITableViewController, HitsController {
+open class HitsTableViewController<CellConfigurator: TableViewCellConfigurable>: UITableViewController, HitsController {
     
   public var hitsSource: HitsInteractor<CellConfigurator.Model>?
   

--- a/Sources/InstantSearch/Hits/TableView/HitsTableViewController.swift
+++ b/Sources/InstantSearch/Hits/TableView/HitsTableViewController.swift
@@ -6,9 +6,11 @@
 //  Copyright © 2020 Algolia. All rights reserved.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
+#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
 import UIKit
-import InstantSearch
 
 open class HitsTableViewController<CellConfigurator: TableViewCellConfigurator>: UITableViewController, HitsController {
     
@@ -39,3 +41,4 @@ open class HitsTableViewController<CellConfigurator: TableViewCellConfigurator>:
   }
   
 }
+#endif

--- a/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
@@ -1,0 +1,62 @@
+//
+//  MultiIndexSearchConnector.swift
+//  DemoDirectory
+//
+//  Created by Vladislav Fitc on 23/07/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+
+public struct MultiIndexSearchConnector: Connection {
+  
+  public let hitsConnector: MultiIndexHitsConnector
+  public let hitsControllerConnection: Connection
+  
+  public let queryInputConnector: QueryInputConnector<MultiIndexSearcher>
+  public let queryInputControllerConnection: Connection
+  
+  public init<QI: QueryInputController, HC: MultiIndexHitsController>(searcher: MultiIndexSearcher,
+                                                                      indexModules: [MultiIndexHitsConnector.IndexModule],
+                                                                      hitsController: HC,
+                                                                      queryInputInteractor: QueryInputInteractor = .init(),
+                                                                      queryInputController: QI) {
+    self.hitsConnector = .init(appID: searcher.client.applicationID, apiKey: searcher.client.apiKey, indexModules: indexModules)
+    hitsControllerConnection = self.hitsConnector.interactor.connectController(hitsController)
+    self.queryInputConnector = .init(searcher: searcher, interactor: queryInputInteractor)
+    queryInputControllerConnection = queryInputInteractor.connectController(queryInputController)
+    searcher.search()
+  }
+  
+  public init<QI: QueryInputController, HC: MultiIndexHitsController>(appID: ApplicationID,
+                                                                      apiKey: APIKey,
+                                                                      indexModules: [MultiIndexHitsConnector.IndexModule],
+                                                                      hitsController: HC,
+                                                                      queryInputInteractor: QueryInputInteractor = .init(),
+                                                                      queryInputController: QI) {
+    let searcher = MultiIndexSearcher(appID: appID,
+                                      apiKey: apiKey,
+                                      indexNames: indexModules.map(\.indexName))
+    self.init(searcher: searcher,
+              indexModules: indexModules,
+              hitsController: hitsController,
+              queryInputInteractor: queryInputInteractor,
+              queryInputController: queryInputController)
+  }
+  
+  public func connect() {
+    disconnect()
+    hitsConnector.connect()
+    hitsControllerConnection.connect()
+    queryInputConnector.connect()
+    queryInputControllerConnection.connect()
+  }
+  
+  public func disconnect() {
+    hitsConnector.disconnect()
+    hitsControllerConnection.disconnect()
+    queryInputConnector.disconnect()
+    queryInputControllerConnection.disconnect()
+  }
+  
+}

--- a/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
@@ -8,14 +8,33 @@
 
 import Foundation
 
+/**
+Connector encapsulating basic search experience within multiple indices
+
+Most of the components associated by this connector are created and connected automatically, it's only required to provide a proper `Controller` implementations.
+*/
 public struct MultiIndexSearchConnector: Connection {
   
+  /// Connector establishing the linkage between searcher, hits interactor and optionally filter state
   public let hitsConnector: MultiIndexHitsConnector
+  
+  /// Connection between hits interactor of hits connector and provided hits controller
   public let hitsControllerConnection: Connection
   
+  /// Connector establishing the linkage between searcher and query input interactor
   public let queryInputConnector: QueryInputConnector<MultiIndexSearcher>
+  
+  /// Connection between query input interactor of query input connector and provided query input controller
   public let queryInputControllerConnection: Connection
   
+  /**
+   - Parameters:
+     - searcher: External multi index sercher
+     - indexModules: List of index modules associating index name, hits interactor and optional filter state
+     - hitsController: Hits controller
+     - queryInputInteractor: External query input interactor
+     - queryInputController: Query input controller
+   */
   public init<QI: QueryInputController, HC: MultiIndexHitsController>(searcher: MultiIndexSearcher,
                                                                       indexModules: [MultiIndexHitsConnector.IndexModule],
                                                                       hitsController: HC,
@@ -28,6 +47,15 @@ public struct MultiIndexSearchConnector: Connection {
     searcher.search()
   }
   
+  /**
+   - Parameters:
+     - appID: Application ID
+     - apiKey: API Key
+     - indexModules: List of index modules associating index name, hits interactor and optional filter state
+     - hitsController: Hits controller
+     - queryInputInteractor: External query input interactor
+     - queryInputController: Query input controller
+   */
   public init<QI: QueryInputController, HC: MultiIndexHitsController>(appID: ApplicationID,
                                                                       apiKey: APIKey,
                                                                       indexModules: [MultiIndexHitsConnector.IndexModule],

--- a/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
@@ -47,7 +47,9 @@ public struct MultiIndexSearchConnector: Connection {
                                                                       hitsController: HC,
                                                                       queryInputInteractor: QueryInputInteractor = .init(),
                                                                       queryInputController: QI) {
-    self.hitsConnector = .init(appID: searcher.client.applicationID, apiKey: searcher.client.apiKey, indexModules: indexModules)
+    let hitsInteractor = MultiIndexHitsInteractor(hitsInteractors: indexModules.map(\.hitsInteractor))
+    let filterStates = indexModules.map(\.filterState)
+    self.hitsConnector = .init(searcher: searcher, interactor: hitsInteractor, filterStates: filterStates)
     hitsControllerConnection = self.hitsConnector.interactor.connectController(hitsController)
     self.queryInputConnector = .init(searcher: searcher, interactor: queryInputInteractor)
     queryInputControllerConnection = queryInputInteractor.connectController(queryInputController)

--- a/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
@@ -10,7 +10,14 @@ import Foundation
 
 /**
 Connector encapsulating basic search experience within multiple indices
-
+ 
+ Managed connections:
+ - hits interactor <-> searcher
+ - hits interactor <-> hits controller
+ - hits interactor <-> filter states (if provided)
+ - query input interactor <-> searcher
+ - query input interactor <-> query input controller
+ - searcher <-> filter states (if provided)
 Most of the components associated by this connector are created and connected automatically, it's only required to provide a proper `Controller` implementations.
 */
 public struct MultiIndexSearchConnector: Connection {

--- a/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
@@ -9,9 +9,7 @@
 import Foundation
 
 public struct SingleIndexSearchConnector<Record: Codable>: Connection {
-  
-  public typealias HitsInteractor = InstantSearchCore.HitsInteractor<Record>
-  
+    
   public let hitsConnector: HitsConnector<Record>
   public let hitsControllerConnection: Connection
   
@@ -24,9 +22,9 @@ public struct SingleIndexSearchConnector<Record: Codable>: Connection {
   public init<HC: HitsController, QI: QueryInputController>(searcher: SingleIndexSearcher,
                                                             queryInputInteractor: QueryInputInteractor = .init(),
                                                             queryInputController: QI,
-                                                            hitsInteractor: HitsInteractor = .init(),
+                                                            hitsInteractor: HitsInteractor<Record> = .init(),
                                                             hitsController: HC,
-                                                            filterState: FilterState? = nil) where HC.DataSource == HitsInteractor {
+                                                            filterState: FilterState? = nil) where HC.DataSource == HitsInteractor<Record> {
     hitsConnector = .init(searcher: searcher, interactor: hitsInteractor, filterState: filterState)
     queryInputConnector = .init(searcher: searcher, interactor: queryInputInteractor)
     
@@ -48,9 +46,9 @@ public struct SingleIndexSearchConnector<Record: Codable>: Connection {
                                                             indexName: IndexName,
                                                             queryInputInteractor: QueryInputInteractor = .init(),
                                                             queryInputController: QI,
-                                                            hitsInteractor: HitsInteractor = .init(),
+                                                            hitsInteractor: HitsInteractor<Record> = .init(),
                                                             hitsController: HC,
-                                                            filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor {
+                                                            filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor<Record> {
     let searcher = SingleIndexSearcher(appID: appID,
                                        apiKey: apiKey,
                                        indexName: indexName)

--- a/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
@@ -1,0 +1,84 @@
+//
+//  SingleIndexSearchConnector.swift
+//  DemoDirectory
+//
+//  Created by Vladislav Fitc on 23/07/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+
+public struct SingleIndexSearchConnector<Record: Codable>: Connection {
+  
+  public typealias HitsInteractor = InstantSearchCore.HitsInteractor<Record>
+  
+  public let hitsConnector: HitsConnector<Record>
+  public let hitsControllerConnection: Connection
+  
+  public let queryInputConnector: QueryInputConnector<SingleIndexSearcher>
+  public let queryInputControllerConnection: Connection
+  
+  public let filterStateHitsInteractorConnection: Connection?
+  public let filterStateSearcherConnection: Connection?
+  
+  public init<HC: HitsController, QI: QueryInputController>(searcher: SingleIndexSearcher,
+                                                            queryInputInteractor: QueryInputInteractor = .init(),
+                                                            queryInputController: QI,
+                                                            hitsInteractor: HitsInteractor = .init(),
+                                                            hitsController: HC,
+                                                            filterState: FilterState? = nil) where HC.DataSource == HitsInteractor {
+    hitsConnector = .init(searcher: searcher, interactor: hitsInteractor, filterState: filterState)
+    queryInputConnector = .init(searcher: searcher, interactor: queryInputInteractor)
+    
+    queryInputControllerConnection = queryInputInteractor.connectController(queryInputController)
+    hitsControllerConnection = hitsInteractor.connectController(hitsController)
+    
+    if let filterState = filterState {
+      filterStateHitsInteractorConnection = hitsInteractor.connectFilterState(filterState)
+      filterStateSearcherConnection = searcher.connectFilterState(filterState)
+    } else {
+      filterStateHitsInteractorConnection = nil
+      filterStateSearcherConnection = nil
+    }
+    
+  }
+  
+  public init<HC: HitsController, QI: QueryInputController>(appID: ApplicationID,
+                                                            apiKey: APIKey,
+                                                            indexName: IndexName,
+                                                            queryInputInteractor: QueryInputInteractor = .init(),
+                                                            queryInputController: QI,
+                                                            hitsInteractor: HitsInteractor = .init(),
+                                                            hitsController: HC,
+                                                            filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor {
+    let searcher = SingleIndexSearcher(appID: appID,
+                                       apiKey: apiKey,
+                                       indexName: indexName)
+    self.init(searcher: searcher,
+              queryInputInteractor: queryInputInteractor,
+              queryInputController: queryInputController,
+              hitsInteractor: hitsInteractor,
+              hitsController: hitsController,
+              filterState: filterState)
+  }
+  
+  public func connect() {
+    disconnect()
+    queryInputConnector.connect()
+    queryInputControllerConnection.connect()
+    hitsConnector.connect()
+    hitsControllerConnection.connect()
+    filterStateSearcherConnection?.connect()
+    filterStateHitsInteractorConnection?.connect()
+  }
+  
+  public func disconnect() {
+    queryInputConnector.disconnect()
+    queryInputControllerConnection.disconnect()
+    hitsConnector.disconnect()
+    hitsControllerConnection.disconnect()
+    filterStateSearcherConnection?.disconnect()
+    filterStateHitsInteractorConnection?.disconnect()
+  }
+  
+}

--- a/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
@@ -11,6 +11,14 @@ import Foundation
 /**
  Connector encapsulating basic search experience within single index
  
+ Managed connections:
+ - hits interactor <-> searcher
+ - hits interactor <-> hits controller
+ - hits interactor <-> filter state (if provided)
+ - query input interactor <-> searcher
+ - query input interactor <-> query input controller
+ - searcher <-> filter state (if provided)
+ 
  Most of the components associated by this connector are created and connected automatically, it's only required to provide a proper `Controller` implementations.
  */
 public struct SingleIndexSearchConnector<Record: Codable>: Connection {

--- a/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
@@ -8,17 +8,40 @@
 
 import Foundation
 
+/**
+ Connector encapsulating basic search experience within single index
+ 
+ Most of the components associated by this connector are created and connected automatically, it's only required to provide a proper `Controller` implementations.
+ */
 public struct SingleIndexSearchConnector<Record: Codable>: Connection {
-    
+  
+  /// Connector establishing the linkage between searcher, hits interactor and optionally filter state
   public let hitsConnector: HitsConnector<Record>
+  
+  /// Connection between hits interactor of hits connector and provided hits controller
   public let hitsControllerConnection: Connection
   
+  /// Connector establishing the linkage between searcher and query input interactor
   public let queryInputConnector: QueryInputConnector<SingleIndexSearcher>
+  
+  /// Connection between query input interactor of query input connector and provided query input controller
   public let queryInputControllerConnection: Connection
   
+  /// Connection between filter state and hits interactor of hits connector
   public let filterStateHitsInteractorConnection: Connection?
+  
+  /// Connection between filter state and searcher
   public let filterStateSearcherConnection: Connection?
   
+  /**
+   - Parameters:
+     - searcher: External single index sercher
+     - queryInputInteractor: External query input interactor
+     - queryInputController: Query input controller
+     - hitsInteractor: External hits interactor
+     - hitsController: Hits controller
+     - filterState: Filter state
+  */
   public init<HC: HitsController, QI: QueryInputController>(searcher: SingleIndexSearcher,
                                                             queryInputInteractor: QueryInputInteractor = .init(),
                                                             queryInputController: QI,
@@ -41,6 +64,17 @@ public struct SingleIndexSearchConnector<Record: Codable>: Connection {
     
   }
   
+  /**
+   - Parameters:
+     - appID: Application ID
+     - apiKey: API Key
+     - indexName: Name of the index in which search will be performed
+     - queryInputInteractor: External query input interactor
+     - queryInputController: Query input controller
+     - hitsInteractor: External hits interactor
+     - hitsController: Hits controller
+     - filterState: Filter state
+   */
   public init<HC: HitsController, QI: QueryInputController>(appID: ApplicationID,
                                                             apiKey: APIKey,
                                                             indexName: IndexName,

--- a/Sources/InstantSearchCore/FacetList/FacetListConnector.swift
+++ b/Sources/InstantSearchCore/FacetList/FacetListConnector.swift
@@ -9,112 +9,131 @@
 import Foundation
 
 public class FacetListConnector: Connection {
-
+  
   public enum Searcher {
     case singleIndex(SingleIndexSearcher)
     case facet(FacetSearcher)
   }
-
+  
   public let filterState: FilterState
   public let searcher: Searcher
   public let interactor: FacetListInteractor
   public let attribute: Attribute
-
+  
   public let filterStateConnection: Connection
   public let searcherConnection: Connection
-
-  internal init(searcher: Searcher,
-                filterState: FilterState,
-                interactor: FacetListInteractor = .init(),
-                attribute: Attribute,
-                operator: RefinementOperator,
-                groupName: String? = nil) {
-
+  public let controllerConnection: Connection?
+  
+  internal init<Controller: FacetListController>(searcher: Searcher,
+                                                 filterState: FilterState = .init(),
+                                                 interactor: FacetListInteractor = .init(),
+                                                 controller: Controller? = nil,
+                                                 attribute: Attribute,
+                                                 operator: RefinementOperator,
+                                                 groupName: String? = nil) {
+    
     self.filterState = filterState
     self.searcher = searcher
     self.interactor = interactor
     self.attribute = attribute
-
+    
     self.filterStateConnection = interactor.connectFilterState(filterState,
                                                                with: attribute,
                                                                operator: `operator`,
                                                                groupName: groupName)
+    
+    if let controller = controller {
+      self.controllerConnection = interactor.connectController(controller)
+    } else {
+      self.controllerConnection = nil
+    }
+    
     switch searcher {
     case .facet(let facetSearcher):
       searcherConnection = interactor.connectFacetSearcher(facetSearcher)
-
+      
     case .singleIndex(let singleIndexSearcher):
       searcherConnection = interactor.connectSearcher(singleIndexSearcher, with: attribute)
     }
-
+    
   }
-
-  public convenience init(searcher: SingleIndexSearcher,
-                          filterState: FilterState,
-                          attribute: Attribute,
-                          operator: RefinementOperator,
-                          groupName: String? = nil,
-                          interactor: FacetListInteractor = .init()) {
+  
+  public convenience init<Controller: FacetListController>(searcher: SingleIndexSearcher,
+                                                           filterState: FilterState = .init(),
+                                                           attribute: Attribute,
+                                                           operator: RefinementOperator,
+                                                           groupName: String? = nil,
+                                                           interactor: FacetListInteractor = .init(),
+                                                           controller: Controller? = nil) {
     self.init(searcher: .singleIndex(searcher),
               filterState: filterState,
               interactor: interactor,
+              controller: controller,
               attribute: attribute,
               operator: `operator`,
               groupName: groupName)
   }
-
-  public convenience init(searcher: FacetSearcher,
-                          filterState: FilterState,
-                          attribute: Attribute,
-                          operator: RefinementOperator,
-                          groupName: String? = nil,
-                          interactor: FacetListInteractor = .init()) {
+  
+  public convenience init<Controller: FacetListController>(searcher: FacetSearcher,
+                                                           filterState: FilterState = .init(),
+                                                           attribute: Attribute,
+                                                           operator: RefinementOperator,
+                                                           groupName: String? = nil,
+                                                           interactor: FacetListInteractor = .init(),
+                                                           controller: Controller? = nil) {
     self.init(searcher: .facet(searcher),
               filterState: filterState,
               interactor: interactor,
+              controller: controller,
               attribute: attribute,
               operator: `operator`,
               groupName: groupName)
   }
-
-  public convenience init(searcher: SingleIndexSearcher,
-                          filterState: FilterState,
-                          attribute: Attribute,
-                          facets: [Facet],
-                          selectionMode: SelectionMode,
-                          operator: RefinementOperator,
-                          groupName: String? = nil) {
+  
+  public convenience init<Controller: FacetListController>(searcher: SingleIndexSearcher,
+                                                           filterState: FilterState = .init(),
+                                                           attribute: Attribute,
+                                                           facets: [Facet],
+                                                           selectionMode: SelectionMode,
+                                                           operator: RefinementOperator,
+                                                           groupName: String? = nil,
+                                                           controller: Controller? = nil) {
     self.init(searcher: .singleIndex(searcher),
               filterState: filterState,
               interactor: .init(facets: facets, selectionMode: selectionMode),
+              controller: controller,
               attribute: attribute,
               operator: `operator`,
               groupName: groupName)
   }
-
-  public convenience init(searcher: FacetSearcher,
-                          filterState: FilterState,
-                          attribute: Attribute,
-                          facets: [Facet],
-                          selectionMode: SelectionMode,
-                          operator: RefinementOperator,
-                          groupName: String? = nil) {
+  
+  public convenience init<Controller: FacetListController>(searcher: FacetSearcher,
+                                                           filterState: FilterState = .init(),
+                                                           attribute: Attribute,
+                                                           facets: [Facet],
+                                                           selectionMode: SelectionMode,
+                                                           operator: RefinementOperator,
+                                                           groupName: String? = nil,
+                                                           controller: Controller? = nil) {
     self.init(searcher: .facet(searcher),
               filterState: filterState,
               interactor: .init(facets: facets, selectionMode: selectionMode),
+              controller: controller,
               attribute: attribute,
               operator: `operator`,
               groupName: groupName)
   }
-
+  
   public func connect() {
     filterStateConnection.connect()
     searcherConnection.connect()
+    controllerConnection?.connect()
   }
-
+  
   public func disconnect() {
     filterStateConnection.disconnect()
     searcherConnection.disconnect()
+    controllerConnection?.disconnect()
   }
-
+  
 }

--- a/Sources/InstantSearchCore/QueryBuilder/QueryBuilder.swift
+++ b/Sources/InstantSearchCore/QueryBuilder/QueryBuilder.swift
@@ -119,5 +119,3 @@ public struct QueryBuilder {
   }
 
 }
-
-extension SearchResponse: Builder {}

--- a/Sources/InstantSearchCore/Searcher/MultiIndex/MultiIndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/MultiIndex/MultiIndexSearcher.swift
@@ -150,8 +150,8 @@ public class MultiIndexSearcher: Searcher, SequencerDelegate, SearchResultObserv
     processingQueue.maxConcurrentOperationCount = 1
     processingQueue.qualityOfService = .userInitiated
 
-    self.pageLoaders = indexQueryStates.enumerated().map { (index, _) in
-      return PageLoaderProxy(setPage: { self.indexQueryStates[index].query.page = $0 }, launchSearch: self.search)
+    self.pageLoaders = indexQueryStates.enumerated().map { [weak self] (index, _) in
+      return PageLoaderProxy(setPage: { self?.indexQueryStates[index].query.page = $0 },                       launchSearch: { self?.search() })
     }
 
   }

--- a/Tests/InstantSearchCoreTests/Unit/Connectors/MultiIndexSearchConnectorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Connectors/MultiIndexSearchConnectorTests.swift
@@ -1,0 +1,80 @@
+//
+//  MultiIndexSearchConnectorTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 07/08/2020.
+//
+
+import Foundation
+@testable import InstantSearchCore
+import XCTest
+
+class MultiIndexSearchConnectorTests: XCTestCase {
+  
+  struct ConnectorContainer {
+    
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let indexModules: [MultiIndexHitsConnector.IndexModule] = [
+      .init(indexName: "i1", hitsInteractor: HitsInteractor<JSON>()),
+      .init(indexName: "i2", hitsInteractor: HitsInteractor<JSON>())
+    ]
+    let controller = TestMultiIndexHitsController()
+    let queryInputInteractor = QueryInputInteractor()
+    let queryInputController = TestQueryInputController()
+    
+    lazy var connector = MultiIndexSearchConnector(searcher: searcher,
+                                                   indexModules: indexModules,
+                                                   hitsController: controller,
+                                                   queryInputInteractor: queryInputInteractor,
+                                                   queryInputController: queryInputController)
+  }
+  
+  func testHitsInteractorSearcherConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = MultiIndexHitsInteractorSearcherConnectionTests.ConnectionTester(searcher: module.searcher,
+                                                                                  interactor: module.connector.hitsConnector.interactor,
+                                                                                  source: self)
+    tester.check(isConnected: true)
+  }
+  
+  func testHitsInteractorControllerConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = MultiIndexHitsInteractorControllerConnectionTests.ConnectionTester(controller: module.controller,
+                                                                                    interactor: module.connector.hitsConnector.interactor,
+                                                                                    source: self)
+    tester.check(isConnected: true)
+  }
+  
+  func testQueryInputSearcherConnect() {
+    // to complete when SingleIndexSearcher become abstract enough
+  }
+  
+  func testQueryInputControllerConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = QueryInputControllerConnectionTester(interactor: module.queryInputInteractor,
+                                                      controller: module.queryInputController,
+                                                      presetQuery: nil,
+                                                      source: self)
+    tester.check(isConnected: true)
+  }
+  
+  func testDisconnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    module.connector.disconnect()
+    MultiIndexHitsInteractorSearcherConnectionTests.ConnectionTester(searcher: module.searcher,
+                                                                     interactor: module.connector.hitsConnector.interactor,
+                                                                     source: self).check(isConnected: false)
+    MultiIndexHitsInteractorControllerConnectionTests.ConnectionTester(controller: module.controller,
+                                                                       interactor: module.connector.hitsConnector.interactor,
+                                                                       source: self).check(isConnected: false)
+    QueryInputControllerConnectionTester(interactor: module.queryInputInteractor,
+                                         controller: module.queryInputController,
+                                         presetQuery: nil,
+                                         source: self).check(isConnected: false)
+  }
+  
+}

--- a/Tests/InstantSearchCoreTests/Unit/Connectors/SingleIndexSearchConnectorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Connectors/SingleIndexSearchConnectorTests.swift
@@ -52,10 +52,10 @@ class SingleIndexSearchConnectorTests: XCTestCase {
   func testHitsInteractorSearcherConnect() {
     var module = ConnectorContainer()
     module.connector.connect()
-    let tester = HitsInteractorSearcherConnectionTester(searcher: module.searcher,
-                                                        interactor: module.hitsInteractor,
-                                                        infiniteScrollingController: module.infiniteScrollingController,
-                                                        source: self)
+    let tester = HitsInteractorSearcherConnectionTests.ConnectionTester(searcher: module.searcher,
+                                                                        interactor: module.hitsInteractor,
+                                                                        infiniteScrollingController: module.infiniteScrollingController,
+                                                                        source: self)
     tester.check(isConnected: true)
   }
   
@@ -105,10 +105,10 @@ class SingleIndexSearchConnectorTests: XCTestCase {
                                              controller: module.hitsController,
                                              source: self).check(isConnected: false)
     
-    HitsInteractorSearcherConnectionTester(searcher: module.searcher,
-                                           interactor: module.hitsInteractor,
-                                           infiniteScrollingController: module.infiniteScrollingController,
-                                           source: self).check(isConnected: false)
+    HitsInteractorSearcherConnectionTests.ConnectionTester(searcher: module.searcher,
+                                                           interactor: module.hitsInteractor,
+                                                           infiniteScrollingController: module.infiniteScrollingController,
+                                                           source: self).check(isConnected: false)
     
     QueryInputControllerConnectionTester(interactor: module.queryInputInteractor,
                                          controller: module.queryInputController,

--- a/Tests/InstantSearchCoreTests/Unit/Connectors/SingleIndexSearchConnectorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Connectors/SingleIndexSearchConnectorTests.swift
@@ -1,0 +1,119 @@
+//
+//  SingleIndexSearchConnectorTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 06/08/2020.
+//
+
+import Foundation
+@testable import InstantSearchCore
+import XCTest
+
+class SingleIndexSearchConnectorTests: XCTestCase {
+  
+  struct ConnectorContainer {
+    
+    lazy var infiniteScrollingController: TestInfiniteScrollingController = {
+      let controller = TestInfiniteScrollingController()
+      controller.pendingPages = [0, 2]
+      return controller
+    }()
+    
+    let searcher = SingleIndexSearcher(client: SearchClient(appID: "", apiKey: ""), indexName: "")
+    let queryInputInteractor = QueryInputInteractor()
+    let queryInputController = TestQueryInputController()
+    lazy var hitsInteractor = getInteractor(with: infiniteScrollingController)
+    let hitsController = TestHitsController<JSON>()
+    let filterState = FilterState()
+    
+    lazy var connector = SingleIndexSearchConnector(searcher: searcher,
+                                                    queryInputInteractor: queryInputInteractor,
+                                                    queryInputController: queryInputController,
+                                                    hitsInteractor: hitsInteractor,
+                                                    hitsController: hitsController,
+                                                    filterState: filterState)
+    
+    func getInteractor(with infiniteScrollingController: InfiniteScrollable) -> HitsInteractor<JSON> {
+      
+      let paginator = Paginator<JSON>()
+      
+      let page1 = ["i1", "i2", "i3"].map { JSON.string($0) }
+      paginator.pageMap = PageMap([1: page1])
+      
+      let interactor = HitsInteractor(settings: .init(infiniteScrolling: .on(withOffset: 10), showItemsOnEmptyQuery: true),
+                                      paginationController: paginator,
+                                      infiniteScrollingController: infiniteScrollingController)
+      
+      return interactor
+    }
+    
+  }
+  
+  func testHitsInteractorSearcherConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = HitsInteractorSearcherConnectionTester(searcher: module.searcher,
+                                                        interactor: module.hitsInteractor,
+                                                        infiniteScrollingController: module.infiniteScrollingController,
+                                                        source: self)
+    tester.check(isConnected: true)
+  }
+  
+  func testHitsInteractorFilterStateConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = HitsInteractorFilterStateConnectionTester(interactor: module.hitsInteractor,
+                                                           filterState: module.filterState,
+                                                           source: self)
+    tester.requestChangedExpectedFulfillmentCount = 2
+    tester.check(isConnected: true)
+  }
+  
+  func testHitsInteractorControllerConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = HitsInteractorControllerConnectionTester(interactor: module.hitsInteractor,
+                                                          controller: module.hitsController,
+                                                          source: self)
+    tester.check(isConnected: true)
+  }
+  
+  func testQueryInputSearcherConnect() {
+    // to complete when SingleIndexSearcher become abstract enough
+  }
+  
+  func testQueryInputControllerConnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    let tester = QueryInputControllerConnectionTester(interactor: module.queryInputInteractor,
+                                                      controller: module.queryInputController,
+                                                      presetQuery: nil,
+                                                      source: self)
+    tester.check(isConnected: true)
+  }
+  
+  func testDisconnect() {
+    var module = ConnectorContainer()
+    module.connector.connect()
+    module.connector.disconnect()
+    
+    HitsInteractorFilterStateConnectionTester(interactor: module.hitsInteractor,
+                                              filterState: module.filterState,
+                                              source: self).check(isConnected: false)
+    
+    HitsInteractorControllerConnectionTester(interactor: module.hitsInteractor,
+                                             controller: module.hitsController,
+                                             source: self).check(isConnected: false)
+    
+    HitsInteractorSearcherConnectionTester(searcher: module.searcher,
+                                           interactor: module.hitsInteractor,
+                                           infiniteScrollingController: module.infiniteScrollingController,
+                                           source: self).check(isConnected: false)
+    
+    QueryInputControllerConnectionTester(interactor: module.queryInputInteractor,
+                                         controller: module.queryInputController,
+                                         presetQuery: nil,
+                                         source: self).check(isConnected: false)
+  }
+  
+}

--- a/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorSearcherConnectionTests.swift
@@ -15,28 +15,28 @@ class HitsInteractorSearcherConnectionTests: XCTestCase {
   
   weak var disposableInteractor: HitsInteractor<JSON>?
   weak var disposableSearcher: SingleIndexSearcher?
-
+  
   func getInteractor(with infiniteScrollingController: InfiniteScrollable) -> HitsInteractor<JSON> {
-
+    
     let paginator = Paginator<JSON>()
-
+    
     let page1 = ["i1", "i2", "i3"].map { JSON.string($0) }
     paginator.pageMap = PageMap([1: page1])
-
+    
     let interactor = HitsInteractor(settings: .init(infiniteScrolling: .on(withOffset: 10), showItemsOnEmptyQuery: true),
                                     paginationController: paginator,
                                     infiniteScrollingController: infiniteScrollingController)
-
+    
     return interactor
   }
   
   func testLeak() {
     let infiniteScrollingController = TestInfiniteScrollingController()
     infiniteScrollingController.pendingPages = [0, 2]
-
+    
     let searcher = SingleIndexSearcher(client: SearchClient(appID: "", apiKey: ""), indexName: "")
     let interactor = getInteractor(with: infiniteScrollingController)
-
+    
     disposableInteractor = interactor
     disposableSearcher = searcher
     
@@ -50,124 +50,140 @@ class HitsInteractorSearcherConnectionTests: XCTestCase {
     XCTAssertNil(disposableInteractor, "Leaked interactor")
     XCTAssertNil(disposableSearcher, "Leaked searcher")
   }
-
+  
   func testConnect() {
-
+    
     let infiniteScrollingController = TestInfiniteScrollingController()
     infiniteScrollingController.pendingPages = [0, 2]
-
+    
     let searcher = SingleIndexSearcher(client: SearchClient(appID: "", apiKey: ""), indexName: "")
     let interactor = getInteractor(with: infiniteScrollingController)
-
+    
     let connection: Connection = HitsInteractor.SingleIndexSearcherConnection(interactor: interactor,
                                                                               searcher: searcher)
     connection.connect()
-
-    let tester = HitsInteractorSearcherConnectionTester(searcher: searcher,
-                                                        interactor: interactor,
-                                                        infiniteScrollingController: infiniteScrollingController,
-                                                        source: self)
+    
+    let tester = ConnectionTester(searcher: searcher,
+                                  interactor: interactor,
+                                  infiniteScrollingController: infiniteScrollingController,
+                                  source: self)
     tester.check(isConnected: true)
-
+    
   }
-
+  
   func testDisconnect() {
-
+    
     let infiniteScrollingController = TestInfiniteScrollingController()
     infiniteScrollingController.pendingPages = [0, 2]
-
+    
     let searcher = SingleIndexSearcher(client: SearchClient(appID: "", apiKey: ""), indexName: "")
     let interactor = getInteractor(with: infiniteScrollingController)
-
+    
     let connection: Connection = HitsInteractor.SingleIndexSearcherConnection(interactor: interactor,
                                                                               searcher: searcher)
     connection.connect()
     connection.disconnect()
-
-    let tester = HitsInteractorSearcherConnectionTester(searcher: searcher,
-                                                        interactor: interactor,
-                                                        infiniteScrollingController: infiniteScrollingController,
-                                                        source: self)
+    
+    let tester = ConnectionTester(searcher: searcher,
+                                  interactor: interactor,
+                                  infiniteScrollingController: infiniteScrollingController,
+                                  source: self)
     tester.check(isConnected: false)
-
+    
   }
-
+  
   func testConnectMethod() {
-
+    
     let infiniteScrollingController = TestInfiniteScrollingController()
     infiniteScrollingController.pendingPages = [0, 2]
-
+    
     let searcher = SingleIndexSearcher(client: SearchClient(appID: "", apiKey: ""), indexName: "")
     let interactor = getInteractor(with: infiniteScrollingController)
-
+    
     interactor.connectSearcher(searcher)
-
-    let tester = HitsInteractorSearcherConnectionTester(searcher: searcher,
-                                                        interactor: interactor,
-                                                        infiniteScrollingController: infiniteScrollingController,
-                                                        source: self)
+    
+    let tester = ConnectionTester(searcher: searcher,
+                                  interactor: interactor,
+                                  infiniteScrollingController: infiniteScrollingController,
+                                  source: self)
     tester.check(isConnected: true)
-
+    
   }
-
+  
 }
 
-class HitsInteractorSearcherConnectionTester {
+extension HitsInteractorSearcherConnectionTests {
   
-  let searcher: SingleIndexSearcher
-  let interactor: HitsInteractor<JSON>
-  let infiniteScrollingController: TestInfiniteScrollingController
-  let source: XCTestCase
-
-  init(searcher: SingleIndexSearcher,
-       interactor: HitsInteractor<JSON>,
-       infiniteScrollingController: TestInfiniteScrollingController,
-       source: XCTestCase) {
-    self.searcher = searcher
-    self.interactor = interactor
-    self.infiniteScrollingController = infiniteScrollingController
-    self.source = source
-  }
-
-  func check(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
-    if isConnected {
-      XCTAssertTrue(searcher === infiniteScrollingController.pageLoader, file: file, line: line)
-    } else {
-      XCTAssertNil(infiniteScrollingController.pageLoader, file: file, line: line)
+  class ConnectionTester {
+    
+    let searcher: SingleIndexSearcher
+    let interactor: HitsInteractor<JSON>
+    let infiniteScrollingController: TestInfiniteScrollingController
+    let source: XCTestCase
+    
+    init(searcher: SingleIndexSearcher,
+         interactor: HitsInteractor<JSON>,
+         infiniteScrollingController: TestInfiniteScrollingController,
+         source: XCTestCase) {
+      self.searcher = searcher
+      self.interactor = interactor
+      self.infiniteScrollingController = infiniteScrollingController
+      self.source = source
     }
-
-    let queryChangedExpectation = source.expectation(description: "query changed")
-    queryChangedExpectation.isInverted = !isConnected
-
-    interactor.onRequestChanged.subscribe(with: self) { _, _ in
-      queryChangedExpectation.fulfill()
+    
+    func check(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      testPageLoader(isConnected: isConnected, file: file, line: line)
+      testQueryChanged(isConnected: isConnected, file: file, line: line)
+      testResultsUpdated(isConnected: isConnected, file: file, line: line)
+      testPendingPages(isConnected: isConnected, file: file, line: line)
+      source.waitForExpectations(timeout: 2, handler: nil)
     }
-
-    searcher.query = "query"
-    searcher.indexQueryState.query.page = 0
-    infiniteScrollingController.pendingPages = [0]
-
-    let resultsUpdatedExpectation = source.expectation(description: "results updated")
-    resultsUpdatedExpectation.isInverted = !isConnected
-
-    interactor.onResultsUpdated.subscribe(with: self) { tester, _ in
-      resultsUpdatedExpectation.fulfill()
-      XCTAssertTrue(tester.infiniteScrollingController.pendingPages.isEmpty, file: file, line: line)
+    
+    private func testPageLoader(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      if isConnected {
+        XCTAssertTrue(searcher === infiniteScrollingController.pageLoader, file: file, line: line)
+      } else {
+        XCTAssertNil(infiniteScrollingController.pageLoader, file: file, line: line)
+      }
     }
-
-    let searchResponse = SearchResponse(hits: [Hit(object: ["field": "value"])])
-    searcher.onResults.fire(searchResponse)
-
-    infiniteScrollingController.pendingPages = [0]
-    searcher.onError.fire((searcher.indexQueryState.query, NSError()))
-
-    if isConnected {
-      XCTAssertTrue(infiniteScrollingController.pendingPages.isEmpty, file: file, line: line)
-    } else {
-      XCTAssertFalse(infiniteScrollingController.pendingPages.isEmpty, file: file, line: line)
+    
+    private func testQueryChanged(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      let queryChangedExpectation = source.expectation(description: "query changed")
+      queryChangedExpectation.isInverted = !isConnected
+      
+      interactor.onRequestChanged.subscribe(with: self) { _, _ in
+        queryChangedExpectation.fulfill()
+      }
+      
+      searcher.query = "query"
+      searcher.indexQueryState.query.page = 0
+      infiniteScrollingController.pendingPages = [0]
     }
-
-    source.waitForExpectations(timeout: 2, handler: nil)
+    
+    private func testResultsUpdated(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      let resultsUpdatedExpectation = source.expectation(description: "results updated")
+      resultsUpdatedExpectation.isInverted = !isConnected
+      
+      interactor.onResultsUpdated.subscribe(with: self) { tester, _ in
+        resultsUpdatedExpectation.fulfill()
+        XCTAssertTrue(tester.infiniteScrollingController.pendingPages.isEmpty, file: file, line: line)
+      }
+      
+      let searchResponse = SearchResponse(hits: [Hit(object: ["field": "value"])])
+      searcher.onResults.fire(searchResponse)
+    }
+    
+    private func testPendingPages(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      infiniteScrollingController.pendingPages = [0]
+      searcher.onError.fire((searcher.indexQueryState.query, NSError()))
+      
+      if isConnected {
+        XCTAssertTrue(infiniteScrollingController.pendingPages.isEmpty, file: file, line: line)
+      } else {
+        XCTAssertFalse(infiniteScrollingController.pendingPages.isEmpty, file: file, line: line)
+      }
+    }
+    
   }
   
 }

--- a/Tests/InstantSearchCoreTests/Unit/Hits/TestHitsController.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/TestHitsController.swift
@@ -25,3 +25,23 @@ class TestHitsController<Hit: Codable>: HitsController {
   }
 
 }
+
+class TestMultiIndexHitsController: MultiIndexHitsController {
+  
+  var hitsSource: MultiIndexHitsSource?
+  
+  var didReload: (() -> Void)?
+  var didScrollToTop: (() -> Void)?
+
+  
+  func scrollToTop() {
+    didScrollToTop?()
+  }
+  
+  func reload() {
+    didReload?()
+  }
+  
+  
+  
+}

--- a/Tests/InstantSearchCoreTests/Unit/MultiIndexHits/MultiIndexHitsInteractorControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/MultiIndexHits/MultiIndexHitsInteractorControllerConnectionTests.swift
@@ -1,0 +1,138 @@
+//
+//  MultiIndexHitsInteractorControllerConnectionTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 07/08/2020.
+//
+
+import Foundation
+import AlgoliaSearchClient
+@testable import InstantSearchCore
+import XCTest
+
+class MultiIndexHitsInteractorControllerConnectionTests: XCTestCase {
+  
+  weak var disposableInteractor: MultiIndexHitsInteractor?
+  weak var disposableController: TestMultiIndexHitsController?
+  
+  func testLeak() {
+    let controller = TestMultiIndexHitsController()
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    disposableInteractor = interactor
+    disposableController = controller
+    
+    let connection: Connection = MultiIndexHitsInteractor.ControllerConnection(interactor: interactor, controller: controller)
+    connection.connect()
+
+  }
+  
+  override func tearDown() {
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableController, "Leaked controller")
+  }
+  
+  func testConnect() {
+    
+    let controller = TestMultiIndexHitsController()
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    let connection: Connection = MultiIndexHitsInteractor.ControllerConnection(interactor: interactor, controller: controller)
+    connection.connect()
+    
+    ConnectionTester(controller: controller,
+                     interactor: interactor,
+                     source: self).check(isConnected: true)
+    
+  }
+  
+  func testConnectMethod() {
+    
+    let controller = TestMultiIndexHitsController()
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    interactor.connectController(controller)
+    
+    ConnectionTester(controller: controller,
+                     interactor: interactor,
+                     source: self).check(isConnected: true)
+    
+    
+  }
+  
+  func testDisconnect() {
+    let controller = TestMultiIndexHitsController()
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    let connection: Connection = MultiIndexHitsInteractor.ControllerConnection(interactor: interactor, controller: controller)
+    connection.connect()
+    connection.disconnect()
+    
+    ConnectionTester(controller: controller,
+                     interactor: interactor,
+                     source: self).check(isConnected: false)
+    
+  }
+  
+}
+
+extension MultiIndexHitsInteractorControllerConnectionTests {
+  
+  class ConnectionTester {
+    
+    let controller: TestMultiIndexHitsController
+    let interactor: MultiIndexHitsInteractor
+    let source: XCTestCase
+    
+    init(controller: TestMultiIndexHitsController,
+         interactor: MultiIndexHitsInteractor,
+         source: XCTestCase) {
+      self.controller = controller
+      self.interactor = interactor
+      self.source = source
+    }
+    
+    func check(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      checkHitsSource(isConnected: isConnected, file: file, line: line)
+      checkScrollToTop(isConnected: isConnected, file: file, line: line)
+      checkReload(isConnected: isConnected, file: file, line: line)
+      source.waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+    private func checkHitsSource(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      if isConnected {
+        XCTAssert(controller.hitsSource === interactor, file: file, line: line)
+      } else {
+        XCTAssertNil(controller.hitsSource, file: file, line: line)
+      }
+    }
+    
+    private func checkScrollToTop(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      let expectation = source.expectation(description: "scroll to top")
+      expectation.isInverted = !isConnected
+      controller.didScrollToTop = {
+        expectation.fulfill()
+      }
+      interactor.onRequestChanged.fire(())
+    }
+    
+    private func checkReload(isConnected: Bool, file: StaticString = #file, line: UInt = #line) {
+      let expectation = source.expectation(description: "reload")
+      expectation.isInverted = !isConnected
+      controller.didReload = {
+        expectation.fulfill()
+      }
+      interactor.onResultsUpdated.fire([])
+    }
+    
+  }
+  
+}

--- a/Tests/InstantSearchCoreTests/Unit/MultiIndexHits/MultiIndexHitsInteractorSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/MultiIndexHits/MultiIndexHitsInteractorSearcherConnectionTests.swift
@@ -1,0 +1,144 @@
+//
+//  MultiIndexHitsInteractorSearcherConnectionTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 07/08/2020.
+//
+
+import Foundation
+import AlgoliaSearchClient
+@testable import InstantSearchCore
+import XCTest
+
+class MultiIndexHitsInteractorSearcherConnectionTests: XCTestCase {
+  
+  weak var disposableInteractor: MultiIndexHitsInteractor?
+  weak var disposableSearcher: MultiIndexSearcher?
+  
+  func testLeak() {
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    disposableInteractor = interactor
+    disposableSearcher = searcher
+    
+    let connection: Connection = MultiIndexHitsInteractor.SearcherConnection(interactor: interactor, searcher: searcher)
+    connection.connect()
+  }
+  
+  override func tearDown() {
+    
+    XCTAssertNil(disposableInteractor, "Leaked interactor")
+    XCTAssertNil(disposableSearcher, "Leaked searcher")
+  }
+  
+  func testConnect() {
+    
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    let connection: Connection = MultiIndexHitsInteractor.SearcherConnection(interactor: interactor, searcher: searcher)
+    connection.connect()
+    
+    ConnectionTester(searcher: searcher,
+                     interactor: interactor,
+                     source: self).check(isConnected: true)
+    
+  }
+  
+  func testConnectMethod() {
+    
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    interactor.connectSearcher(searcher)
+    
+    ConnectionTester(searcher: searcher,
+                     interactor: interactor,
+                     source: self).check(isConnected: true)
+    
+    
+  }
+  
+  func testDisconnect() {
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let subInteractorA = HitsInteractor<JSON>()
+    let subInteractorB = HitsInteractor<JSON>()
+    let interactor = MultiIndexHitsInteractor(hitsInteractors: [subInteractorA, subInteractorB])
+    
+    let connection: Connection = MultiIndexHitsInteractor.SearcherConnection(interactor: interactor, searcher: searcher)
+    connection.connect()
+    connection.disconnect()
+    
+    ConnectionTester(searcher: searcher,
+                     interactor: interactor,
+                     source: self).check(isConnected: false)
+    
+  }
+  
+}
+
+extension MultiIndexHitsInteractorSearcherConnectionTests {
+  
+  class ConnectionTester {
+    
+    let searcher: MultiIndexSearcher
+    let interactor: MultiIndexHitsInteractor
+    let source: XCTestCase
+    
+    init(searcher: MultiIndexSearcher,
+         interactor: MultiIndexHitsInteractor,
+         source: XCTestCase) {
+      self.searcher = searcher
+      self.interactor = interactor
+      self.source = source
+    }
+    
+    func check(isConnected: Bool,
+               file: StaticString = #file,
+               line: UInt = #line) {
+      checkQueryChanged(isConnected: isConnected, file: file, line: line)
+      checkResultsUpdated(isConnected: isConnected, file: file, line: line)
+      source.waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+    private func checkQueryChanged(isConnected: Bool,
+                                   file: StaticString = #file,
+                                   line: UInt = #line) {
+      let queryChangedExpectation = source.expectation(description: "query changed")
+      queryChangedExpectation.isInverted = !isConnected
+      
+      interactor.onRequestChanged.subscribe(with: self) { _, _ in
+        queryChangedExpectation.fulfill()
+      }
+      
+      searcher.query = "query"
+    }
+    
+    private func checkResultsUpdated(isConnected: Bool,
+                                     file: StaticString = #file,
+                                     line: UInt = #line) {
+      let resultsUpdatedExpectation = source.expectation(description: "results updated")
+      resultsUpdatedExpectation.isInverted = !isConnected
+      
+      interactor.onResultsUpdated.subscribe(with: self) { tester, _ in
+        resultsUpdatedExpectation.fulfill()
+      }
+      
+      let searchResponse = SearchesResponse(results: [
+        SearchResponse(hits: [Hit(object: ["field0": "value0"])]),
+        SearchResponse(hits: [Hit(object: ["field1": "value1"])]),
+      ])
+      
+      searcher.onResults.fire(searchResponse)
+    }
+    
+  }
+  
+}

--- a/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputSearcherConnectionTests.swift
@@ -133,8 +133,8 @@ class QueryInputSearcherConnectionTester {
       queryChangedExpectation.fulfill()
     }
     
-    searcher.onSearch.subscribe(with: self) { _, _ in
-      XCTAssertEqual(searcher.query, query)
+    searcher.onSearch.subscribe(with: self) { test, _ in
+      XCTAssertEqual(test.searcher.query, query)
       launchSearchExpectation.fulfill()
     }
 


### PR DESCRIPTION
This PR adds to **InstantSearch**:
- `SingleIndexSearchConnector` & `MultiIndexSearchConnector` which establish the necessary connections for basic single and multi-index search experiences respectively. They encapsulate `QueryInput`, `Searcher`, `Hits` components and provide convenient initialisers including `Controllers`.
- `HitsTableViewController` and `HitsCollectionViewController` implementations to use with with connectors mentioned above for quick demos and prototyping.
- Memory leak fix in `MultiIndexSearcher` due to `PageLoader` initialization

Components intoduced in this PR will be used in the updated Getting Started Guide.