### PR TITLE
refactor: Separate the InstantSearchSwiftUI product

### DIFF
--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author = { "Algolia" => "contact@algolia.com" }
   s.source = { :git => 'https://github.com/algolia/instantsearch-ios.git', :tag => s.version }
 
-  s.swift_version = "5.1"
+  s.swift_version = "5.2"
   
   s.default_subspec = 'UI'
   
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
   
   s.subspec "Core" do |ss|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
-      ss.exclude_files = 'Sources/InstantSearchCore/SwiftUI/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.10'
       ss.dependency 'InstantSearch/Insights'
       ss.ios.deployment_target = '9.0'
@@ -36,7 +35,6 @@ Pod::Spec.new do |s|
   
   s.subspec "UI" do |ss|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
-      ss.exclude_files = 'Sources/InstantSearch/SwiftUI/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
@@ -46,7 +44,7 @@ Pod::Spec.new do |s|
   end
   
   s.subspec "SwiftUI" do |ss|
-      ss.source_files = 'Sources/InstantSearchCore/SwiftUI/**/*.{swift}', 'Sources/InstantSearch/SwiftUI/**/*.{swift}'
+      ss.source_files = 'Sources/InstantSearchSwiftUI/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
       ss.ios.deployment_target = '13.0'
       ss.osx.deployment_target = '10.15'

--- a/Package.swift
+++ b/Package.swift
@@ -20,29 +20,40 @@ let package = Package(
       targets: ["InstantSearchCore"]),
     .library(
       name: "InstantSearchInsights",
-      targets: ["InstantSearchInsights"])
+      targets: ["InstantSearchInsights"]),
+    .library(
+      name: "InstantSearchSwiftUI",
+      targets: ["InstantSearchSwiftUI"])
   ],
   dependencies: [
-    .package(name: "AlgoliaSearchClient", url: "https://github.com/algolia/algoliasearch-client-swift", from: "8.10.0")
+    .package(name: "AlgoliaSearchClient",
+             url: "https://github.com/algolia/algoliasearch-client-swift", from: "8.10.0")
   ],
   targets: [
     .target(
       name: "InstantSearchInsights",
       dependencies: ["AlgoliaSearchClient"]),
+    .testTarget(
+      name: "InstantSearchInsightsTests",
+      dependencies: ["InstantSearchInsights", "AlgoliaSearchClient"]),
     .target(
       name: "InstantSearchCore",
       dependencies: ["AlgoliaSearchClient", "InstantSearchInsights"]),
+    .testTarget(
+      name: "InstantSearchCoreTests",
+      dependencies: ["InstantSearchCore", "AlgoliaSearchClient", "InstantSearchInsights"]),
     .target(
       name: "InstantSearch",
       dependencies: ["InstantSearchCore"]),
     .testTarget(
-      name: "InstantSearchInsightsTests",
-      dependencies: ["InstantSearchInsights", "AlgoliaSearchClient"]),
-    .testTarget(
-      name: "InstantSearchCoreTests",
-      dependencies: ["InstantSearchCore", "AlgoliaSearchClient", "InstantSearchInsights"]),
-    .testTarget(
       name: "InstantSearchTests",
-      dependencies: ["InstantSearch"])
+      dependencies: ["InstantSearch"]),
+    .target(
+      name: "InstantSearchSwiftUI",
+      dependencies: ["InstantSearchCore"]),
+    .testTarget(
+      name: "InstantSearchSwiftUITests",
+      dependencies: ["InstantSearchSwiftUI"])
+
   ]
 )

--- a/Readme.md
+++ b/Readme.md
@@ -17,8 +17,9 @@ InstantSearch family: **InstantSearch iOS** | [InstantSearch Android][instantsea
 
  **InstantSearch iOS** consists of three products
  - *InstantSearch Insights* – library that allows developers to capture search-related events
- - *InstantSearch Core* – the business logic modules of InstantSearch without provided UIKit controllers
- - *InstantSearch* – the complete InstantSearch toolset including UIKit and SwiftUI components
+ - *InstantSearch Core* – the business logic modules of InstantSearch
+ - *InstantSearch* – the complete InstantSearch toolset including UIKit components
+ - *InstantSearch SwiftUI* – the set of SwiftUI data models and views to use on top of Core components
 
 ## Demo
 

--- a/Sources/InstantSearchCore/Hits/HitsInteractor.swift
+++ b/Sources/InstantSearchCore/Hits/HitsInteractor.swift
@@ -82,7 +82,7 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
 
   public func hit(atIndex index: Int) -> Record? {
     guard let hitsPageMap = paginator.pageMap else { return nil }
-    notifyForInfiniteScrolling(rowNumber: index)
+    notifyDidPresentRow(atIndex: index)
     return hitsPageMap[index]
   }
 
@@ -111,12 +111,12 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
     return pageMap.loadedPages.flatMap { $0.items }.compactMap(toRaw)
   }
 
-  internal func notifyForInfiniteScrolling(rowNumber: Int) {
+  public func notifyDidPresentRow(atIndex rowIndex: Int) {
     guard
       case .on(let pageLoadOffset) = settings.infiniteScrolling,
       let hitsPageMap = paginator.pageMap else { return }
 
-    infiniteScrollingController.calculatePagesAndLoad(currentRow: rowNumber, offset: pageLoadOffset, pageMap: hitsPageMap)
+    infiniteScrollingController.calculatePagesAndLoad(currentRow: rowIndex, offset: pageLoadOffset, pageMap: hitsPageMap)
   }
 
 }

--- a/Sources/InstantSearchSwiftUI/DataModel/CurrentFiltersObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/CurrentFiltersObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/DynamicFacetListObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/DynamicFacetListObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 15/06/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/FacetListObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/FacetListObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/FilterClearObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/FilterClearObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/FilterListObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/FilterListObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 10/06/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/FilterToggleObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/FilterToggleObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 11/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/FilterToggleObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/FilterToggleObservableController.swift
@@ -1,6 +1,6 @@
 //
 //  FilterToggleObservableController.swift
-//  DemoEcommerce
+//
 //
 //  Created by Vladislav Fitc on 11/04/2021.
 //

--- a/Sources/InstantSearchSwiftUI/DataModel/HierarchicalObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/HierarchicalObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 21/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/HierarchicalObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/HierarchicalObservableController.swift
@@ -1,6 +1,6 @@
 //
 //  HierarchicalObservableController.swift
-//  DemoEcommerce
+//
 //
 //  Created by Vladislav Fitc on 21/04/2021.
 //

--- a/Sources/InstantSearchSwiftUI/DataModel/HitsObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/HitsObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 26/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI
@@ -27,17 +29,12 @@ public class HitsObservableController<Hit: Codable>: ObservableObject, HitsContr
   }
 
   public func reload() {
-    guard let paginator = self.hitsSource?.paginator, !paginator.isInvalidated,
-          let pageMap = paginator.pageMap else {
-      hits.removeAll()
-      return
-    }
-    self.hits = pageMap.map { $0 }
+    self.hits = hitsSource?.getCurrentHits() ?? []
   }
 
   /// Function to call on hit appearance  to ensure the infinite scrolling functionality
   public func notifyAppearanceOfHit(atIndex index: Int) {
-    hitsSource?.notifyForInfiniteScrolling(rowNumber: index)
+    hitsSource?.notifyDidPresentRow(atIndex: index)
   }
 
   public init() {

--- a/Sources/InstantSearchSwiftUI/DataModel/LoadingObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/LoadingObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 01/06/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/NumberRangeObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/NumberRangeObservableController.swift
@@ -1,6 +1,7 @@
 //
 //  NumberRangeObservableController.swift
 //
+//
 //  Created by Vladislav Fitc on 21/04/2021.
 //
 

--- a/Sources/InstantSearchSwiftUI/DataModel/NumberRangeObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/NumberRangeObservableController.swift
@@ -4,7 +4,9 @@
 //  Created by Vladislav Fitc on 21/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/QueryInputObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/QueryInputObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/RelevantSortObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/RelevantSortObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 04/07/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/SelectableSegmentObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/SelectableSegmentObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 04/07/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/StatsObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/StatsObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/StatsTextObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/StatsTextObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/DataModel/SwitchIndexObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/SwitchIndexObservableController.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 01/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/FacetList.swift
+++ b/Sources/InstantSearchSwiftUI/View/FacetList.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64)) && !os(tvOS)
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/FacetRow.swift
+++ b/Sources/InstantSearchSwiftUI/View/FacetRow.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 20/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/FilterList.swift
+++ b/Sources/InstantSearchSwiftUI/View/FilterList.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 21/06/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64)) && !os(tvOS)
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/HierarchicalFacetRow.swift
+++ b/Sources/InstantSearchSwiftUI/View/HierarchicalFacetRow.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/06/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/HierarchicalList.swift
+++ b/Sources/InstantSearchSwiftUI/View/HierarchicalList.swift
@@ -1,6 +1,6 @@
 //
 //  HierarchicalList.swift
-//  DemoEcommerce
+//
 //
 //  Created by Vladislav Fitc on 10/04/2021.
 //

--- a/Sources/InstantSearchSwiftUI/View/HierarchicalList.swift
+++ b/Sources/InstantSearchSwiftUI/View/HierarchicalList.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 10/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64)) && !os(tvOS)
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/HitsList.swift
+++ b/Sources/InstantSearchSwiftUI/View/HitsList.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/SearchBar.swift
+++ b/Sources/InstantSearchSwiftUI/View/SearchBar.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64)) && !os(tvOS)
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/SuggestionRow.swift
+++ b/Sources/InstantSearchSwiftUI/View/SuggestionRow.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 01/04/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI

--- a/Sources/InstantSearchSwiftUI/View/Text+Highlighting.swift
+++ b/Sources/InstantSearchSwiftUI/View/Text+Highlighting.swift
@@ -5,7 +5,9 @@
 //  Created by Vladislav Fitc on 29/03/2021.
 //
 
-import Foundation
+#if !InstantSearchCocoaPods
+import InstantSearchCore
+#endif
 #if canImport(Combine) && canImport(SwiftUI) && (arch(arm64) || arch(x86_64))
 import Combine
 import SwiftUI


### PR DESCRIPTION
**Summary**

This PR separates the SwiftUI components to a particular InstantSearchSwiftUI product.
The InstantSearch/SwiftUI Cocoapods subspec will still work as before. 