### PR TITLE
fix: Wrap iOS availability restriction for advanced connectors initializers

### DIFF
--- a/Sources/InstantSearch/AdvancedConnectors/MultiIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/MultiIndexSearchConnector+UIKit.swift
@@ -13,21 +13,29 @@ import UIKit
 
 public extension MultiIndexSearchConnector {
 
-  @available(iOS 13.0, *)
   init<HC: MultiIndexHitsController>(searcher: MultiIndexSearcher,
                                      indexModules: [MultiIndexHitsConnector.IndexModule],
                                      searchController: UISearchController,
                                      hitsController: HC) {
     let queryInputInteractor = QueryInputInteractor()
-    let textFieldController = TextFieldController(searchBar: searchController.searchBar)
-    self.init(searcher: searcher,
-              indexModules: indexModules,
-              hitsController: hitsController,
-              queryInputInteractor: queryInputInteractor,
-              queryInputController: textFieldController)
+    if #available(iOS 13.0, *) {
+      let textFieldController = TextFieldController(searchBar: searchController.searchBar)
+      self.init(searcher: searcher,
+                indexModules: indexModules,
+                hitsController: hitsController,
+                queryInputInteractor: queryInputInteractor,
+                queryInputController: textFieldController)
+    } else {
+      let searchBarController = SearchBarController(searchBar: searchController.searchBar)
+      self.init(searcher: searcher,
+                indexModules: indexModules,
+                hitsController: hitsController,
+                queryInputInteractor: queryInputInteractor,
+                queryInputController: searchBarController)
+    }
+
   }
 
-  @available(iOS 13.0, *)
   init<HC: MultiIndexHitsController>(appID: ApplicationID,
                                      apiKey: APIKey,
                                      indexModules: [MultiIndexHitsConnector.IndexModule],

--- a/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
+++ b/Sources/InstantSearch/AdvancedConnectors/SingleIndexSearchConnector+UIKit.swift
@@ -13,23 +13,31 @@ import UIKit
 
 public extension SingleIndexSearchConnector {
 
-  @available(iOS 13.0, *)
   init<HC: HitsController>(searcher: SingleIndexSearcher,
                            searchController: UISearchController,
                            hitsInteractor: HitsInteractor<Record> = .init(),
                            hitsController: HC,
                            filterState: FilterState? = nil)  where HC.DataSource == HitsInteractor<Record> {
     let queryInputInteractor = QueryInputInteractor()
-    let textFieldController = TextFieldController(searchBar: searchController.searchBar)
-    self.init(searcher: searcher,
-              queryInputInteractor: queryInputInteractor,
-              queryInputController: textFieldController,
-              hitsInteractor: hitsInteractor,
-              hitsController: hitsController,
-              filterState: filterState)
+    if #available(iOS 13.0, *) {
+      let textFieldController = TextFieldController(searchBar: searchController.searchBar)
+      self.init(searcher: searcher,
+                queryInputInteractor: queryInputInteractor,
+                queryInputController: textFieldController,
+                hitsInteractor: hitsInteractor,
+                hitsController: hitsController,
+                filterState: filterState)
+    } else {
+      let searchBarController = SearchBarController(searchBar: searchController.searchBar)
+      self.init(searcher: searcher,
+                queryInputInteractor: queryInputInteractor,
+                queryInputController: searchBarController,
+                hitsInteractor: hitsInteractor,
+                hitsController: hitsController,
+                filterState: filterState)
+    }
   }
 
-  @available(iOS 13.0, *)
   init<HC: HitsController>(appID: ApplicationID,
                            apiKey: APIKey,
                            indexName: IndexName,


### PR DESCRIPTION
**Summary**

This PR moves the iOS availability requirement inside the advanced connectors convenient initialisers, so they can be used with any supported iOS version, making Getting started guide universal. 

Fix #164 