### PR TITLE
fix: Xcode 12 crash due to unsynchronised sequencer

### DIFF
--- a/Sources/InstantSearchCore/Sequencer/Sequencer.swift
+++ b/Sources/InstantSearchCore/Sequencer/Sequencer.swift
@@ -48,9 +48,6 @@ class Sequencer: Sequencable {
   /// Sequence number for the next operation.
   private var nextSeqNo: Int = 0
 
-  /// Queue used to serialize accesses to `nextSeqNo`.
-  private let incrementSequenceQueue = DispatchQueue(label: "Sequencer.lock")
-
   /// Queue used to serialize accesses to the Sequencer
   private let syncQueue = DispatchQueue(label: "AlgoliaSequencerSync.queue")
 
@@ -92,44 +89,31 @@ class Sequencer: Sequencable {
 
   /// Launch next operation.
   func orderOperation(operationLauncher: @escaping Sequencable.OperationLauncher) {
-    
-        // Increase sequence number.
-//        let currentSeqNo: Int = incrementSequenceQueue.sync {
-//          nextSeqNo += 1
-//          return nextSeqNo
-//        }
-
-        // Cancel obsolete operations.
-//        pendingOperations
-//            .filter { $0.0 <= currentSeqNo - maxPendingOperationsCount }
-//            .keys
-//            .forEach(cancelOperation)
-
-//        let sequencingOperation = SequencerCompletionOperation(sequenceNo: currentSeqNo, sequencer: self, correspondingOperation: operation)
-//        sequencingOperation.addDependency(operation)
-    
-        syncQueue.async { [weak self] in
-          guard let sequencer = self else { return }
-          // Increase sequence number
-          sequencer.nextSeqNo += 1
-          let currentSeqNo = sequencer.nextSeqNo
-          
-          // Launch sequenced operation
-          let operation = operationLauncher()
-          sequencer.pendingOperations[currentSeqNo] = operation
-          
-          // Create an launch completion operation
-          let sequencingOperation = SequencerCompletionOperation(sequenceNo: currentSeqNo, sequencer: sequencer, correspondingOperation: operation)
-          sequencingOperation.addDependency(operation)
-          sequencer.sequencerQueue.addOperation(sequencingOperation)
-          
-          // Cancel obsolete operations
-          for (operationNo, operation) in sequencer.pendingOperations.filter({ $0.0 <= currentSeqNo - sequencer.maxPendingOperationsCount }) {
-            operation.cancel()
-            sequencer.pendingOperations.removeValue(forKey: operationNo)
-          }
-        }
-    
+    syncQueue.async { [weak self] in
+      guard let sequencer = self else { return }
+      
+      // Increase sequence number
+      sequencer.nextSeqNo += 1
+      let currentSeqNo = sequencer.nextSeqNo
+      
+      // Launch sequenced operation
+      let operation = operationLauncher()
+      sequencer.pendingOperations[currentSeqNo] = operation
+      
+      // Create and launch completion operation
+      let sequencingOperation = SequencerCompletionOperation(sequenceNo: currentSeqNo, sequencer: sequencer, correspondingOperation: operation)
+      sequencingOperation.addDependency(operation)
+      sequencer.sequencerQueue.addOperation(sequencingOperation)
+      
+      // Cancel obsolete operations
+      let obsoleteOperations = sequencer.pendingOperations.filter { $0.0 <= currentSeqNo - sequencer.maxPendingOperationsCount }
+      for (operationNo, operation) in  obsoleteOperations {
+        print("Cancel \(String(describing: operation.name)) as it seqNo \(operationNo) precedes min allowed \(currentSeqNo - sequencer.maxPendingOperationsCount)")
+        operation.cancel()
+        sequencer.pendingOperations.removeValue(forKey: operationNo)
+      }
+      print("Sequenced \(String(describing: operation.name)) as \(currentSeqNo)")
+    }
   }
 
   // MARK: - Manage operations
@@ -137,84 +121,34 @@ class Sequencer: Sequencable {
   /// Cancel all pending operations.
   func cancelPendingOperations() {
     syncQueue.async { [weak self] in
-        guard let sequencer = self else { return }
-        for seqNo in sequencer.pendingOperations.keys {
-          if let operation = sequencer.pendingOperations[seqNo] {
-            operation.cancel()
-            sequencer.pendingOperations.removeValue(forKey: seqNo)
-          }
-//          sequencer.cancelOperation(withSeqNo: seqNo)
-        }
+      guard let sequencer = self else { return }
+      for (operationNo, operation) in sequencer.pendingOperations {
+        operation.cancel()
+        sequencer.pendingOperations.removeValue(forKey: operationNo)
+      }
     }
   }
-
-  /// Cancel a specific operation.
-  ///
-  /// - parameter seqNo: The operation's sequence number.
-  ///
-//  private func cancelOperation(withSeqNo seqNo: Int) {
-//    syncQueue.async { [weak self] in
-//        guard let sequencer = self else { return }
-//        if let operation = sequencer.pendingOperations[seqNo] {
-//          operation.cancel()
-//          sequencer.pendingOperations.removeValue(forKey: seqNo)
-//        }
-//    }
-//  }
-
+  
   /// Clean-up after a succesful completion of a sequenced operation
   ///
   /// - parameter seqNo: The operation's sequence number.
   ///
-//  private func dismissOperation(withSeqNo seqNo: Int) {
-//    syncQueue.async { [weak self] in
-//        guard let sequencer = self else { return }
-//        guard let operationToDismiss = sequencer.pendingOperations[seqNo], !operationToDismiss.isCancelled else {
-//            return
-//        }
-//
-//        // Remove the current operation.
-//        sequencer.pendingOperations.removeValue(forKey: seqNo)
-//
-//        // Obsolete operations should not happen since they have been cancelled by more recent operations (see above).
-//        // WARNING: Only works if the current queue is serial!
-//        assert(sequencer.lastReceivedSeqNo == nil || sequencer.lastReceivedSeqNo! < seqNo)
-//
-//        // Update last received response.
-//        sequencer.lastReceivedSeqNo = seqNo
-//    }
-//  }
-  
-  // Cancel all previous operations (as this one is deemed more recent).
-//  private func cancelPreviousPendingOperations(beforeSeqNo seqNo: Int) {
-//    syncQueue.async { [weak self] in
-//      guard let sequencer = self else { return }
-//      let previousOperations = sequencer.pendingOperations.filter { $0.0 < seqNo }.values
-//      for operation in previousOperations {
-//        operation.cancel()
-//        sequencer.pendingOperations.removeValue(forKey: seqNo)
-//      }
-//    }
-//
-//  }
-  
-  
-  private func dismissAndCancelPreviousOperations(forSeqNo seqNo: Int) {
+  private func dismissOperation(forSeqNo seqNo: Int) {
     syncQueue.async { [weak self] in
       guard let sequencer = self else { return }
       
-      let previousOperations = sequencer.pendingOperations.filter { $0.0 < seqNo }.values
-      for operation in previousOperations {
+      print("Dismiss \(seqNo)")
+      
+      // Cancel all preceding operations (as this one is deemed more recent).
+      let precedingOperations = sequencer.pendingOperations.filter { $0.0 < seqNo }
+      for (operationNo, operation) in precedingOperations {
+        print("Cancel \(String(describing: operation.name)) as preceding to \(seqNo)")
         operation.cancel()
-        sequencer.pendingOperations.removeValue(forKey: seqNo)
+        sequencer.pendingOperations.removeValue(forKey: operationNo)
       }
       
       // Remove the current operation.
       sequencer.pendingOperations.removeValue(forKey: seqNo)
-
-      // Obsolete operations should not happen since they have been cancelled by more recent operations (see above).
-      // WARNING: Only works if the current queue is serial!
-      assert(sequencer.lastReceivedSeqNo == nil || sequencer.lastReceivedSeqNo! < seqNo)
 
       // Update last received response.
       sequencer.lastReceivedSeqNo = seqNo
@@ -242,9 +176,7 @@ private extension Sequencer {
             guard
                 let sequencer = sequencer,
                 !correspondingOperation.isCancelled else { return }
-            sequencer.dismissAndCancelPreviousOperations(forSeqNo: sequenceNo)
-//            sequencer.cancelPreviousPendingOperations(beforeSeqNo: sequenceNo)
-//            sequencer.dismissOperation(withSeqNo: sequenceNo)
+            sequencer.dismissOperation(forSeqNo: sequenceNo)
         }
 
     }

--- a/Sources/InstantSearchCore/Sequencer/Sequencer.swift
+++ b/Sources/InstantSearchCore/Sequencer/Sequencer.swift
@@ -59,9 +59,16 @@ class Sequencer: Sequencable {
     didSet {
       syncQueue.async { [weak self] in
         guard let sequencer = self else { return }
-        let hasPendingOperations = !sequencer.pendingOperations.filter { !($0.value.isCancelled || $0.value.isFinished) }.isEmpty
+        let hasPendingOperations = !sequencer.pendingOperations.values.filter { !($0.isCancelled || $0.isFinished) }.isEmpty
         sequencer.delegate?.didChangeOperationsState(hasPendingOperations: hasPendingOperations)
       }
+    }
+  }
+  
+  /// Indicates whether there are any pending operations.
+  var hasPendingOperations: Bool {
+    syncQueue.sync {
+      !pendingOperations.values.filter { !$0.isCancelled || !$0.isFinished }.isEmpty
     }
   }
 

--- a/Sources/InstantSearchCore/Sequencer/Sequencer.swift
+++ b/Sources/InstantSearchCore/Sequencer/Sequencer.swift
@@ -108,11 +108,11 @@ class Sequencer: Sequencable {
       // Cancel obsolete operations
       let obsoleteOperations = sequencer.pendingOperations.filter { $0.0 <= currentSeqNo - sequencer.maxPendingOperationsCount }
       for (operationNo, operation) in  obsoleteOperations {
-        print("Cancel \(String(describing: operation.name)) as it seqNo \(operationNo) precedes min allowed \(currentSeqNo - sequencer.maxPendingOperationsCount)")
+        Logger.trace("Sequencer: cancel \(String(describing: operation.name)) as it seqNo \(operationNo) precedes min allowed \(currentSeqNo - sequencer.maxPendingOperationsCount)")
         operation.cancel()
         sequencer.pendingOperations.removeValue(forKey: operationNo)
       }
-      print("Sequenced \(String(describing: operation.name)) as \(currentSeqNo)")
+      Logger.trace("Sequencer: sequenced \(String(describing: operation.name)) as \(currentSeqNo)")
     }
   }
 
@@ -137,12 +137,12 @@ class Sequencer: Sequencable {
     syncQueue.async { [weak self] in
       guard let sequencer = self else { return }
       
-      print("Dismiss \(seqNo)")
+      Logger.trace("Sequencer: Dismiss \(seqNo)")
       
       // Cancel all preceding operations (as this one is deemed more recent).
       let precedingOperations = sequencer.pendingOperations.filter { $0.0 < seqNo }
       for (operationNo, operation) in precedingOperations {
-        print("Cancel \(String(describing: operation.name)) as preceding to \(seqNo)")
+        Logger.trace("Sequencer: Cancel \(String(describing: operation.name)) as preceding to \(seqNo)")
         operation.cancel()
         sequencer.pendingOperations.removeValue(forKey: operationNo)
       }

--- a/Tests/InstantSearchCoreTests/Unit/SequencerTest.swift
+++ b/Tests/InstantSearchCoreTests/Unit/SequencerTest.swift
@@ -116,14 +116,6 @@ class DelayedOperation: AsyncOperation {
 
 class SequencerTest: XCTestCase {
 
-  override func setUp() {
-    super.setUp()
-  }
-
-  override func tearDown() {
-    super.tearDown()
-  }
-
   func testObsoleteOperationsCancellation() {
 
     let sequencer = Sequencer()
@@ -190,27 +182,6 @@ class SequencerTest: XCTestCase {
 
     XCTAssertEqual(slowOperations.filter { $0.isCancelled }.count, slowOperationsCount)
     XCTAssertFalse(fastOperation.isCancelled)
-
-  }
-
-  func testPendingOperations() {
-
-    let sequencer = Sequencer()
-
-    sequencer.maxPendingOperationsCount = 3
-
-    let exp = expectation(description: "op expectation")
-
-    let op1 = DelayedOperation(delay: 1, completionHandler: exp.fulfill)
-
-    let testQueue = OperationQueue()
-    testQueue.addOperation(op1)
-
-    sequencer.orderOperation { op1 }
-    XCTAssertTrue(sequencer.hasPendingOperations)
-
-    waitForExpectations(timeout: 5, handler: .none)
-    XCTAssertFalse(sequencer.hasPendingOperations)
 
   }
 

--- a/Tests/InstantSearchCoreTests/Unit/SequencerTest.swift
+++ b/Tests/InstantSearchCoreTests/Unit/SequencerTest.swift
@@ -196,4 +196,29 @@ class SequencerTest: XCTestCase {
 
   }
   
+  func testPendingOperations() {
+
+    Logger.minSeverityLevel = .trace
+    let sequencer = Sequencer()
+
+    sequencer.maxPendingOperationsCount = 3
+
+    let exp = expectation(description: "op expectation")
+
+    let op1 = DelayedOperation(delay: 1000, completionHandler: exp.fulfill)
+    op1.name = "Operation!!!"
+
+    let testQueue = OperationQueue()
+    testQueue.addOperation(op1)
+
+    sequencer.orderOperation { op1 }
+    XCTAssertTrue(sequencer.hasPendingOperations)
+
+    waitForExpectations(timeout: 5, handler: .none)
+    XCTAssertFalse(sequencer.hasPendingOperations)
+
+  }
+
+  
+  
 }


### PR DESCRIPTION
**Summary**

This PR refactor Sequencer implementation to make it thread-safe and to avoid crashes occurring in Xcode 12

Resolves #128 