### PR TITLE
fix: Bump API client dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "algolia/algoliasearch-client-swift" ~> 8.7
+github "algolia/algoliasearch-client-swift" ~> 8.10
 github "apple/swift-log" ~> 1.4

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   
   s.subspec "Insights" do |ss|
       ss.source_files = 'Sources/InstantSearchInsights/**/*.{swift}'
-      ss.dependency 'AlgoliaSearchClient', '~> 8.8'
+      ss.dependency 'AlgoliaSearchClient', '~> 8.10'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.watchos.deployment_target = '3.0'
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |ss|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
       ss.exclude_files = 'Sources/InstantSearchCore/SwiftUI/**/*.{swift}'
-      ss.dependency 'AlgoliaSearchClient', '~> 8.8'
+      ss.dependency 'AlgoliaSearchClient', '~> 8.10'
       ss.dependency 'InstantSearch/Insights'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
       targets: ["InstantSearchInsights"])
   ],
   dependencies: [
-    .package(name: "AlgoliaSearchClient", url: "https://github.com/algolia/algoliasearch-client-swift", .branch("feat/dynamic-faceting"))
+    .package(name: "AlgoliaSearchClient", url: "https://github.com/algolia/algoliasearch-client-swift", from: "8.10.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
**Summary**

Bump Swift API client dependencies in the Package, podspec and the Cartfile