### PR TITLE
feat: Connection between Numeric filter and Searcher to fetch numeric value bounds

### DIFF
--- a/Sources/InstantSearch/Numeric Comparator/NumericStepperController.swift
+++ b/Sources/InstantSearch/Numeric Comparator/NumericStepperController.swift
@@ -26,9 +26,9 @@ public class NumericStepperController: NumberController {
     self.computation = computation
     stepper.addTarget(self, action: #selector(stepperOnValueChanged), for: .valueChanged)
   }
-  
+
   public func setBounds(bounds: ClosedRange<Double>?) {
-    
+
   }
 
   @objc func stepperOnValueChanged(sender: UIStepper) {

--- a/Sources/InstantSearch/Numeric Comparator/NumericStepperController.swift
+++ b/Sources/InstantSearch/Numeric Comparator/NumericStepperController.swift
@@ -28,7 +28,8 @@ public class NumericStepperController: NumberController {
   }
 
   public func setBounds(bounds: ClosedRange<Double>?) {
-
+    stepper.minimumValue = bounds?.lowerBound ?? 0
+    stepper.maximumValue = bounds?.upperBound ?? .infinity
   }
 
   @objc func stepperOnValueChanged(sender: UIStepper) {

--- a/Sources/InstantSearch/Numeric Comparator/NumericStepperController.swift
+++ b/Sources/InstantSearch/Numeric Comparator/NumericStepperController.swift
@@ -26,6 +26,10 @@ public class NumericStepperController: NumberController {
     self.computation = computation
     stepper.addTarget(self, action: #selector(stepperOnValueChanged), for: .valueChanged)
   }
+  
+  public func setBounds(bounds: ClosedRange<Double>?) {
+    
+  }
 
   @objc func stepperOnValueChanged(sender: UIStepper) {
     computation?.just(value: sender.value)

--- a/Sources/InstantSearch/Numeric Comparator/NumericTextFieldController.swift
+++ b/Sources/InstantSearch/Numeric Comparator/NumericTextFieldController.swift
@@ -25,7 +25,7 @@ public class NumericTextFieldController: NSObject, NumberController {
   public func setComputation(computation: Computation<Int>) {
     self.computation = computation
   }
-  
+
   public func setBounds(bounds: ClosedRange<Int>?) {
     textField.placeholder = bounds.flatMap { "\($0.lowerBound) - \($0.upperBound)" }
   }

--- a/Sources/InstantSearch/Numeric Comparator/NumericTextFieldController.swift
+++ b/Sources/InstantSearch/Numeric Comparator/NumericTextFieldController.swift
@@ -25,6 +25,10 @@ public class NumericTextFieldController: NSObject, NumberController {
   public func setComputation(computation: Computation<Int>) {
     self.computation = computation
   }
+  
+  public func setBounds(bounds: ClosedRange<Int>?) {
+    textField.placeholder = bounds.flatMap { "\($0.lowerBound) - \($0.upperBound)" }
+  }
 
   public let textField: UITextField
 

--- a/Sources/InstantSearchCore/Number/Connector/FilterComparisonConnector+Controller.swift
+++ b/Sources/InstantSearchCore/Number/Connector/FilterComparisonConnector+Controller.swift
@@ -11,6 +11,7 @@ public extension FilterComparisonConnector {
 
   /**
    - Parameters:
+     - searcher: Searcher that handles your searches
      - filterState: FilterState that holds your filters
      - attribute: Attribute to filter with a numeric comparison
      - numericOperator: Comparison operator to apply
@@ -20,7 +21,8 @@ public extension FilterComparisonConnector {
      - groupName: Filter group name in the filter state. If not specified, the attribute value is used as the group name
      - controller: Controller interfacing with a concrete number view
   */
-  convenience init<Controller: NumberController>(filterState: FilterState,
+  convenience init<Controller: NumberController>(searcher: SingleIndexSearcher,
+                                                 filterState: FilterState,
                                                  attribute: Attribute,
                                                  numericOperator: Filter.Numeric.Operator,
                                                  number: Number,
@@ -28,7 +30,8 @@ public extension FilterComparisonConnector {
                                                  operator: RefinementOperator,
                                                  groupName: String? = nil,
                                                  controller: Controller) where Controller.Item == Number {
-    self.init(filterState: filterState,
+    self.init(searcher: searcher,
+              filterState: filterState,
               attribute: attribute,
               numericOperator: numericOperator,
               number: number,

--- a/Sources/InstantSearchCore/Number/Connector/FilterComparisonConnector.swift
+++ b/Sources/InstantSearchCore/Number/Connector/FilterComparisonConnector.swift
@@ -13,7 +13,7 @@ public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable>
 
   /// Searcher that handles your searches
   public let searcher: Searcher
-  
+
   /// Logic applied to comparison
   public let interactor: NumberInteractor<Number>
 
@@ -34,7 +34,7 @@ public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable>
 
   /// Connection between interactor and searcher
   public let searcherConnection: Connection
-  
+
   /// Connection between interactor and filter state
   public let filterStateConnection: Connection
 

--- a/Sources/InstantSearchCore/Number/Connector/FilterComparisonConnector.swift
+++ b/Sources/InstantSearchCore/Number/Connector/FilterComparisonConnector.swift
@@ -11,6 +11,9 @@ import Foundation
 /// Component to filter on a numeric value using a comparison operator.
 public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable> {
 
+  /// Searcher that handles your searches
+  public let searcher: Searcher
+  
   /// Logic applied to comparison
   public let interactor: NumberInteractor<Number>
 
@@ -29,6 +32,9 @@ public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable>
   /// Filter group name in the filter state
   public let groupName: String
 
+  /// Connection between interactor and searcher
+  public let searcherConnection: Connection
+  
   /// Connection between interactor and filter state
   public let filterStateConnection: Connection
 
@@ -37,6 +43,7 @@ public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable>
 
   /**
    - Parameters:
+     - searcher: Searcher that handles your searches
      - filterState: FilterState that holds your filters
      - attribute: Attribute to filter with a numeric comparison
      - numericOperator: Comparison operator to apply
@@ -45,19 +52,22 @@ public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable>
      - operator: Whether the filter is added to a conjuncitve(`and`) or  a disjuncitve (`or`) group in the filter state. Default value: .and
      - groupName: Filter group name in the filter state. If not specified, the attribute value is used as the group name
   */
-  public init(filterState: FilterState,
+  public init(searcher: SingleIndexSearcher,
+              filterState: FilterState,
               attribute: Attribute,
               numericOperator: Filter.Numeric.Operator,
               number: Number,
               bounds: ClosedRange<Number>?,
               operator: RefinementOperator,
               groupName: String? = nil) {
+    self.searcher = searcher
     self.interactor = .init()
     self.filterState = filterState
     self.attribute = attribute
     self.numericOperator = numericOperator
     self.operator = `operator`
     self.groupName = groupName ?? attribute.rawValue
+    self.searcherConnection = interactor.connectSearcher(searcher, attribute: attribute)
     self.filterStateConnection = interactor.connectFilterState(filterState,
                                                                attribute: attribute,
                                                                numericOperator: numericOperator,
@@ -75,11 +85,13 @@ public class FilterComparisonConnector<Number: Comparable & DoubleRepresentable>
 extension FilterComparisonConnector: Connection {
 
   public func connect() {
+    searcherConnection.connect()
     filterStateConnection.connect()
     controllerConnections.forEach { $0.connect() }
   }
 
   public func disconnect() {
+    searcherConnection.connect()
     filterStateConnection.disconnect()
     controllerConnections.forEach { $0.disconnect() }
   }

--- a/Sources/InstantSearchCore/Number/FilterComparison+Controller.swift
+++ b/Sources/InstantSearchCore/Number/FilterComparison+Controller.swift
@@ -27,11 +27,11 @@ public struct NumberInteractorControllerConnection<Controller: NumberController,
       }
       controller.setItem(item)
     }.onQueue(.main)
-    
+
     interactor.onBoundsComputed.subscribePast(with: controller) { (controller, bounds) in
       controller.setBounds(bounds: bounds)
     }.onQueue(.main)
-    
+
   }
 
   public func disconnect() {

--- a/Sources/InstantSearchCore/Number/FilterComparison+Controller.swift
+++ b/Sources/InstantSearchCore/Number/FilterComparison+Controller.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct NumberInteractorControllerConnection<Controller: NumberController, Number: Comparable & DoubleRepresentable>: Connection where Controller.Item == Number {
+public struct NumberInteractorControllerConnection<Controller: NumberController, Number: DoubleRepresentable>: Connection where Controller.Item == Number {
 
   public let interactor: NumberInteractor<Number>
   public let controller: Controller
@@ -27,6 +27,11 @@ public struct NumberInteractorControllerConnection<Controller: NumberController,
       }
       controller.setItem(item)
     }.onQueue(.main)
+    
+    interactor.onBoundsComputed.subscribePast(with: controller) { (controller, bounds) in
+      controller.setBounds(bounds: bounds)
+    }.onQueue(.main)
+    
   }
 
   public func disconnect() {

--- a/Sources/InstantSearchCore/Number/NumberController.swift
+++ b/Sources/InstantSearchCore/Number/NumberController.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 
-public protocol NumberController: ItemController where Item: Numeric {
+public protocol NumberController: ItemController where Item: Numeric & Comparable {
 
   func setComputation(computation: Computation<Item>)
+  func setBounds(bounds: ClosedRange<Item>?)
 
 }


### PR DESCRIPTION
**Summary**

- Add connection between `NumberInteractor` and `Searcher` in `FilterComparisonConnector` to fetch bounds from the `SearchResponse` on each search
- Add `setBounds` method to `NumberController`. 
- Add `setBounds` method to `NumberController` implementations of the __InstantSearch__