### PR TITLE
refactor: Suppress generic requirements in `LoadingConnector` and `QueryInputConnector`

### DIFF
--- a/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/MultiIndexSearchConnector.swift
@@ -29,7 +29,7 @@ public struct MultiIndexSearchConnector: Connection {
   public let hitsControllerConnection: Connection
 
   /// Connector establishing the linkage between searcher and query input interactor
-  public let queryInputConnector: QueryInputConnector<MultiIndexSearcher>
+  public let queryInputConnector: QueryInputConnector
 
   /// Connection between query input interactor of query input connector and provided query input controller
   public let queryInputControllerConnection: Connection

--- a/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
+++ b/Sources/InstantSearchCore/AdvancedConnectors/SingleIndexSearchConnector.swift
@@ -30,7 +30,7 @@ public struct SingleIndexSearchConnector<Record: Codable>: Connection {
   public let hitsControllerConnection: Connection
 
   /// Connector establishing the linkage between searcher and query input interactor
-  public let queryInputConnector: QueryInputConnector<SingleIndexSearcher>
+  public let queryInputConnector: QueryInputConnector
 
   /// Connection between query input interactor of query input connector and provided query input controller
   public let queryInputControllerConnection: Connection

--- a/Sources/InstantSearchCore/Loading/Connector/LoadingConnector+Controller.swift
+++ b/Sources/InstantSearchCore/Loading/Connector/LoadingConnector+Controller.swift
@@ -15,7 +15,7 @@ public extension LoadingConnector {
       - interactor: Logic applied to a loading indicator
       - controller: Controller that interfaces with a concrete loading view
    */
-  convenience init<Controller: LoadingController>(searcher: S,
+  convenience init<Controller: LoadingController>(searcher: Searcher,
                                                   interactor: LoadingInteractor = .init(),
                                                   controller: Controller) {
     self.init(searcher: searcher, interactor: interactor)

--- a/Sources/InstantSearchCore/Loading/Connector/LoadingConnector.swift
+++ b/Sources/InstantSearchCore/Loading/Connector/LoadingConnector.swift
@@ -11,10 +11,10 @@ import Foundation
 /// Component that shows a loading indicator during pending requests.
 ///
 /// [Documentation](https://www.algolia.com/doc/api-reference/widgets/loading/ios/)
-public class LoadingConnector<S: Searcher> {
+public class LoadingConnector {
 
   /// Searcher that handles your searches
-  public let searcher: S
+  public let searcher: Searcher
 
   /// Logic that handles showing a loading indicator
   public let interactor: LoadingInteractor
@@ -30,7 +30,7 @@ public class LoadingConnector<S: Searcher> {
       - searcher: Searcher that handles your searches
       - interactor: Logic applied to a loading indicator
    */
-  public init(searcher: S,
+  public init(searcher: Searcher,
               interactor: LoadingInteractor = .init()) {
     self.searcher = searcher
     self.interactor = interactor

--- a/Sources/InstantSearchCore/Loading/LoadingInteractor+Searcher.swift
+++ b/Sources/InstantSearchCore/Loading/LoadingInteractor+Searcher.swift
@@ -10,10 +10,10 @@ import Foundation
 
 public extension LoadingInteractor {
 
-  struct SearcherConnection<S: Searcher>: Connection {
+  struct SearcherConnection: Connection {
 
     public let interactor: LoadingInteractor
-    public let searcher: S
+    public let searcher: Searcher
 
     public func connect() {
       searcher.isLoading.subscribePast(with: interactor) { interactor, isLoading in
@@ -31,7 +31,7 @@ public extension LoadingInteractor {
 
 public extension LoadingInteractor {
 
-  @discardableResult func connectSearcher<S: Searcher>(_ searcher: S) -> SearcherConnection<S> {
+  @discardableResult func connectSearcher(_ searcher: Searcher) -> SearcherConnection {
     let connection = SearcherConnection(interactor: self, searcher: searcher)
     connection.connect()
     return connection

--- a/Sources/InstantSearchCore/QueryInput/Connector/QueryInputConnector+Controller.swift
+++ b/Sources/InstantSearchCore/QueryInput/Connector/QueryInputConnector+Controller.swift
@@ -16,10 +16,10 @@ extension QueryInputConnector {
      - searchTriggeringMode: Defines the event triggering a new search
      - controller: Controller interfacing with a concrete query input view
    */
-  public convenience init<Controller: QueryInputController>(searcher: S,
-                                                            interactor: QueryInputInteractor = .init(),
-                                                            searchTriggeringMode: SearchTriggeringMode = .searchAsYouType,
-                                                            controller: Controller) {
+  public convenience init<Controller: QueryInputController, S: Searcher>(searcher: S,
+                                                                         interactor: QueryInputInteractor = .init(),
+                                                                         searchTriggeringMode: SearchTriggeringMode = .searchAsYouType,
+                                                                         controller: Controller) {
     self.init(searcher: searcher,
               interactor: interactor,
               searchTriggeringMode: searchTriggeringMode)

--- a/Sources/InstantSearchCore/QueryInput/Connector/QueryInputConnector.swift
+++ b/Sources/InstantSearchCore/QueryInput/Connector/QueryInputConnector.swift
@@ -11,10 +11,10 @@ import Foundation
 /// Component that performs a text-based query
 ///
 /// [Documentation](https://www.algolia.com/doc/api-reference/widgets/search-box/ios/)
-public class QueryInputConnector<S: Searcher> {
+public class QueryInputConnector {
 
   /// Searcher that handles your searches
-  public let searcher: S
+  public let searcher: Searcher
 
   /// Business logic that handles new search inputs
   public let interactor: QueryInputInteractor
@@ -31,9 +31,9 @@ public class QueryInputConnector<S: Searcher> {
      - interactor: Business logic that handles new search inputs
      - searchTriggeringMode: Defines the event triggering a new search
    */
-  public init(searcher: S,
-              interactor: QueryInputInteractor = .init(),
-              searchTriggeringMode: SearchTriggeringMode = .searchAsYouType) {
+  public init<S: Searcher>(searcher: S,
+                           interactor: QueryInputInteractor = .init(),
+                           searchTriggeringMode: SearchTriggeringMode = .searchAsYouType) {
     self.searcher = searcher
     self.interactor = interactor
     self.searcherConnection = interactor.connectSearcher(searcher, searchTriggeringMode: searchTriggeringMode)


### PR DESCRIPTION
**Summary**

Remove the necessity to specify a `Searcher` generic type in `LoadingConnector` and `QueryInputConnector`.
Makes the API more straightforward without any bad impact on the consistency and type-safety. 