### PR TITLE
chore: Create a mutable copy of `TaggedString` to access its lazy properties

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "algolia/algoliasearch-client-swift" ~> 8.1
+github "algolia/algoliasearch-client-swift" ~> 8.2
 github "apple/swift-log" ~> 1.3

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   
   s.subspec "Insights" do |ss|
       ss.source_files = 'Sources/InstantSearchInsights/**/*.{swift}'
-      ss.dependency 'AlgoliaSearchClient', '~> 8.1'
+      ss.dependency 'AlgoliaSearchClient', '~> 8.2'
       ss.dependency 'InstantSearchInsights', '~> 2.3'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   
   s.subspec "Core" do |ss|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
-      ss.dependency 'AlgoliaSearchClient', '~> 8.1'
+      ss.dependency 'AlgoliaSearchClient', '~> 8.2'
       ss.dependency 'InstantSearch/Insights'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
       targets: ["InstantSearchInsights"])
   ],
   dependencies: [
-    .package(name: "AlgoliaSearchClient", url:"https://github.com/algolia/algoliasearch-client-swift", from: "8.1.0")
+    .package(name: "AlgoliaSearchClient", url:"https://github.com/algolia/algoliasearch-client-swift", from: "8.2.0")
   ],
   targets: [
     .target(

--- a/Sources/InstantSearchCore/Common/Hit+Place.swift
+++ b/Sources/InstantSearchCore/Common/Hit+Place.swift
@@ -76,7 +76,10 @@ extension Hit: CustomStringConvertible where T == Place {
     return [streetName, city, county, country]
       .compactMap { $0 }
       .filter { !$0.taggedString.input.isEmpty }
-      .map { $0.taggedString.output }
+      .map { highlightedString in
+        var taggedString = highlightedString.taggedString
+        return taggedString.output
+      }
       .joined(separator: ", ")
 
   }

--- a/Sources/InstantSearchCore/Highlighting/NSAttributedString+TaggedString.swift
+++ b/Sources/InstantSearchCore/Highlighting/NSAttributedString+TaggedString.swift
@@ -23,6 +23,7 @@ extension NSAttributedString {
   public convenience init(taggedString: TaggedString,
                           inverted: Bool = false,
                           attributes: [NSAttributedString.Key: Any]) {
+    var taggedString = taggedString
     let attributedString = NSMutableAttributedString(string: taggedString.output)
     let ranges = inverted ? taggedString.untaggedRanges : taggedString.taggedRanges
     ranges.forEach { range in


### PR DESCRIPTION
**Summary**

Fix for compatibility with [Swift Client change](https://github.com/algolia/algoliasearch-client-swift/pull/689).
