### PR TITLE
fix: Set public setter for indexQueryStates property in MultiIndexSea…

### DIFF
--- a/Sources/InstantSearchCore/Searcher/MultiIndex/MultiIndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/MultiIndex/MultiIndexSearcher.swift
@@ -35,7 +35,7 @@ public class MultiIndexSearcher: Searcher, SequencerDelegate, SearchResultObserv
   public let client: SearchClient
 
   /// List of  index & query tuples
-  public internal(set) var indexQueryStates: [IndexQueryState] {
+  public var indexQueryStates: [IndexQueryState] {
     didSet {
       let indexNameDiff = zip(oldValue.map(\.indexName), indexQueryStates.map(\.indexName)).enumerated()
       for (queryIndex, (oldIndexName, newIndexName)) in indexNameDiff where oldIndexName != newIndexName {


### PR DESCRIPTION
**Summary**
After Swift API Client v8 release, Query became a structure so it became impossible to directly mutate query in the `MultiIndexSearcher`. 
This PR makes the setter of `indexQueryStates` property public and fixes this inconvenience. 

Resolves #127 