### PR TITLE
fix(insights): expired events removal

### DIFF
--- a/Sources/InstantSearchCore/Tracker/FilterTrackable.swift
+++ b/Sources/InstantSearchCore/Tracker/FilterTrackable.swift
@@ -16,16 +16,19 @@ protocol FilterTrackable {
   func viewed(eventName: EventName,
               indexName: IndexName,
               filters: [String],
+              timestamp: Date?,
               userToken: UserToken?)
 
   func clicked(eventName: EventName,
                indexName: IndexName,
                filters: [String],
+               timestamp: Date?,
                userToken: UserToken?)
 
   func converted(eventName: EventName,
                  indexName: IndexName,
                  filters: [String],
+                 timestamp: Date?,
                  userToken: UserToken?)
 
 }

--- a/Sources/InstantSearchCore/Tracker/FilterTracker.swift
+++ b/Sources/InstantSearchCore/Tracker/FilterTracker.swift
@@ -42,19 +42,31 @@ public extension FilterTracker {
   func trackClick<F: FilterType>(for filter: F,
                                  eventName customEventName: EventName? = nil) {
     guard let sqlForm = (filter as? SQLSyntaxConvertible)?.sqlForm else { return }
-    tracker.clicked(eventName: customEventName ?? eventName, indexName: searcher.indexName, filters: [sqlForm], userToken: .none)
+    tracker.clicked(eventName: customEventName ?? eventName,
+                    indexName: searcher.indexName,
+                    filters: [sqlForm],
+                    timestamp: .none,
+                    userToken: .none)
   }
 
   func trackView<F: FilterType>(for filter: F,
                                 eventName customEventName: EventName? = nil) {
     guard let sqlForm = (filter as? SQLSyntaxConvertible)?.sqlForm else { return }
-    tracker.viewed(eventName: customEventName ?? eventName, indexName: searcher.indexName, filters: [sqlForm], userToken: .none)
+    tracker.viewed(eventName: customEventName ?? eventName,
+                   indexName: searcher.indexName,
+                   filters: [sqlForm],
+                   timestamp: .none,
+                   userToken: .none)
   }
 
   func trackConversion<F: FilterType>(for filter: F,
                                       eventName customEventName: EventName? = nil) {
     guard let sqlForm = (filter as? SQLSyntaxConvertible)?.sqlForm else { return }
-    tracker.converted(eventName: customEventName ?? eventName, indexName: searcher.indexName, filters: [sqlForm], userToken: .none)
+    tracker.converted(eventName: customEventName ?? eventName,
+                      indexName: searcher.indexName,
+                      filters: [sqlForm],
+                      timestamp: .none,
+                      userToken: .none)
   }
 
 }

--- a/Sources/InstantSearchCore/Tracker/HitsAfterSearchTrackable.swift
+++ b/Sources/InstantSearchCore/Tracker/HitsAfterSearchTrackable.swift
@@ -17,17 +17,20 @@ protocol HitsAfterSearchTrackable {
                           indexName: IndexName,
                           objectIDsWithPositions: [(ObjectID, Int)],
                           queryID: QueryID,
+                          timestamp: Date?,
                           userToken: UserToken?)
 
   func convertedAfterSearch(eventName: EventName,
                             indexName: IndexName,
                             objectIDs: [ObjectID],
                             queryID: QueryID,
+                            timestamp: Date?,
                             userToken: UserToken?)
 
   func viewed(eventName: EventName,
               indexName: IndexName,
               objectIDs: [ObjectID],
+              timestamp: Date?,
               userToken: UserToken?)
 
 }

--- a/Sources/InstantSearchCore/Tracker/HitsTracker.swift
+++ b/Sources/InstantSearchCore/Tracker/HitsTracker.swift
@@ -60,6 +60,7 @@ public extension HitsTracker {
                                indexName: searcher.indexName,
                                objectIDsWithPositions: [(hit.objectID, position)],
                                queryID: queryID,
+                               timestamp: .none,
                                userToken: .none)
   }
 
@@ -70,6 +71,7 @@ public extension HitsTracker {
                                  indexName: searcher.indexName,
                                  objectIDs: [hit.objectID],
                                  queryID: queryID,
+                                 timestamp: .none,
                                  userToken: .none)
   }
 
@@ -78,6 +80,7 @@ public extension HitsTracker {
     tracker.viewed(eventName: customEventName ?? self.eventName,
                    indexName: searcher.indexName,
                    objectIDs: [hit.objectID],
+                   timestamp: .none,
                    userToken: .none)
   }
 

--- a/Sources/InstantSearchInsights/Logic/EventTracker.swift
+++ b/Sources/InstantSearchInsights/Logic/EventTracker.swift
@@ -18,13 +18,16 @@ class EventTracker: EventTrackable {
   var eventProcessor: EventProcessable
   var logger: PrefixedLogger
   var userToken: UserToken?
+  var generateTimestamps: Bool
 
   init(eventProcessor: EventProcessable,
        logger: PrefixedLogger,
-       userToken: UserToken? = .none) {
+       userToken: UserToken?,
+       generateTimestamps: Bool) {
     self.eventProcessor = eventProcessor
     self.logger = logger
     self.userToken = userToken
+    self.generateTimestamps = generateTimestamps
   }
 
   /// Provides an appropriate user token
@@ -37,16 +40,21 @@ class EventTracker: EventTrackable {
   func effectiveUserToken(withEventUserToken eventUserToken: UserToken?) -> UserToken {
     return eventUserToken ?? self.userToken ?? Insights.userToken
   }
+  
+  func effectiveTimestamp(for timestamp: Date?) -> Date? {
+    return timestamp ?? (generateTimestamps ? Date() : nil)
+  }
 
   func view(eventName: EventName,
             indexName: IndexName,
             userToken: UserToken? = .none,
+            timestamp: Date?,
             objectIDs: [ObjectID]) {
     do {
       eventProcessor.process(try .view(name: eventName,
                                        indexName: indexName,
                                        userToken: effectiveUserToken(withEventUserToken: userToken),
-                                       timestamp: Date(),
+                                       timestamp: effectiveTimestamp(for: timestamp),
                                        objectIDs: objectIDs))
     } catch let error {
       logger.error(error)
@@ -56,12 +64,13 @@ class EventTracker: EventTrackable {
   func view(eventName: EventName,
             indexName: IndexName,
             userToken: UserToken? = .none,
+            timestamp: Date?,
             filters: [String]) {
     do {
       eventProcessor.process(try .view(name: eventName,
                                        indexName: indexName,
                                        userToken: effectiveUserToken(withEventUserToken: userToken),
-                                       timestamp: Date(),
+                                       timestamp: effectiveTimestamp(for: timestamp),
                                        filters: filters))
     } catch let error {
       logger.error(error)
@@ -71,6 +80,7 @@ class EventTracker: EventTrackable {
   func click(eventName: EventName,
              indexName: IndexName,
              userToken: UserToken?,
+             timestamp: Date?,
              objectIDs: [ObjectID],
              positions: [Int],
              queryID: QueryID) {
@@ -79,7 +89,7 @@ class EventTracker: EventTrackable {
       eventProcessor.process(try .click(name: eventName,
                                         indexName: indexName,
                                         userToken: effectiveUserToken(withEventUserToken: userToken),
-                                        timestamp: Date(),
+                                        timestamp: effectiveTimestamp(for: timestamp),
                                         queryID: queryID,
                                         objectIDsWithPositions: objectIDsWithPositions))
     } catch let error {
@@ -90,12 +100,13 @@ class EventTracker: EventTrackable {
   func click(eventName: EventName,
              indexName: IndexName,
              userToken: UserToken? = .none,
+             timestamp: Date?,
              objectIDs: [ObjectID]) {
     do {
       eventProcessor.process(try .click(name: eventName,
                                         indexName: indexName,
                                         userToken: effectiveUserToken(withEventUserToken: userToken),
-                                        timestamp: Date(),
+                                        timestamp: effectiveTimestamp(for: timestamp),
                                         objectIDs: objectIDs))
     } catch let error {
       logger.error(error)
@@ -106,12 +117,13 @@ class EventTracker: EventTrackable {
   func click(eventName: EventName,
              indexName: IndexName,
              userToken: UserToken? = .none,
+             timestamp: Date?,
              filters: [String]) {
     do {
       eventProcessor.process(try .click(name: eventName,
                                         indexName: indexName,
                                         userToken: effectiveUserToken(withEventUserToken: userToken),
-                                        timestamp: Date(),
+                                        timestamp: effectiveTimestamp(for: timestamp),
                                         filters: filters))
     } catch let error {
       logger.error(error)
@@ -122,12 +134,13 @@ class EventTracker: EventTrackable {
   func conversion(eventName: EventName,
                   indexName: IndexName,
                   userToken: UserToken? = .none,
+                  timestamp: Date?,
                   objectIDs: [ObjectID]) {
     do {
       eventProcessor.process(try .conversion(name: eventName,
                                              indexName: indexName,
                                              userToken: effectiveUserToken(withEventUserToken: userToken),
-                                             timestamp: Date(),
+                                             timestamp: effectiveTimestamp(for: timestamp),
                                              queryID: nil,
                                              objectIDs: objectIDs))
     } catch let error {
@@ -138,12 +151,13 @@ class EventTracker: EventTrackable {
   func conversion(eventName: EventName,
                   indexName: IndexName,
                   userToken: UserToken? = .none,
+                  timestamp: Date?,
                   filters: [String]) {
     do {
       eventProcessor.process(try .conversion(name: eventName,
                                              indexName: indexName,
                                              userToken: effectiveUserToken(withEventUserToken: userToken),
-                                             timestamp: Date(),
+                                             timestamp: effectiveTimestamp(for: timestamp),
                                              queryID: nil,
                                              filters: filters))
     } catch let error {
@@ -154,6 +168,7 @@ class EventTracker: EventTrackable {
   func conversion(eventName: EventName,
                   indexName: IndexName,
                   userToken: UserToken?,
+                  timestamp: Date?,
                   objectIDs: [ObjectID],
                   queryID: QueryID) {
 
@@ -161,7 +176,7 @@ class EventTracker: EventTrackable {
       eventProcessor.process(try .conversion(name: eventName,
                                              indexName: indexName,
                                              userToken: effectiveUserToken(withEventUserToken: userToken),
-                                             timestamp: Date(),
+                                             timestamp: effectiveTimestamp(for: timestamp),
                                              queryID: queryID,
                                              objectIDs: objectIDs))
     } catch let error {

--- a/Sources/InstantSearchInsights/Logic/Insights+EventTracking.swift
+++ b/Sources/InstantSearchInsights/Logic/Insights+EventTracking.swift
@@ -15,15 +15,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func viewed(eventName: EventName,
                      indexName: IndexName,
                      objectIDs: [ObjectID],
+                     timestamp: Date? = .none,
                      userToken: UserToken? = .none) {
     eventTracker.view(eventName: eventName,
                       indexName: indexName,
                       userToken: userToken,
+                      timestamp: timestamp,
                       objectIDs: objectIDs)
   }
 
@@ -31,15 +34,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectID: Index objectID.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func viewed(eventName: EventName,
                      indexName: IndexName,
                      objectID: ObjectID,
+                     timestamp: Date? = nil,
                      userToken: UserToken? = .none) {
     eventTracker.view(eventName: eventName,
                       indexName: indexName,
                       userToken: userToken,
+                      timestamp: timestamp,
                       objectIDs: [objectID])
   }
 
@@ -47,15 +53,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter filters: An array of filters. Limited to 10 filters.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func viewed(eventName: EventName,
                      indexName: IndexName,
                      filters: [String],
+                     timestamp: Date? = .none,
                      userToken: UserToken? = .none) {
     eventTracker.view(eventName: eventName,
                       indexName: indexName,
                       userToken: userToken,
+                      timestamp: timestamp,
                       filters: filters)
   }
 
@@ -63,15 +72,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func clicked(eventName: EventName,
                       indexName: IndexName,
                       objectIDs: [ObjectID],
+                      timestamp: Date? = .none,
                       userToken: UserToken? = .none) {
     eventTracker.click(eventName: eventName,
                        indexName: indexName,
                        userToken: userToken,
+                       timestamp: timestamp,
                        objectIDs: objectIDs)
   }
 
@@ -79,15 +91,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectID: Index objectID.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func clicked(eventName: EventName,
                       indexName: IndexName,
                       objectID: ObjectID,
+                      timestamp: Date? = .none,
                       userToken: UserToken? = .none) {
     eventTracker.click(eventName: eventName,
                        indexName: indexName,
                        userToken: userToken,
+                       timestamp: timestamp,
                        objectIDs: [objectID])
   }
 
@@ -95,15 +110,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter filters: An array of filters. Limited to 10 filters.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func clicked(eventName: EventName,
                       indexName: IndexName,
                       filters: [String],
+                      timestamp: Date? = .none,
                       userToken: UserToken? = .none) {
     eventTracker.click(eventName: eventName,
                        indexName: indexName,
                        userToken: userToken,
+                       timestamp: timestamp,
                        filters: filters)
   }
 
@@ -111,15 +129,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func converted(eventName: EventName,
                         indexName: IndexName,
                         objectIDs: [ObjectID],
+                        timestamp: Date? = .none,
                         userToken: UserToken? = .none) {
     eventTracker.conversion(eventName: eventName,
                             indexName: indexName,
                             userToken: userToken,
+                            timestamp: timestamp,
                             objectIDs: objectIDs)
   }
 
@@ -127,15 +148,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectID: Index objectID.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func converted(eventName: EventName,
                         indexName: IndexName,
                         objectID: ObjectID,
+                        timestamp: Date? = .none,
                         userToken: UserToken? = .none) {
     eventTracker.conversion(eventName: eventName,
                             indexName: indexName,
                             userToken: userToken,
+                            timestamp: timestamp,
                             objectIDs: [objectID])
   }
 
@@ -143,15 +167,18 @@ extension Insights {
   /// - parameter eventName: A user-defined string used to categorize events
   /// - parameter indexName: Name of the targeted index
   /// - parameter filters: An array of filters. Limited to 10 filters.
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func converted(eventName: EventName,
                         indexName: IndexName,
                         filters: [String],
+                        timestamp: Date? = .none,
                         userToken: UserToken? = .none) {
     eventTracker.conversion(eventName: eventName,
                             indexName: indexName,
                             userToken: userToken,
+                            timestamp: timestamp,
                             filters: filters)
   }
 

--- a/Sources/InstantSearchInsights/Logic/Insights+SearchEventTracking.swift
+++ b/Sources/InstantSearchInsights/Logic/Insights+SearchEventTracking.swift
@@ -17,6 +17,7 @@ extension Insights {
   /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
   /// - parameter positions: Position of the click in the list of Algolia search results. Positions count must be the same as objectID count.
   /// - parameter queryID: Algolia queryID
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func clickedAfterSearch(eventName: EventName,
@@ -24,10 +25,12 @@ extension Insights {
                                  objectIDs: [ObjectID],
                                  positions: [Int],
                                  queryID: QueryID,
+                                 timestamp: Date? = .none,
                                  userToken: UserToken? = .none) {
     eventTracker.click(eventName: eventName,
                        indexName: indexName,
                        userToken: userToken,
+                       timestamp: timestamp,
                        objectIDs: objectIDs,
                        positions: positions,
                        queryID: queryID)
@@ -38,18 +41,21 @@ extension Insights {
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectIDsWithPositions: An array of related index objectID and position of the click in the list of Algolia search results. - Warning: Limited to 20 objects.
   /// - parameter queryID: Algolia queryID
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func clickedAfterSearch(eventName: EventName,
                                  indexName: IndexName,
                                  objectIDsWithPositions: [(ObjectID, Int)],
                                  queryID: QueryID,
+                                 timestamp: Date? = .none,
                                  userToken: UserToken? = .none) {
     clickedAfterSearch(eventName: eventName,
                        indexName: indexName,
                        objectIDs: objectIDsWithPositions.map { $0.0 },
                        positions: objectIDsWithPositions.map { $0.1 },
                        queryID: queryID,
+                       timestamp: timestamp,
                        userToken: userToken)
   }
 
@@ -59,6 +65,7 @@ extension Insights {
   /// - parameter objectID: Index objectID
   /// - parameter position: Position of the click in the list of Algolia search results
   /// - parameter queryID: Algolia queryID
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func clickedAfterSearch(eventName: EventName,
@@ -66,12 +73,14 @@ extension Insights {
                                  objectID: ObjectID,
                                  position: Int,
                                  queryID: QueryID,
+                                 timestamp: Date? = .none,
                                  userToken: UserToken? = .none) {
     clickedAfterSearch(eventName: eventName,
                        indexName: indexName,
                        objectIDs: [objectID],
                        positions: [position],
                        queryID: queryID,
+                       timestamp: timestamp,
                        userToken: userToken)
   }
 
@@ -80,16 +89,19 @@ extension Insights {
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
   /// - parameter queryID: Algolia queryID
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func convertedAfterSearch(eventName: EventName,
                                    indexName: IndexName,
                                    objectIDs: [ObjectID],
                                    queryID: QueryID,
+                                   timestamp: Date? = .none,
                                    userToken: UserToken? = .none) {
     eventTracker.conversion(eventName: eventName,
                             indexName: indexName,
                             userToken: userToken,
+                            timestamp: timestamp,
                             objectIDs: objectIDs,
                             queryID: queryID)
   }
@@ -99,16 +111,19 @@ extension Insights {
   /// - parameter indexName: Name of the targeted index
   /// - parameter objectID: Index objectID
   /// - parameter queryID: Algolia queryID
+  /// - parameter timestamp: Event timestamp
   /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
 
   public func convertedAfterSearch(eventName: EventName,
                                    indexName: IndexName,
                                    objectID: ObjectID,
                                    queryID: QueryID,
+                                   timestamp: Date? = .none,
                                    userToken: UserToken? = .none) {
     eventTracker.conversion(eventName: eventName,
                             indexName: indexName,
                             userToken: userToken,
+                            timestamp: timestamp,
                             objectIDs: [objectID],
                             queryID: queryID)
   }

--- a/Sources/InstantSearchInsights/Models/Config.swift
+++ b/Sources/InstantSearchInsights/Models/Config.swift
@@ -23,6 +23,9 @@ struct Algolia {
   struct Insights {
     // Default flush delay is 30 seconds
     static let flushDelay: TimeInterval = 30
+    
+    /// The delay after which the event won't be accepted by server: 4 days
+    static let eventExpirationDelay = (4 * 24 * 3600 as TimeInterval).milliseconds
 
     static let maxEventCountInPackage = 1000
   }

--- a/Sources/InstantSearchInsights/Protocols/EventTrackable.swift
+++ b/Sources/InstantSearchInsights/Protocols/EventTrackable.swift
@@ -14,21 +14,25 @@ protocol EventTrackable {
     func view(eventName: EventName,
               indexName: IndexName,
               userToken: UserToken?,
+              timestamp: Date?,
               objectIDs: [ObjectID])
 
     func view(eventName: EventName,
               indexName: IndexName,
               userToken: UserToken?,
+              timestamp: Date?,
               filters: [String])
 
     func click(eventName: EventName,
                indexName: IndexName,
                userToken: UserToken?,
+               timestamp: Date?,
                objectIDs: [ObjectID])
 
     func click(eventName: EventName,
                indexName: IndexName,
                userToken: UserToken?,
+               timestamp: Date?,
                objectIDs: [ObjectID],
                positions: [Int],
                queryID: QueryID)
@@ -36,22 +40,26 @@ protocol EventTrackable {
     func click(eventName: EventName,
                indexName: IndexName,
                userToken: UserToken?,
+               timestamp: Date?,
                filters: [String])
 
     func conversion(eventName: EventName,
                     indexName: IndexName,
                     userToken: UserToken?,
+                    timestamp: Date?,
                     objectIDs: [ObjectID])
 
     func conversion(eventName: EventName,
                     indexName: IndexName,
                     userToken: UserToken?,
+                    timestamp: Date?,
                     objectIDs: [ObjectID],
                     queryID: QueryID)
 
     func conversion(eventName: EventName,
                     indexName: IndexName,
                     userToken: UserToken?,
+                    timestamp: Date?,
                     filters: [String])
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/Tracker/TestFiltersTracker.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Tracker/TestFiltersTracker.swift
@@ -13,18 +13,30 @@ class TestFiltersTracker: FilterTrackable {
 
   enum EventType { case view, click, convert }
 
-  var did: (((EventType, eventName: EventName, indexName: IndexName, filters: [String], userToken: UserToken?)) -> Void)?
+  var did: (((EventType, eventName: EventName, indexName: IndexName, filters: [String], timestamp: Date?, userToken: UserToken?)) -> Void)?
 
-  func viewed(eventName: EventName, indexName: IndexName, filters: [String], userToken: UserToken?) {
-    did?((.view, eventName, indexName, filters, userToken))
+  func viewed(eventName: EventName,
+              indexName: IndexName,
+              filters: [String],
+              timestamp: Date?,
+              userToken: UserToken?) {
+    did?((.view, eventName, indexName, filters, timestamp, userToken))
   }
 
-  func clicked(eventName: EventName, indexName: IndexName, filters: [String], userToken: UserToken?) {
-    did?((.click, eventName, indexName, filters, userToken))
+  func clicked(eventName: EventName,
+               indexName: IndexName,
+               filters: [String],
+               timestamp: Date?,
+               userToken: UserToken?) {
+    did?((.click, eventName, indexName, filters, timestamp, userToken))
   }
 
-  func converted(eventName: EventName, indexName: IndexName, filters: [String], userToken: UserToken?) {
-    did?((.convert, eventName, indexName, filters, userToken))
+  func converted(eventName: EventName,
+                 indexName: IndexName,
+                 filters: [String],
+                 timestamp: Date?,
+                 userToken: UserToken?) {
+    did?((.convert, eventName, indexName, filters, timestamp, userToken))
   }
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/Tracker/TestHitsTracker.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Tracker/TestHitsTracker.swift
@@ -11,20 +11,20 @@ import Foundation
 
 class TestHitsTracker: HitsAfterSearchTrackable {
 
-  var didClick: (((eventName: EventName, indexName: IndexName, objectIDsWithPositions: [(ObjectID, Int)], queryID: QueryID, userToken: UserToken?)) -> Void)?
-  var didConvert: (((eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], queryID: QueryID, userToken: UserToken?)) -> Void)?
-  var didView: (((eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], userToken: UserToken?)) -> Void)?
+  var didClick: (((eventName: EventName, indexName: IndexName, objectIDsWithPositions: [(ObjectID, Int)], queryID: QueryID, timestamp: Date?, userToken: UserToken?)) -> Void)?
+  var didConvert: (((eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], queryID: QueryID, timestamp: Date?, userToken: UserToken?)) -> Void)?
+  var didView: (((eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], timestamp: Date?, userToken: UserToken?)) -> Void)?
 
-  func clickedAfterSearch(eventName: EventName, indexName: IndexName, objectIDsWithPositions: [(ObjectID, Int)], queryID: QueryID, userToken: UserToken?) {
-      didClick?((eventName, indexName, objectIDsWithPositions, queryID, userToken))
+  func clickedAfterSearch(eventName: EventName, indexName: IndexName, objectIDsWithPositions: [(ObjectID, Int)], queryID: QueryID, timestamp: Date?, userToken: UserToken?) {
+    didClick?((eventName, indexName, objectIDsWithPositions, queryID, timestamp, userToken))
   }
 
-  func convertedAfterSearch(eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], queryID: QueryID, userToken: UserToken?) {
-    didConvert?((eventName, indexName, objectIDs, queryID, userToken))
+  func convertedAfterSearch(eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], queryID: QueryID, timestamp: Date?, userToken: UserToken?) {
+    didConvert?((eventName, indexName, objectIDs, queryID, timestamp, userToken))
   }
 
-  func viewed(eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], userToken: UserToken?) {
-    didView?((eventName, indexName, objectIDs, userToken))
+  func viewed(eventName: EventName, indexName: IndexName, objectIDs: [ObjectID], timestamp: Date?, userToken: UserToken?) {
+    didView?((eventName, indexName, objectIDs, timestamp, userToken))
   }
 
 }

--- a/Tests/InstantSearchInsightsTests/Helpers/TestEventTracker.swift
+++ b/Tests/InstantSearchInsightsTests/Helpers/TestEventTracker.swift
@@ -11,45 +11,45 @@ import AlgoliaSearchClient
 
 class TestEventTracker: EventTrackable {
   
-  var didViewObjects: ((EventName, IndexName, UserToken?, [ObjectID]) -> Void)?
-  var didViewFilters: ((EventName, IndexName, UserToken?, [String]) -> Void)?
-  var didClickObjects: ((EventName, IndexName, UserToken?, [ObjectID]) -> Void)?
-  var didClickObjectsAfterSearch: ((EventName, IndexName, UserToken?, [ObjectID], [Int], QueryID) -> Void)?
-  var didClickFilters: ((EventName, IndexName, UserToken?, [String]) -> Void)?
-  var didConvertObjects: ((EventName, IndexName, UserToken?, [ObjectID]) -> Void)?
-  var didConvertObjectsAfterSearch: ((EventName, IndexName, UserToken?, [ObjectID], QueryID) -> Void)?
-  var didConvertFilters: ((EventName, IndexName, UserToken?, [String]) -> Void)?
+  var didViewObjects: ((EventName, IndexName, UserToken?, Date?, [ObjectID]) -> Void)?
+  var didViewFilters: ((EventName, IndexName, UserToken?, Date?, [String]) -> Void)?
+  var didClickObjects: ((EventName, IndexName, UserToken?, Date?, [ObjectID]) -> Void)?
+  var didClickObjectsAfterSearch: ((EventName, IndexName, UserToken?, Date?, [ObjectID], [Int], QueryID) -> Void)?
+  var didClickFilters: ((EventName, IndexName, UserToken?, Date?, [String]) -> Void)?
+  var didConvertObjects: ((EventName, IndexName, UserToken?, Date?, [ObjectID]) -> Void)?
+  var didConvertObjectsAfterSearch: ((EventName, IndexName, UserToken?, Date?, [ObjectID], QueryID) -> Void)?
+  var didConvertFilters: ((EventName, IndexName, UserToken?, Date?, [String]) -> Void)?
   
-  func view(eventName: EventName, indexName: IndexName, userToken: UserToken?, objectIDs: [ObjectID]) {
-    didViewObjects?(eventName, indexName, userToken, objectIDs)
+  func view(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, objectIDs: [ObjectID]) {
+    didViewObjects?(eventName, indexName, userToken, timestamp, objectIDs)
   }
   
-  func view(eventName: EventName, indexName: IndexName, userToken: UserToken?, filters: [String]) {
-    didViewFilters?(eventName, indexName, userToken, filters)
+  func view(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, filters: [String]) {
+    didViewFilters?(eventName, indexName, userToken, timestamp, filters)
   }
   
-  func click(eventName: EventName, indexName: IndexName, userToken: UserToken?, objectIDs: [ObjectID]) {
-    didClickObjects?(eventName, indexName, userToken, objectIDs)
+  func click(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, objectIDs: [ObjectID]) {
+    didClickObjects?(eventName, indexName, userToken, timestamp, objectIDs)
   }
   
-  func click(eventName: EventName, indexName: IndexName, userToken: UserToken?, objectIDs: [ObjectID], positions: [Int], queryID: QueryID) {
-    didClickObjectsAfterSearch?(eventName, indexName, userToken, objectIDs, positions, queryID)
+  func click(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, objectIDs: [ObjectID], positions: [Int], queryID: QueryID) {
+    didClickObjectsAfterSearch?(eventName, indexName, userToken, timestamp, objectIDs, positions, queryID)
   }
   
-  func click(eventName: EventName, indexName: IndexName, userToken: UserToken?, filters: [String]) {
-    didClickFilters?(eventName, indexName, userToken, filters)
+  func click(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, filters: [String]) {
+    didClickFilters?(eventName, indexName, userToken, timestamp, filters)
   }
   
-  func conversion(eventName: EventName, indexName: IndexName, userToken: UserToken?, objectIDs: [ObjectID]) {
-    didConvertObjects?(eventName, indexName, userToken, objectIDs)
+  func conversion(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, objectIDs: [ObjectID]) {
+    didConvertObjects?(eventName, indexName, userToken, timestamp, objectIDs)
   }
   
-  func conversion(eventName: EventName, indexName: IndexName, userToken: UserToken?, objectIDs: [ObjectID], queryID: QueryID) {
-    didConvertObjectsAfterSearch?(eventName, indexName, userToken, objectIDs, queryID)
+  func conversion(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, objectIDs: [ObjectID], queryID: QueryID) {
+    didConvertObjectsAfterSearch?(eventName, indexName, userToken, timestamp, objectIDs, queryID)
   }
   
-  func conversion(eventName: EventName, indexName: IndexName, userToken: UserToken?, filters: [String]) {
-    didConvertFilters?(eventName, indexName, userToken, filters)
+  func conversion(eventName: EventName, indexName: IndexName, userToken: UserToken?, timestamp: Date?, filters: [String]) {
+    didConvertFilters?(eventName, indexName, userToken, timestamp, filters)
   }
   
 }

--- a/Tests/InstantSearchInsightsTests/Unit/EventTrackerTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/EventTrackerTests.swift
@@ -168,5 +168,43 @@ class EventTrackerTests: XCTestCase {
     
   }
   
+  func testTimeStampGeneration() {
+    
+    let eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                    logger: PrefixedLogger(prefix: "EventTrackerTests"),
+                                    userToken: .none,
+                                    generateTimestamps: true)
+    
+    let expectGeneratedTimeStamp = expectation(description: "Wait for event processor callback")
+
+    eventProcessor.didProcess = { event in
+      XCTAssertNotNil(event.timestamp)
+      expectGeneratedTimeStamp.fulfill()
+    }
+    
+    eventTracker.conversion(eventName: TestEvent.eventName,
+                            indexName: TestEvent.indexName,
+                            timestamp: nil,
+                            filters: TestEvent.filters)
+    
+    waitForExpectations(timeout: 5, handler: nil)
+    
+    eventTracker.generateTimestamps = false
+    
+    let expectEmptyTimestamp = expectation(description: "Wait for event processor callback")
+
+    eventProcessor.didProcess = { event in
+      XCTAssertNil(event.timestamp)
+      expectEmptyTimestamp.fulfill()
+    }
+    
+    eventTracker.conversion(eventName: TestEvent.eventName,
+                            indexName: TestEvent.indexName,
+                            timestamp: nil,
+                            filters: TestEvent.filters)
+    
+    waitForExpectations(timeout: 5, handler: nil)
+  }
+  
 }
 

--- a/Tests/InstantSearchInsightsTests/Unit/EventTrackerTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/EventTrackerTests.swift
@@ -15,7 +15,10 @@ class EventTrackerTests: XCTestCase {
   var eventTracker: EventTracker!
   
   override func setUp() {
-    eventTracker = EventTracker(eventProcessor: eventProcessor, logger: PrefixedLogger(prefix: "EventTrackerTests"))
+    eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                logger: PrefixedLogger(prefix: "EventTrackerTests"),
+                                userToken: .none,
+                                generateTimestamps: true)
   }
   
   func testViewEventWithObjects() {
@@ -35,6 +38,7 @@ class EventTrackerTests: XCTestCase {
     eventTracker.view(eventName: TestEvent.eventName,
                       indexName: TestEvent.indexName,
                       userToken: TestEvent.userToken,
+                      timestamp: TestEvent.timeStamp,
                       objectIDs: TestEvent.objectIDs)
     
     
@@ -59,6 +63,7 @@ class EventTrackerTests: XCTestCase {
     eventTracker.view(eventName: TestEvent.eventName,
                       indexName: TestEvent.indexName,
                       userToken: TestEvent.userToken,
+                      timestamp: TestEvent.timeStamp,
                       filters: TestEvent.filters)
     
     waitForExpectations(timeout: 5, handler: nil)
@@ -82,6 +87,7 @@ class EventTrackerTests: XCTestCase {
     eventTracker.click(eventName: TestEvent.eventName,
                        indexName: TestEvent.indexName,
                        userToken: TestEvent.userToken,
+                       timestamp: TestEvent.timeStamp,
                        objectIDs: TestEvent.objectIDs)
     
     waitForExpectations(timeout: 5, handler: nil)
@@ -105,6 +111,7 @@ class EventTrackerTests: XCTestCase {
     eventTracker.click(eventName: TestEvent.eventName,
                        indexName: TestEvent.indexName,
                        userToken: TestEvent.userToken,
+                       timestamp: TestEvent.timeStamp,
                        filters: TestEvent.filters)
     
     waitForExpectations(timeout: 5, handler: nil)
@@ -129,6 +136,7 @@ class EventTrackerTests: XCTestCase {
     eventTracker.conversion(eventName: TestEvent.eventName,
                             indexName: TestEvent.indexName,
                             userToken: TestEvent.userToken,
+                            timestamp: TestEvent.timeStamp,
                             objectIDs: TestEvent.objectIDs)
     
     waitForExpectations(timeout: 5, handler: nil)
@@ -153,6 +161,7 @@ class EventTrackerTests: XCTestCase {
     eventTracker.conversion(eventName: TestEvent.eventName,
                             indexName: TestEvent.indexName,
                             userToken: TestEvent.userToken,
+                            timestamp: TestEvent.timeStamp,
                             filters: TestEvent.filters)
     
     waitForExpectations(timeout: 5, handler: nil)

--- a/Tests/InstantSearchInsightsTests/Unit/InsightsTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/InsightsTests.swift
@@ -55,7 +55,7 @@ class InsightsTests: XCTestCase {
     let exp = expectation(description: "callback expectation")
     exp.expectedFulfillmentCount = 3
     
-    testEventTracker.didClickObjectsAfterSearch = { eventName, indexName, userToken, objectIDs, positions, queryID in
+    testEventTracker.didClickObjectsAfterSearch = { eventName, indexName, userToken, _, objectIDs, positions, queryID in
       exp.fulfill()
       XCTAssertEqual(TestEvent.queryID, queryID)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -97,7 +97,7 @@ class InsightsTests: XCTestCase {
     let exp = expectation(description: "callback expectation")
     exp.expectedFulfillmentCount = 2
     
-    testEventTracker.didConvertObjectsAfterSearch = { eventName, indexName, userToken, objectIDs, queryID in
+    testEventTracker.didConvertObjectsAfterSearch = { eventName, indexName, userToken, _, objectIDs, queryID in
       exp.fulfill()
       XCTAssertEqual(TestEvent.queryID, queryID)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -130,7 +130,7 @@ class InsightsTests: XCTestCase {
     let exp = expectation(description: "callback expectation")
     exp.expectedFulfillmentCount = 2
     
-    testEventTracker.didClickObjects = { eventName, indexName, userToken, objectIDs in
+    testEventTracker.didClickObjects = { eventName, indexName, userToken, _, objectIDs in
       
       exp.fulfill()
       XCTAssertEqual(TestEvent.eventName, eventName)
@@ -161,7 +161,7 @@ class InsightsTests: XCTestCase {
   func testClickWithFilters() {
     let exp = expectation(description: "callback expectation")
     
-    testEventTracker.didClickFilters = { eventName, indexName, userToken, filters in
+    testEventTracker.didClickFilters = { eventName, indexName, userToken, _, filters in
       exp.fulfill()
       XCTAssertEqual(TestEvent.eventName, eventName)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -182,7 +182,7 @@ class InsightsTests: XCTestCase {
     let exp = expectation(description: "callback expectation")
     exp.expectedFulfillmentCount = 2
     
-    testEventTracker.didConvertObjects = { eventName, indexName, userToken, objectIDs in
+    testEventTracker.didConvertObjects = { eventName, indexName, userToken, _, objectIDs in
       exp.fulfill()
       XCTAssertEqual(TestEvent.eventName, eventName)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -210,7 +210,7 @@ class InsightsTests: XCTestCase {
   func testConversionWithFilters() {
     let exp = expectation(description: "callback expectation")
     
-    testEventTracker.didConvertFilters = { eventName, indexName, userToken, filters in
+    testEventTracker.didConvertFilters = { eventName, indexName, userToken, _, filters in
       exp.fulfill()
       XCTAssertEqual(TestEvent.eventName, eventName)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -231,7 +231,7 @@ class InsightsTests: XCTestCase {
     let exp = expectation(description: "callback expectation")
     exp.expectedFulfillmentCount = 2
     
-    testEventTracker.didViewObjects = { eventName, indexName, userToken, objectIDs in
+    testEventTracker.didViewObjects = { eventName, indexName, userToken, _, objectIDs in
       exp.fulfill()
       XCTAssertEqual(TestEvent.eventName, eventName)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -259,7 +259,14 @@ class InsightsTests: XCTestCase {
   func testViewWithFilters() {
     let exp = expectation(description: "callback expectation")
     
-    testEventTracker.didViewFilters = { eventName, indexName, userToken, filters in
+    testEventTracker.didViewFilters = { eventName, indexName, userToken, _, filters in
+      exp.fulfill()
+      XCTAssertEqual(TestEvent.eventName, eventName)
+      XCTAssertEqual(TestEvent.userToken, userToken)
+      XCTAssertEqual(TestEvent.indexName, indexName)
+      XCTAssertEqual(TestEvent.filters, filters)
+    }
+    testEventTracker.didViewFilters = { eventName, indexName, userToken, _, filters in
       exp.fulfill()
       XCTAssertEqual(TestEvent.eventName, eventName)
       XCTAssertEqual(TestEvent.userToken, userToken)
@@ -289,7 +296,14 @@ class InsightsTests: XCTestCase {
                                         flushDelay: 1,
                                         logger: logger)
     
-    let insights = Insights(eventsProcessor: eventProcessor, logger: logger)
+    let eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                    logger: logger,
+                                    userToken: .none,
+                                    generateTimestamps: true)
+    
+    let insights = Insights(eventProcessor: eventProcessor,
+                            eventTracker: eventTracker,
+                            logger: logger)
     
     insights.clickedAfterSearch(eventName: TestEvent.eventName,
                                 indexName: TestEvent.indexName,
@@ -312,8 +326,15 @@ class InsightsTests: XCTestCase {
     
     let logger = PrefixedLogger(prefix: #function)
     
-    let insights = Insights(eventsProcessor: eventProcessor, logger: logger)
+    let eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                    logger: logger,
+                                    userToken: .none,
+                                    generateTimestamps: true)
     
+    let insights = Insights(eventProcessor: eventProcessor,
+                            eventTracker: eventTracker,
+                            logger: logger)
+
     insights.clickedAfterSearch(eventName: TestEvent.eventName,
                                 indexName: TestEvent.indexName,
                                 objectIDsWithPositions: TestEvent.objectIDsWithPositions,
@@ -336,7 +357,14 @@ class InsightsTests: XCTestCase {
     
     let logger = PrefixedLogger(prefix: #function)
     
-    let insights = Insights(eventsProcessor: eventProcessor, userToken: "global_token", logger: logger)
+    let eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                    logger: logger,
+                                    userToken: "global_token",
+                                    generateTimestamps: true)
+    
+    let insights = Insights(eventProcessor: eventProcessor,
+                            eventTracker: eventTracker,
+                            logger: logger)
     
     insights.clickedAfterSearch(eventName: TestEvent.eventName,
                                 indexName: TestEvent.indexName,
@@ -353,9 +381,13 @@ class InsightsTests: XCTestCase {
     
     let eventProcessor = TestEventProcessor()
     let logger = PrefixedLogger(prefix: #function)
+    let eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                    logger: logger,
+                                    userToken: userToken,
+                                    generateTimestamps: true)
     
-    let insights = Insights(eventsProcessor: eventProcessor,
-                            userToken: userToken,
+    let insights = Insights(eventProcessor: eventProcessor,
+                            eventTracker: eventTracker,
                             logger: logger)
     
     XCTAssertEqual(insights.userToken, userToken)
@@ -383,6 +415,37 @@ class InsightsTests: XCTestCase {
     
     XCTAssertEqual(Insights.shared(appId: "myAppID")?.userToken, modifiedUserToken)
     
+    
+  }
+  
+  func testExpiredEventsPurge() {
+    
+    let exp = expectation(description: "process event expectation")
+        
+    let eventProcessor = TestEventProcessor()
+    let logger = PrefixedLogger(prefix: #function)
+
+    let eventTracker = EventTracker(eventProcessor: eventProcessor,
+                                    logger: logger,
+                                    userToken: "global_token",
+                                    generateTimestamps: true)
+    
+    eventProcessor.didProcess = { event in
+      XCTAssertEqual("global_token", event.userToken)
+      exp.fulfill()
+    }
+    
+    let insights = Insights(eventProcessor: eventProcessor,
+                            eventTracker: eventTracker,
+                            logger: logger)
+    
+    insights.clickedAfterSearch(eventName: TestEvent.eventName,
+                                indexName: TestEvent.indexName,
+                                objectIDsWithPositions: TestEvent.objectIDsWithPositions,
+                                queryID: TestEvent.queryID)
+    
+    waitForExpectations(timeout: 5, handler: nil)
+
     
   }
   


### PR DESCRIPTION
**Summary**

- Add automatic removal of expired events from the package before sending them (fixes #192)
- Add `generateTimestamps` flag to define if the event timestamps might attributed automatically or explicitly