### PR TITLE
Fix tvOS conditional compiling issue

### DIFF
--- a/Sources/InstantSearch/AdvancedConnectors/MultiIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/MultiIndexSearchConnector+UIKit.swift
@@ -8,7 +8,7 @@
 #if !InstantSearchCocoaPods
 import InstantSearchCore
 #endif
-#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
+#if canImport(UIKit) && (os(iOS) || os(macOS))
 import UIKit
 
 public extension MultiIndexSearchConnector {

--- a/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
@@ -8,7 +8,7 @@
 #if !InstantSearchCocoaPods
 import InstantSearchCore
 #endif
-#if canImport(UIKit) && (os(iOS) || os(tvOS) || os(macOS))
+#if canImport(UIKit) && (os(iOS) || os(macOS))
 import UIKit
 
 public extension SingleIndexSearchConnector {

--- a/Sources/InstantSearch/SearchBox/TextFieldController.swift
+++ b/Sources/InstantSearch/SearchBox/TextFieldController.swift
@@ -25,7 +25,7 @@ public class TextFieldController: NSObject, QueryInputController {
     setupTextField()
   }
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
   @available(iOS 13.0, *)
   public convenience init(searchBar: UISearchBar) {
     self.init(textField: searchBar.searchTextField)


### PR DESCRIPTION
This PR fixes condition compiling issue for tvOS due to missing `UISearchBar.searchTextField` property for this platform.