### PR TITLE
Index searchers improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             targets: ["InstantSearchCore"])
     ],
     dependencies: [
-      .package(name: "AlgoliaSearchClient", url:"https://github.com/algolia/algoliasearch-client-swift", from: "8.0.0"),
+      .package(name: "AlgoliaSearchClient", url:"https://github.com/algolia/algoliasearch-client-swift", .branch("feat/partial-update-improvement")),
       .package(name: "InstantSearchInsights", url:"https://github.com/algolia/instantsearch-ios-insights", from: "2.3.2")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             targets: ["InstantSearchCore"])
     ],
     dependencies: [
-      .package(name: "AlgoliaSearchClient", url:"https://github.com/algolia/algoliasearch-client-swift", .branch("feat/partial-update-improvement")),
+      .package(name: "AlgoliaSearchClient", url:"https://github.com/algolia/algoliasearch-client-swift", from: "8.0.0"),
       .package(name: "InstantSearchInsights", url:"https://github.com/algolia/instantsearch-ios-insights", from: "2.3.2")
     ],
     targets: [

--- a/Sources/InstantSearchCore/Searcher/Facet/FacetSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Facet/FacetSearcher.swift
@@ -27,9 +27,11 @@ public class FacetSearcher: Searcher, SequencerDelegate, SearchResultObservable 
   /// Current tuple of index and query
   public var indexQueryState: IndexQueryState
 
-  public var onQueryChanged: Observer<String?>
-
   public let isLoading: Observer<Bool>
+  
+  public var onQueryChanged: Observer<String?>
+  
+  public let onSearch: Observer<Void>
 
   public let onResults: Observer<SearchResult>
 
@@ -90,6 +92,7 @@ public class FacetSearcher: Searcher, SequencerDelegate, SearchResultObservable 
     self.onQueryChanged = .init()
     self.onResults = .init()
     self.onError = .init()
+    self.onSearch = .init()
     self.facetName = facetName
     self.sequencer = .init()
     self.processingQueue = .init()
@@ -103,6 +106,8 @@ public class FacetSearcher: Searcher, SequencerDelegate, SearchResultObservable 
 
   public func search() {
 
+    onSearch.fire(())
+    
     let query = self.query ?? ""
     let indexName = indexQueryState.indexName
 

--- a/Sources/InstantSearchCore/Searcher/MultiIndex/MultiIndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/MultiIndex/MultiIndexSearcher.swift
@@ -46,21 +46,20 @@ public class MultiIndexSearcher: Searcher, SequencerDelegate, SearchResultObserv
 
   public let isLoading: Observer<Bool>
 
-  /// Triggered when a query text of Searcher changed
-  /// - Parameter: equals to a new query text
   public let onQueryChanged: Observer<String?>
   
-  /// Triggered when an index of a query changed
-  /// - Parameter: a tuple of a index of query for which the indexName has changed and the new indexName
-  public let onIndexChanged: Observer<(Int, IndexName)>
+  public let onSearch: Observer<Void>
 
-  /// Triggered when a new result received by Searcher
   public let onResults: Observer<SearchesResponse>
 
   /// Triggered when an error occured during search query execution
   /// - Parameter: a tuple of query and error
   public let onError: Observer<([Query], Error)>
-
+  
+  /// Triggered when an index of a query changed
+  /// - Parameter: a tuple of a index of query for which the indexName has changed and the new indexName
+  public let onIndexChanged: Observer<(Int, IndexName)>
+  
   /// Custom request options
   public var requestOptions: RequestOptions?
 
@@ -142,6 +141,7 @@ public class MultiIndexSearcher: Searcher, SequencerDelegate, SearchResultObserv
     isLoading = .init()
     onResults = .init()
     onError = .init()
+    onSearch = .init()
 
     sequencer.delegate = self
     onResults.retainLastData = true
@@ -161,6 +161,8 @@ public class MultiIndexSearcher: Searcher, SequencerDelegate, SearchResultObserv
     if let shouldTriggerSearch = shouldTriggerSearchForQueries, !shouldTriggerSearch(indexQueryStates.map(\.query)) {
       return
     }
+    
+    onSearch.fire(())
 
     let queries = indexQueryStates.map { IndexedQuery(indexName: $0.indexName, query: $0.query) }
 

--- a/Sources/InstantSearchCore/Searcher/Places/PlacesSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Places/PlacesSearcher.swift
@@ -27,13 +27,15 @@ public class PlacesSearcher: Searcher, SequencerDelegate, SearchResultObservable
   }
 
   public var placesQuery: PlacesQuery
-
-  public var onQueryChanged: Observer<String?>
-
+  
   public let isLoading: Observer<Bool>
 
-  public let onResults: Observer<PlacesClient.SingleLanguageResponse>
+  public var onQueryChanged: Observer<String?>
+  
+  public let onSearch: Observer<Void>
 
+  public let onResults: Observer<PlacesClient.SingleLanguageResponse>
+  
   /// Triggered when an error occured during search query execution
   /// - Parameter: a tuple of query text and error
   public let onError: Observer<(String, Error)>
@@ -57,6 +59,7 @@ public class PlacesSearcher: Searcher, SequencerDelegate, SearchResultObservable
     self.onQueryChanged = .init()
     self.onResults = .init()
     self.onError = .init()
+    self.onSearch = .init()
     self.sequencer = .init()
     updateClientUserAgents()
     sequencer.delegate = self
@@ -65,6 +68,8 @@ public class PlacesSearcher: Searcher, SequencerDelegate, SearchResultObservable
   }
 
   public func search() {
+    
+    onSearch.fire(())
 
     let operation = placesClient.search(query: placesQuery, language: .english) { [weak self] result in
       guard let searcher = self else { return }

--- a/Sources/InstantSearchCore/Searcher/Searcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Searcher.swift
@@ -21,6 +21,9 @@ public protocol Searcher: class {
   /// Triggered when query text changed
   /// - Parameter: a new query text value
   var onQueryChanged: Observer<String?> { get }
+  
+  /// Triggered when a search operation launched
+  var onSearch: Observer<Void> { get }
 
   /// Launches search query execution with current query text value
   func search()

--- a/Sources/InstantSearchCore/Searcher/SingleIndex/SingleIndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/SingleIndex/SingleIndexSearcher.swift
@@ -9,8 +9,8 @@
 
 import Foundation
 import AlgoliaSearchClient
-/** An entity performing search queries targeting one index
-*/
+
+/// An entity performing search queries targeting one index
 
 public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObservable {
 
@@ -68,6 +68,15 @@ public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObser
   /// Flag defining if disjunctive faceting is enabled
   /// - Default value: true
   public var isDisjunctiveFacetingEnabled = true
+  
+  /// Closure defining the condition under which the search operation should be triggered
+  ///
+  /// Example: if you don't want search operation triggering in case of empty query, you should set this value
+  /// ````
+  /// searcher.shouldTriggerSearchForQuery = { query in query.query ?? "" != "" }
+  /// ````
+  /// - Default value: nil
+  public var shouldTriggerSearchForQuery: ((Query) -> Bool)?
 
   /// Sequencer which orders and debounce redundant search operations
   internal let sequencer: Sequencer
@@ -135,6 +144,10 @@ public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObser
   }
 
   public func search() {
+    
+    if let shouldTriggerSearch = shouldTriggerSearchForQuery, !shouldTriggerSearch(indexQueryState.query) {
+      return
+    }
 
     let query = indexQueryState.query
 

--- a/Sources/InstantSearchCore/Searcher/SingleIndex/SingleIndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/SingleIndex/SingleIndexSearcher.swift
@@ -44,12 +44,15 @@ public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObser
 
   public let isLoading: Observer<Bool>
 
+  /// Triggered when a new result received by Searcher
   public let onResults: Observer<SearchResponse>
 
   /// Triggered when an error occured during search query execution
   /// - Parameter: a tuple of query and error
   public let onError: Observer<(Query, Error)>
 
+  /// Triggered when a query text of Searcher changed
+  /// - Parameter: equals to a new query text
   public let onQueryChanged: Observer<String?>
 
   /// Triggered when an index of Searcher changed

--- a/Sources/InstantSearchCore/Searcher/SingleIndex/SingleIndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/SingleIndex/SingleIndexSearcher.swift
@@ -43,22 +43,21 @@ public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObser
   }
 
   public let isLoading: Observer<Bool>
+  
+  public let onQueryChanged: Observer<String?>
+  
+  public let onSearch: Observer<Void>
 
-  /// Triggered when a new result received by Searcher
   public let onResults: Observer<SearchResponse>
 
   /// Triggered when an error occured during search query execution
   /// - Parameter: a tuple of query and error
   public let onError: Observer<(Query, Error)>
 
-  /// Triggered when a query text of Searcher changed
-  /// - Parameter: equals to a new query text
-  public let onQueryChanged: Observer<String?>
-
   /// Triggered when an index of Searcher changed
   /// - Parameter: equals to a new index value
   public let onIndexChanged: Observer<IndexName>
-
+  
   /// Custom request options
   public var requestOptions: RequestOptions?
 
@@ -123,6 +122,7 @@ public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObser
     onQueryChanged = .init()
     onIndexChanged = .init()
     processingQueue = .init()
+    onSearch = .init()
     sequencer.delegate = self
     onResults.retainLastData = true
     onError.retainLastData = false
@@ -151,6 +151,8 @@ public class SingleIndexSearcher: Searcher, SequencerDelegate, SearchResultObser
     if let shouldTriggerSearch = shouldTriggerSearchForQuery, !shouldTriggerSearch(indexQueryState.query) {
       return
     }
+    
+    onSearch.fire(())
 
     let query = indexQueryState.query
 

--- a/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputSearcherConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/QueryInput/QueryInputSearcherConnectionTests.swift
@@ -116,8 +116,8 @@ class QueryInputSearcherConnectionTests: XCTestCase {
     interactor.onQueryChanged.subscribe(with: self) { (_, _) in
       queryChangedExpectation.fulfill()
     }
-
-    searcher.didLaunchSearch = {
+    
+    searcher.onSearch.subscribe(with: self) { _, _ in
       XCTAssertEqual(searcher.query, query)
       launchSearchExpectation.fulfill()
     }

--- a/Tests/InstantSearchCoreTests/Unit/QueryInput/TestSearcher.swift
+++ b/Tests/InstantSearchCoreTests/Unit/QueryInput/TestSearcher.swift
@@ -18,14 +18,14 @@ class TestSearcher: Searcher {
     }
   }
 
-  var didLaunchSearch: (() -> Void)?
-
   var isLoading: Observer<Bool> = .init()
 
   var onQueryChanged: Observer<String?> = .init()
+  
+  var onSearch: Observer<Void> = .init()
 
   func search() {
-    didLaunchSearch?()
+    onSearch.fire(())
   }
 
   func cancel() {

--- a/Tests/InstantSearchCoreTests/Unit/Searcher/MultiIndexSearcherTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Searcher/MultiIndexSearcherTests.swift
@@ -1,0 +1,37 @@
+//
+//  MultiIndexSearcherTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 03/08/2020.
+//
+
+import Foundation
+import XCTest
+@testable import InstantSearchCore
+
+class MultiIndexSearcherTests: XCTestCase {
+  
+  func testOnQueryChanged() {
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["index1", "index2"])
+    let exp = expectation(description: "Query change expectation")
+    searcher.onQueryChanged.subscribe(with: self) { (test, newQuery) in
+      exp.fulfill()
+    }
+    searcher.query = ""
+    waitForExpectations(timeout: 10, handler: .none)
+  }
+  
+  func testOnIndexChanged() {
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["index1", "index2"])
+    let exp = expectation(description: "")
+    searcher.onIndexChanged.subscribe(with: self) { (test, args) in
+      let (index, indexName) = args
+      XCTAssertEqual(index, 1)
+      XCTAssertEqual(indexName, "index3")
+      exp.fulfill()
+    }
+    searcher.indexQueryStates[1].indexName = "index3"
+    waitForExpectations(timeout: 10, handler: .none)
+  }
+
+}

--- a/Tests/InstantSearchCoreTests/Unit/Searcher/MultiIndexSearcherTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Searcher/MultiIndexSearcherTests.swift
@@ -18,7 +18,7 @@ class MultiIndexSearcherTests: XCTestCase {
       exp.fulfill()
     }
     searcher.query = ""
-    waitForExpectations(timeout: 10, handler: .none)
+    waitForExpectations(timeout: 2, handler: .none)
   }
   
   func testOnIndexChanged() {
@@ -31,7 +31,31 @@ class MultiIndexSearcherTests: XCTestCase {
       exp.fulfill()
     }
     searcher.indexQueryStates[1].indexName = "index3"
-    waitForExpectations(timeout: 10, handler: .none)
+    waitForExpectations(timeout: 2, handler: .none)
   }
+  
+  func testOnSearch() {
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let exp = expectation(description: "Search expectation")
+    searcher.onSearch.subscribe(with: self) { (test, _) in
+      exp.fulfill()
+    }
+    searcher.search()
+    waitForExpectations(timeout: 2, handler: .none)
+  }
+  
+  func testConditionalSearch() {
+    let searcher = MultiIndexSearcher(appID: "", apiKey: "", indexNames: ["i1", "i2"])
+    let exp = expectation(description: "Search expectation")
+    exp.isInverted = true
+    searcher.onSearch.subscribe(with: self) { (test, _) in
+      exp.fulfill()
+    }
+    searcher.shouldTriggerSearchForQueries = { queries in return queries[0].query ?? "" != "" }
+    searcher.query = nil
+    searcher.search()
+    waitForExpectations(timeout: 2, handler: .none)
+  }
+
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/Searcher/SingleIndexSearcherTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Searcher/SingleIndexSearcherTests.swift
@@ -1,0 +1,36 @@
+//
+//  SingleIndexSearcherTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 03/08/2020.
+//
+
+import Foundation
+import XCTest
+@testable import InstantSearchCore
+
+class SingleIndexSearcherTests: XCTestCase {
+  
+  func testOnQueryChanged() {
+    let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "index1")
+    let exp = expectation(description: "Query change expectation")
+    searcher.onQueryChanged.subscribe(with: self) { (test, newQuery) in
+      XCTAssertEqual(newQuery, "new query")
+      exp.fulfill()
+    }
+    searcher.query = "new query"
+    waitForExpectations(timeout: 10, handler: .none)
+  }
+  
+  func testOnIndexChanged() {
+    let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "index1")
+    let exp = expectation(description: "")
+    searcher.onIndexChanged.subscribe(with: self) { (test, indexName) in
+      XCTAssertEqual(indexName, "index3")
+      exp.fulfill()
+    }
+    searcher.indexQueryState.indexName = "index3"
+    waitForExpectations(timeout: 10, handler: .none)
+  }
+
+}

--- a/Tests/InstantSearchCoreTests/Unit/Searcher/SingleIndexSearcherTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Searcher/SingleIndexSearcherTests.swift
@@ -19,18 +19,41 @@ class SingleIndexSearcherTests: XCTestCase {
       exp.fulfill()
     }
     searcher.query = "new query"
-    waitForExpectations(timeout: 10, handler: .none)
+    waitForExpectations(timeout: 2, handler: .none)
   }
   
   func testOnIndexChanged() {
     let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "index1")
-    let exp = expectation(description: "")
+    let exp = expectation(description: "Index change expectation")
     searcher.onIndexChanged.subscribe(with: self) { (test, indexName) in
       XCTAssertEqual(indexName, "index3")
       exp.fulfill()
     }
     searcher.indexQueryState.indexName = "index3"
-    waitForExpectations(timeout: 10, handler: .none)
+    waitForExpectations(timeout: 2, handler: .none)
+  }
+  
+  func testOnSearch() {
+    let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "index1")
+    let exp = expectation(description: "Search expectation")
+    searcher.onSearch.subscribe(with: self) { (test, _) in
+      exp.fulfill()
+    }
+    searcher.search()
+    waitForExpectations(timeout: 2, handler: .none)
+  }
+  
+  func testConditionalSearch() {
+    let searcher = SingleIndexSearcher(appID: "", apiKey: "", indexName: "index1")
+    let exp = expectation(description: "Search expectation")
+    exp.isInverted = true
+    searcher.onSearch.subscribe(with: self) { (test, _) in
+      exp.fulfill()
+    }
+    searcher.shouldTriggerSearchForQuery = { query in return query.query ?? "" != "" }
+    searcher.query = nil
+    searcher.search()
+    waitForExpectations(timeout: 2, handler: .none)
   }
 
 }


### PR DESCRIPTION
This PR add a few demanded functionalities to index searchers:
- Optional `shouldTriggerSearch` closure defining if an actual request must be performed when `search()` function called
- `onIndexChanged` event for `MultiIndexSearcher`
- Code documentation improvements