### PR TITLE
fix: Remove Objective-C leftovers from the Insights causing the crash

### DIFF
--- a/Sources/InstantSearchInsights/Logic/EventTracker.swift
+++ b/Sources/InstantSearchInsights/Logic/EventTracker.swift
@@ -13,7 +13,7 @@ import AlgoliaSearchClient
 /// Provides convenient functions for tracking events which can be used for search personalization.
 ///
 
-class EventTracker: NSObject, EventTrackable {
+class EventTracker: EventTrackable {
 
   var eventProcessor: EventProcessable
   var logger: PrefixedLogger

--- a/Sources/InstantSearchInsights/Logic/Insights.swift
+++ b/Sources/InstantSearchInsights/Logic/Insights.swift
@@ -30,7 +30,7 @@ import AppKit
 ///                               position: 1)
 /// ````
 
-@objcMembers public class Insights: NSObject {
+public class Insights {
 
   /// Specify the desired API endpoint region
   /// By default API endpoint is routed automatically

--- a/Tests/InstantSearchInsightsTests/Unit/InsightsTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/InsightsTests.swift
@@ -37,8 +37,8 @@ class InsightsTests: XCTestCase {
     let insightsShared = Insights.shared(appId: appID)
     XCTAssertNotNil(insightsShared)
     
-    XCTAssertEqual(insightsRegister, insightsShared, "Getting the Insights instance from register and shared should be the same")
-    
+    XCTAssertTrue(insightsRegister === insightsShared, "Getting the Insights instance from register and shared must be the same")
+        
   }
   
   func testOptIntOptOut() {


### PR DESCRIPTION
**Summary**

[Crash report](https://secure.helpscout.net/conversation/1590238758).
The reason of this crash is the issue in the Swift - Objective-C interoperability [explained here](https://stackoverflow.com/questions/61006622/exc-bad-access-in-swift-isuniquelyreferenced-nonnull-native-when-accessing-swift).

This PR fixes this crash by removing the Objective-C leftovers of the standalone Insights library.