### PR TITLE
fix: Carthage build

### DIFF
--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -1,0 +1,14 @@
+name: Carthage
+on: [pull_request]
+jobs:
+  check-Carthage:
+    runs-on: macos-11
+    steps:
+     - uses: actions/checkout@v2
+     - name: Select Xcode version
+       run: sudo xcode-select -s '/Applications/Xcode_13.2.app/Contents/Developer'
+     - name: Initialize Cartfile
+       run: |
+        touch Cartfile
+        pwd
+        ls

--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -11,4 +11,4 @@ jobs:
        run: |
         pwd
         ls
-        tee Cartfile <<<"github \"algolia/instantsearch-ios\" \"${GITHUB_REF##*/}\""
+        tee Cartfile <<<"github \"algolia/instantsearch-ios\" \"${{ github.head_ref }}\""

--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -11,5 +11,4 @@ jobs:
        run: |
         pwd
         ls
-        touch Cartfile
-        tee Cartfile <<<'github "algolia/instantsearch-ios" "${GITHUB_REF##*/}"'
+        tee Cartfile <<<"github \"algolia/instantsearch-ios\" \"${GITHUB_REF##*/}\""

--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -12,3 +12,6 @@ jobs:
         pwd
         ls
         tee Cartfile <<<"github \"algolia/instantsearch-ios\" \"${{ github.head_ref }}\""
+        carthage update --no-build
+        sh ./Carthage/Checkouts/instantsearch-ios/carthage-prebuild
+        carthage build --use-xcframeworks --platform ios

--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -4,11 +4,12 @@ jobs:
   check-Carthage:
     runs-on: macos-11
     steps:
-     - uses: actions/checkout@v2
+    #  - uses: actions/checkout@v2
      - name: Select Xcode version
        run: sudo xcode-select -s '/Applications/Xcode_13.2.app/Contents/Developer'
      - name: Initialize Cartfile
        run: |
-        touch Cartfile
         pwd
         ls
+        touch Cartfile
+        tee Cartfile <<<'github "algolia/instantsearch-ios" "${GITHUB_REF##*/}"'

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,3 @@
-github "algolia/algoliasearch-client-swift" ~> 8.14
-#github "algolia/instantsearch-telemetry-native" 
 github "apple/swift-log" ~> 1.4
-git "file:///Users/vladislav.fitc/Workspace/algolia/instantsearch-telemetry-native" "fix/carthage-build"
+github "algolia/algoliasearch-client-swift" ~> 8.14
+github "algolia/instantsearch-telemetry-native" "fix/carthage-build"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "apple/swift-log" ~> 1.4
 github "algolia/algoliasearch-client-swift" ~> 8.14
-github "algolia/instantsearch-telemetry-native" ~> 0.1.1
+github "algolia/instantsearch-telemetry-native" ~> 0.1.2

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "apple/swift-log" ~> 1.4
 github "algolia/algoliasearch-client-swift" ~> 8.14
-github "algolia/instantsearch-telemetry-native" "fix/carthage-build"
+github "algolia/instantsearch-telemetry-native" ~> 0.1.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
-github "algolia/algoliasearch-client-swift" ~> 8.13
-github "algolia/instantsearch-telemetry-native" ~> 0.1.0-beta1
+github "algolia/algoliasearch-client-swift" ~> 8.14
+#github "algolia/instantsearch-telemetry-native" 
 github "apple/swift-log" ~> 1.4
+git "file:///Users/vladislav.fitc/Workspace/algolia/instantsearch-telemetry-native" "fix/carthage-build"

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.13'
       ss.dependency 'InstantSearch/Insights'
-      ss.dependency 'InstantSearchTelemetry', '~> 0.1.0'
+      ss.dependency 'InstantSearchTelemetry', '~> 0.1.1'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.watchos.deployment_target = '3.0'

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'InstantSearch'
   s.version = '7.17.0'
-  s.platforms = { :ios => "9.0", :osx => "10.13", :watchos => "3.0", :tvos => "9.0" }
+  s.platforms = { :ios => "9.0", :osx => "10.11", :watchos => "2.0", :tvos => "9.0" }
 
   s.license = { type: 'Apache 2.0', file: 'LICENSE.md' }
   s.summary = 'A library of widgets and helpers to build instant-search applications on iOS.'
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
       ss.dependency 'AlgoliaSearchClient', '~> 8.13'
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
-      ss.watchos.deployment_target = '3.0'
+      ss.watchos.deployment_target = '2.0'
       ss.tvos.deployment_target = '9.0'
   end
   
@@ -26,10 +26,10 @@ Pod::Spec.new do |s|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.13'
       ss.dependency 'InstantSearch/Insights'
-      ss.dependency 'InstantSearchTelemetry', '~> 0.1.1'
+      ss.dependency 'InstantSearchTelemetry', '~> 0.1.2'
       ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.13'
-      ss.watchos.deployment_target = '3.0'
+      ss.osx.deployment_target = '10.11'
+      ss.watchos.deployment_target = '2.0'
       ss.tvos.deployment_target = '9.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
   end
@@ -38,8 +38,8 @@ Pod::Spec.new do |s|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
       ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.13'
-      ss.watchos.deployment_target = '3.0'
+      ss.osx.deployment_target = '10.11'
+      ss.watchos.deployment_target = '2.0'
       ss.tvos.deployment_target = '9.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
   end

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'InstantSearch'
   s.version = '7.17.0'
-  s.platforms = { :ios => "9.0", :osx => "10.10", :watchos => "3.0", :tvos => "9.0" }
+  s.platforms = { :ios => "9.0", :osx => "10.13", :watchos => "3.0", :tvos => "9.0" }
 
   s.license = { type: 'Apache 2.0', file: 'LICENSE.md' }
   s.summary = 'A library of widgets and helpers to build instant-search applications on iOS.'
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
       ss.dependency 'InstantSearch/Insights'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.1'
       ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
+      ss.osx.deployment_target = '10.13'
       ss.watchos.deployment_target = '3.0'
       ss.tvos.deployment_target = '9.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
       ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
+      ss.osx.deployment_target = '10.13'
       ss.watchos.deployment_target = '3.0'
       ss.tvos.deployment_target = '9.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }

--- a/InstantSearch.xcodeproj/AlgoliaSearchClient_Info.plist
+++ b/InstantSearch.xcodeproj/AlgoliaSearchClient_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchCoreTests_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchCoreTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchCore_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchCore_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchInsightsTests_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchInsightsTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchInsights_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchInsights_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchSwiftUITests_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchSwiftUITests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchSwiftUI_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchSwiftUI_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchTelemetry_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchTelemetry_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearchTests_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearchTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/InstantSearch_Info.plist
+++ b/InstantSearch.xcodeproj/InstantSearch_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/Logging_Info.plist
+++ b/InstantSearch.xcodeproj/Logging_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/SwiftProtobuf_Info.plist
+++ b/InstantSearch.xcodeproj/SwiftProtobuf_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/project.pbxproj
+++ b/InstantSearch.xcodeproj/project.pbxproj
@@ -1,0 +1,7778 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"instantsearch-ios::InstantSearchPackageTests::ProductTarget" /* InstantSearchPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_2044 /* Build configuration list for PBXAggregateTarget "InstantSearchPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_2047 /* PBXTargetDependency */,
+				OBJ_2049 /* PBXTargetDependency */,
+				OBJ_2051 /* PBXTargetDependency */,
+				OBJ_2052 /* PBXTargetDependency */,
+			);
+			name = InstantSearchPackageTests;
+			productName = InstantSearchPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_1175 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_757 /* AsyncOperation.swift */; };
+		OBJ_1176 /* WaitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_758 /* WaitTask.swift */; };
+		OBJ_1177 /* AccountClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_760 /* AccountClient.swift */; };
+		OBJ_1178 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_761 /* AnalyticsClient.swift */; };
+		OBJ_1179 /* InsightsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_762 /* InsightsClient.swift */; };
+		OBJ_1180 /* PersonalizationClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_763 /* PersonalizationClient.swift */; };
+		OBJ_1181 /* PlacesClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_764 /* PlacesClient.swift */; };
+		OBJ_1182 /* RecommendClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_765 /* RecommendClient.swift */; };
+		OBJ_1183 /* SearchClient+APIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_767 /* SearchClient+APIKey.swift */; };
+		OBJ_1184 /* SearchClient+Dictionaries.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_768 /* SearchClient+Dictionaries.swift */; };
+		OBJ_1185 /* SearchClient+Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_769 /* SearchClient+Logs.swift */; };
+		OBJ_1186 /* SearchClient+Management.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_770 /* SearchClient+Management.swift */; };
+		OBJ_1187 /* SearchClient+MultiCluster.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_771 /* SearchClient+MultiCluster.swift */; };
+		OBJ_1188 /* SearchClient+MultiIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_772 /* SearchClient+MultiIndex.swift */; };
+		OBJ_1189 /* SearchClient+SecuredAPIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_773 /* SearchClient+SecuredAPIKey.swift */; };
+		OBJ_1190 /* SearchClient+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_774 /* SearchClient+Wait.swift */; };
+		OBJ_1191 /* SearchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_775 /* SearchClient.swift */; };
+		OBJ_1192 /* AlgoliaCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_777 /* AlgoliaCommand.swift */; };
+		OBJ_1193 /* Command+ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_778 /* Command+ABTest.swift */; };
+		OBJ_1194 /* Command+APIKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_779 /* Command+APIKeys.swift */; };
+		OBJ_1195 /* Command+Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_780 /* Command+Advanced.swift */; };
+		OBJ_1196 /* Command+Answers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_781 /* Command+Answers.swift */; };
+		OBJ_1197 /* Command+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_782 /* Command+Custom.swift */; };
+		OBJ_1198 /* Command+Dictionaries.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_783 /* Command+Dictionaries.swift */; };
+		OBJ_1199 /* Command+Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_784 /* Command+Index.swift */; };
+		OBJ_1200 /* Command+Indexing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_785 /* Command+Indexing.swift */; };
+		OBJ_1201 /* Command+Insights.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_786 /* Command+Insights.swift */; };
+		OBJ_1202 /* Command+MultiCluster.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_787 /* Command+MultiCluster.swift */; };
+		OBJ_1203 /* Command+MultipleIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_788 /* Command+MultipleIndex.swift */; };
+		OBJ_1204 /* Command+Personalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_789 /* Command+Personalization.swift */; };
+		OBJ_1205 /* Command+Places.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_790 /* Command+Places.swift */; };
+		OBJ_1206 /* Command+Recommend.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_791 /* Command+Recommend.swift */; };
+		OBJ_1207 /* Command+Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_792 /* Command+Rule.swift */; };
+		OBJ_1208 /* Command+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_793 /* Command+Search.swift */; };
+		OBJ_1209 /* Command+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_794 /* Command+Settings.swift */; };
+		OBJ_1210 /* Command+Synonym.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_795 /* Command+Synonym.swift */; };
+		OBJ_1211 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_796 /* Command.swift */; };
+		OBJ_1212 /* AssertionTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_798 /* AssertionTestHelper.swift */; };
+		OBJ_1213 /* CustomParametersCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_800 /* CustomParametersCoder.swift */; };
+		OBJ_1214 /* ClientDateCodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_802 /* ClientDateCodingStrategy.swift */; };
+		OBJ_1215 /* KeyedDecodingContainer+DateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_803 /* KeyedDecodingContainer+DateFormat.swift */; };
+		OBJ_1216 /* KeyedEncodingContainer+DateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_804 /* KeyedEncodingContainer+DateFormat.swift */; };
+		OBJ_1217 /* DecodingErrorPrettyPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_805 /* DecodingErrorPrettyPrinter.swift */; };
+		OBJ_1218 /* DynamicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_806 /* DynamicKey.swift */; };
+		OBJ_1219 /* Encodiable+HTTPBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_807 /* Encodiable+HTTPBody.swift */; };
+		OBJ_1220 /* KeyedDecodingContainer+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_808 /* KeyedDecodingContainer+Convenience.swift */; };
+		OBJ_1221 /* BoolContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_810 /* BoolContainer.swift */; };
+		OBJ_1222 /* CustomKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_811 /* CustomKey.swift */; };
+		OBJ_1223 /* StringNumberContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_812 /* StringNumberContainer.swift */; };
+		OBJ_1224 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_814 /* HMAC.swift */; };
+		OBJ_1225 /* String+HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_815 /* String+HMAC.swift */; };
+		OBJ_1226 /* Array+Chunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_817 /* Array+Chunks.swift */; };
+		OBJ_1227 /* Data+JSONString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_818 /* Data+JSONString.swift */; };
+		OBJ_1228 /* Dictionary+Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_819 /* Dictionary+Merging.swift */; };
+		OBJ_1229 /* Optional+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_820 /* Optional+Convenience.swift */; };
+		OBJ_1230 /* TimeInterval+Minutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_821 /* TimeInterval+Minutes.swift */; };
+		OBJ_1231 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_822 /* Logging.swift */; };
+		OBJ_1232 /* ObjectIDChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_823 /* ObjectIDChecker.swift */; };
+		OBJ_1233 /* Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_825 /* Builder.swift */; };
+		OBJ_1234 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_826 /* Cancellable.swift */; };
+		OBJ_1235 /* ResultContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_827 /* ResultContainer.swift */; };
+		OBJ_1236 /* URLEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_828 /* URLEncodable.swift */; };
+		OBJ_1237 /* ResultCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_829 /* ResultCallback.swift */; };
+		OBJ_1238 /* String+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_831 /* String+Base64.swift */; };
+		OBJ_1239 /* String+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_832 /* String+Environment.swift */; };
+		OBJ_1240 /* String+Wrapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_833 /* String+Wrapping.swift */; };
+		OBJ_1241 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_835 /* UserAgent.swift */; };
+		OBJ_1242 /* UserAgentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_836 /* UserAgentController.swift */; };
+		OBJ_1243 /* Version+Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_837 /* Version+Current.swift */; };
+		OBJ_1244 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_838 /* Version.swift */; };
+		OBJ_1245 /* AnyWaitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_840 /* AnyWaitable.swift */; };
+		OBJ_1246 /* TaskWaitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_841 /* TaskWaitable.swift */; };
+		OBJ_1247 /* Waitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_842 /* Waitable.swift */; };
+		OBJ_1248 /* WaitableWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_843 /* WaitableWrapper.swift */; };
+		OBJ_1249 /* Index+Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_845 /* Index+Advanced.swift */; };
+		OBJ_1250 /* Index+Answers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_846 /* Index+Answers.swift */; };
+		OBJ_1251 /* Index+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_847 /* Index+Export.swift */; };
+		OBJ_1252 /* Index+Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_848 /* Index+Index.swift */; };
+		OBJ_1253 /* Index+Indexing.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_849 /* Index+Indexing.swift */; };
+		OBJ_1254 /* Index+Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_850 /* Index+Logs.swift */; };
+		OBJ_1255 /* Index+Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_851 /* Index+Rule.swift */; };
+		OBJ_1256 /* Index+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_852 /* Index+Search.swift */; };
+		OBJ_1257 /* Index+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_853 /* Index+Settings.swift */; };
+		OBJ_1258 /* Index+Synonym.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_854 /* Index+Synonym.swift */; };
+		OBJ_1259 /* Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_855 /* Index.swift */; };
+		OBJ_1260 /* ACL.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_858 /* ACL.swift */; };
+		OBJ_1261 /* APIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_859 /* APIKey.swift */; };
+		OBJ_1262 /* APIKeyCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_860 /* APIKeyCreation.swift */; };
+		OBJ_1263 /* APIKeyDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_861 /* APIKeyDeletion.swift */; };
+		OBJ_1264 /* APIKeyParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_862 /* APIKeyParameters.swift */; };
+		OBJ_1265 /* APIKeyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_863 /* APIKeyResponse.swift */; };
+		OBJ_1266 /* APIKeyRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_864 /* APIKeyRevision.swift */; };
+		OBJ_1267 /* ListAPIKeysResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_865 /* ListAPIKeysResponse.swift */; };
+		OBJ_1268 /* SecuredAPIKeyRestriction.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_867 /* SecuredAPIKeyRestriction.swift */; };
+		OBJ_1269 /* ABTest+Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_870 /* ABTest+Variant.swift */; };
+		OBJ_1270 /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_871 /* ABTest.swift */; };
+		OBJ_1271 /* ABTestID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_872 /* ABTestID.swift */; };
+		OBJ_1272 /* ABTestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_873 /* ABTestStatus.swift */; };
+		OBJ_1273 /* ABTestResponse+Variant.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_875 /* ABTestResponse+Variant.swift */; };
+		OBJ_1274 /* ABTestResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_876 /* ABTestResponse.swift */; };
+		OBJ_1275 /* ABTestShortResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_877 /* ABTestShortResponse.swift */; };
+		OBJ_1276 /* ABTestsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_878 /* ABTestsResponse.swift */; };
+		OBJ_1277 /* ABTestCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_880 /* ABTestCreation.swift */; };
+		OBJ_1278 /* ABTestDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_881 /* ABTestDeletion.swift */; };
+		OBJ_1279 /* ABTestRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_882 /* ABTestRevision.swift */; };
+		OBJ_1280 /* AnalyticsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_883 /* AnalyticsConfiguration.swift */; };
+		OBJ_1281 /* AnswersQuery+Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_885 /* AnswersQuery+Language.swift */; };
+		OBJ_1282 /* AnswersQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_886 /* AnswersQuery.swift */; };
+		OBJ_1283 /* AppRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_888 /* AppRevision.swift */; };
+		OBJ_1284 /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_889 /* Attribute.swift */; };
+		OBJ_1285 /* CommonParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_890 /* CommonParameters.swift */; };
+		OBJ_1286 /* AlgoliaCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_892 /* AlgoliaCredentials.swift */; };
+		OBJ_1287 /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_893 /* Credentials.swift */; };
+		OBJ_1288 /* ObjectID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_894 /* ObjectID.swift */; };
+		OBJ_1289 /* Region.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_895 /* Region.swift */; };
+		OBJ_1290 /* RequestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_896 /* RequestOptions.swift */; };
+		OBJ_1291 /* ResponseField.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_897 /* ResponseField.swift */; };
+		OBJ_1292 /* Revision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_898 /* Revision.swift */; };
+		OBJ_1293 /* StringOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_899 /* StringOption.swift */; };
+		OBJ_1294 /* StringWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_900 /* StringWrapper.swift */; };
+		OBJ_1295 /* TimeRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_901 /* TimeRange.swift */; };
+		OBJ_1296 /* UserToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_902 /* UserToken.swift */; };
+		OBJ_1297 /* FieldWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_904 /* FieldWrapper.swift */; };
+		OBJ_1298 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_905 /* JSON.swift */; };
+		OBJ_1299 /* PrefixedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_906 /* PrefixedString.swift */; };
+		OBJ_1300 /* SingleOrList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_907 /* SingleOrList.swift */; };
+		OBJ_1301 /* TreeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_908 /* TreeModel.swift */; };
+		OBJ_1302 /* CompoundsDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_910 /* CompoundsDictionary.swift */; };
+		OBJ_1303 /* CustomDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_911 /* CustomDictionary.swift */; };
+		OBJ_1304 /* DictionaryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_912 /* DictionaryEntry.swift */; };
+		OBJ_1305 /* DictionaryName.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_913 /* DictionaryName.swift */; };
+		OBJ_1306 /* DictionaryQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_914 /* DictionaryQuery.swift */; };
+		OBJ_1307 /* DictionaryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_915 /* DictionaryRequest.swift */; };
+		OBJ_1308 /* DictionaryRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_916 /* DictionaryRevision.swift */; };
+		OBJ_1309 /* DictionarySearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_917 /* DictionarySearchResponse.swift */; };
+		OBJ_1310 /* DictionarySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_918 /* DictionarySettings.swift */; };
+		OBJ_1311 /* PluralsDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_919 /* PluralsDictionary.swift */; };
+		OBJ_1312 /* StopwordsDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_920 /* StopwordsDictionary.swift */; };
+		OBJ_1313 /* EventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_923 /* EventName.swift */; };
+		OBJ_1314 /* EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_924 /* EventType.swift */; };
+		OBJ_1315 /* InsightsEvent+Click.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_925 /* InsightsEvent+Click.swift */; };
+		OBJ_1316 /* InsightsEvent+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_926 /* InsightsEvent+Conversion.swift */; };
+		OBJ_1317 /* InsightsEvent+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_927 /* InsightsEvent+View.swift */; };
+		OBJ_1318 /* InsightsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_928 /* InsightsEvent.swift */; };
+		OBJ_1319 /* EventConstructionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_929 /* EventConstructionError.swift */; };
+		OBJ_1320 /* InsightsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_930 /* InsightsConfiguration.swift */; };
+		OBJ_1321 /* InsightsEvent+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_931 /* InsightsEvent+Resources.swift */; };
+		OBJ_1322 /* CallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_933 /* CallType.swift */; };
+		OBJ_1323 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_934 /* Configuration.swift */; };
+		OBJ_1324 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_935 /* Empty.swift */; };
+		OBJ_1325 /* HTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_937 /* HTTPError.swift */; };
+		OBJ_1326 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_938 /* HTTPMethod.swift */; };
+		OBJ_1327 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_939 /* HTTPStatusCode.swift */; };
+		OBJ_1328 /* Hosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_940 /* Hosts.swift */; };
+		OBJ_1329 /* URL+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_941 /* URL+Convenience.swift */; };
+		OBJ_1330 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_943 /* Log.swift */; };
+		OBJ_1331 /* LogType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_944 /* LogType.swift */; };
+		OBJ_1332 /* LogsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_945 /* LogsResponse.swift */; };
+		OBJ_1333 /* Cluster.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_947 /* Cluster.swift */; };
+		OBJ_1334 /* ClusterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_948 /* ClusterName.swift */; };
+		OBJ_1335 /* ClustersListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_949 /* ClustersListResponse.swift */; };
+		OBJ_1336 /* HasPendingMappingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_950 /* HasPendingMappingResponse.swift */; };
+		OBJ_1337 /* Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_952 /* Creation.swift */; };
+		OBJ_1338 /* Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_953 /* Deletion.swift */; };
+		OBJ_1339 /* TopUserIDResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_954 /* TopUserIDResponse.swift */; };
+		OBJ_1340 /* UserID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_955 /* UserID.swift */; };
+		OBJ_1341 /* UserIDListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_956 /* UserIDListResponse.swift */; };
+		OBJ_1342 /* UserIDQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_957 /* UserIDQuery.swift */; };
+		OBJ_1343 /* UserIDResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_958 /* UserIDResponse.swift */; };
+		OBJ_1344 /* UserIDSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_959 /* UserIDSearchResponse.swift */; };
+		OBJ_1345 /* EventScoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_961 /* EventScoring.swift */; };
+		OBJ_1346 /* FacetScoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_962 /* FacetScoring.swift */; };
+		OBJ_1347 /* PersonalizationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_963 /* PersonalizationConfiguration.swift */; };
+		OBJ_1348 /* PersonalizationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_964 /* PersonalizationStrategy.swift */; };
+		OBJ_1349 /* SetStrategyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_965 /* SetStrategyResponse.swift */; };
+		OBJ_1350 /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_967 /* Country.swift */; };
+		OBJ_1351 /* MultiLanguagePlace.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_968 /* MultiLanguagePlace.swift */; };
+		OBJ_1352 /* Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_969 /* Place.swift */; };
+		OBJ_1353 /* PlaceCodingKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_970 /* PlaceCodingKeys.swift */; };
+		OBJ_1354 /* PlaceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_971 /* PlaceType.swift */; };
+		OBJ_1355 /* PlacesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_972 /* PlacesConfiguration.swift */; };
+		OBJ_1356 /* PlacesQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_973 /* PlacesQuery.swift */; };
+		OBJ_1357 /* PlacesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_974 /* PlacesResponse.swift */; };
+		OBJ_1358 /* RecommendationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_976 /* RecommendationModel.swift */; };
+		OBJ_1359 /* RecommendationsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_977 /* RecommendationsOptions.swift */; };
+		OBJ_1360 /* RenderingContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_979 /* RenderingContent.swift */; };
+		OBJ_1361 /* Rule+Alternatives.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_980 /* Rule+Alternatives.swift */; };
+		OBJ_1362 /* Rule+Anchoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_981 /* Rule+Anchoring.swift */; };
+		OBJ_1363 /* Rule+AutomaticFacetFilters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_982 /* Rule+AutomaticFacetFilters.swift */; };
+		OBJ_1364 /* Rule+Condition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_983 /* Rule+Condition.swift */; };
+		OBJ_1365 /* Rule+Consequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_984 /* Rule+Consequence.swift */; };
+		OBJ_1366 /* Rule+Edit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_985 /* Rule+Edit.swift */; };
+		OBJ_1367 /* Rule+Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_986 /* Rule+Pattern.swift */; };
+		OBJ_1368 /* Rule+Promotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_987 /* Rule+Promotion.swift */; };
+		OBJ_1369 /* Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_988 /* Rule.swift */; };
+		OBJ_1370 /* RuleQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_989 /* RuleQuery.swift */; };
+		OBJ_1371 /* RuleSearchResponse+Hit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_990 /* RuleSearchResponse+Hit.swift */; };
+		OBJ_1372 /* RuleSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_991 /* RuleSearchResponse.swift */; };
+		OBJ_1373 /* ApplicationID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_993 /* ApplicationID.swift */; };
+		OBJ_1374 /* Answer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_995 /* Answer.swift */; };
+		OBJ_1375 /* HighlightResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_996 /* HighlightResult.swift */; };
+		OBJ_1376 /* Hit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_997 /* Hit.swift */; };
+		OBJ_1377 /* MatchLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_998 /* MatchLevel.swift */; };
+		OBJ_1378 /* RankingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_999 /* RankingInfo.swift */; };
+		OBJ_1379 /* SnippetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1000 /* SnippetResult.swift */; };
+		OBJ_1380 /* IndexName.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1001 /* IndexName.swift */; };
+		OBJ_1381 /* BatchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1004 /* BatchOperation.swift */; };
+		OBJ_1382 /* BatchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1005 /* BatchResponse.swift */; };
+		OBJ_1383 /* IndexBatchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1006 /* IndexBatchOperation.swift */; };
+		OBJ_1384 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1007 /* Cursor.swift */; };
+		OBJ_1385 /* IndexOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1008 /* IndexOperation.swift */; };
+		OBJ_1386 /* ObjectRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1009 /* ObjectRequest.swift */; };
+		OBJ_1387 /* ObjectWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1010 /* ObjectWrapper.swift */; };
+		OBJ_1388 /* PartialUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1011 /* PartialUpdate.swift */; };
+		OBJ_1389 /* PartialUpdateAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1012 /* PartialUpdateAction.swift */; };
+		OBJ_1390 /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1013 /* Scope.swift */; };
+		OBJ_1391 /* BatchesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1015 /* BatchesResponse.swift */; };
+		OBJ_1392 /* IndexedFacetQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1016 /* IndexedFacetQuery.swift */; };
+		OBJ_1393 /* IndexedQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1017 /* IndexedQuery.swift */; };
+		OBJ_1394 /* IndicesListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1018 /* IndicesListResponse.swift */; };
+		OBJ_1395 /* MultiSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1019 /* MultiSearchQuery.swift */; };
+		OBJ_1396 /* MultipleQueriesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1020 /* MultipleQueriesRequest.swift */; };
+		OBJ_1397 /* MultipleQueriesStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1021 /* MultipleQueriesStrategy.swift */; };
+		OBJ_1398 /* SearchesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1022 /* SearchesResponse.swift */; };
+		OBJ_1399 /* AroundPrecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1025 /* AroundPrecision.swift */; };
+		OBJ_1400 /* AroundRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1026 /* AroundRadius.swift */; };
+		OBJ_1401 /* BoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1027 /* BoundingBox.swift */; };
+		OBJ_1402 /* ExplainModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1028 /* ExplainModule.swift */; };
+		OBJ_1403 /* FiltersStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1029 /* FiltersStorage.swift */; };
+		OBJ_1404 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1030 /* Point.swift */; };
+		OBJ_1405 /* Polygon.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1031 /* Polygon.swift */; };
+		OBJ_1406 /* DeleteByQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1032 /* DeleteByQuery.swift */; };
+		OBJ_1407 /* Query+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1033 /* Query+Codable.swift */; };
+		OBJ_1408 /* Query+URLEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1034 /* Query+URLEncodable.swift */; };
+		OBJ_1409 /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1035 /* Query.swift */; };
+		OBJ_1410 /* QueryID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1036 /* QueryID.swift */; };
+		OBJ_1411 /* FacetSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1038 /* FacetSearchResponse.swift */; };
+		OBJ_1412 /* HitWithPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1039 /* HitWithPosition.swift */; };
+		OBJ_1413 /* MultiSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1040 /* MultiSearchResponse.swift */; };
+		OBJ_1414 /* ObjectsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1041 /* ObjectsResponse.swift */; };
+		OBJ_1415 /* Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1045 /* Alternative.swift */; };
+		OBJ_1416 /* AlternativeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1046 /* AlternativeType.swift */; };
+		OBJ_1417 /* Explain.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1047 /* Explain.swift */; };
+		OBJ_1418 /* QueryMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1048 /* QueryMatch.swift */; };
+		OBJ_1419 /* Facet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1050 /* Facet.swift */; };
+		OBJ_1420 /* FacetsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1051 /* FacetsStorage.swift */; };
+		OBJ_1421 /* FacetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1053 /* FacetStats.swift */; };
+		OBJ_1422 /* FacetStatsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1054 /* FacetStatsStorage.swift */; };
+		OBJ_1423 /* HighlightedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1056 /* HighlightedString.swift */; };
+		OBJ_1424 /* TaggedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1057 /* TaggedString.swift */; };
+		OBJ_1425 /* FacetOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1060 /* FacetOrdering.swift */; };
+		OBJ_1426 /* FacetValuesOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1061 /* FacetValuesOrder.swift */; };
+		OBJ_1427 /* FacetsOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1062 /* FacetsOrder.swift */; };
+		OBJ_1428 /* SearchResponse+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1063 /* SearchResponse+Codable.swift */; };
+		OBJ_1429 /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1064 /* SearchResponse.swift */; };
+		OBJ_1430 /* SearchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1065 /* SearchConfiguration.swift */; };
+		OBJ_1431 /* SearchParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1066 /* SearchParameters.swift */; };
+		OBJ_1432 /* SearchParametersStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1067 /* SearchParametersStorage.swift */; };
+		OBJ_1433 /* AdvancedSyntaxFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1070 /* AdvancedSyntaxFeatures.swift */; };
+		OBJ_1434 /* AlternativesAsExact.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1071 /* AlternativesAsExact.swift */; };
+		OBJ_1435 /* AttributeForFaceting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1072 /* AttributeForFaceting.swift */; };
+		OBJ_1436 /* CustomRankingCriterion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1073 /* CustomRankingCriterion.swift */; };
+		OBJ_1437 /* DecompoundedAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1074 /* DecompoundedAttributes.swift */; };
+		OBJ_1438 /* Distinct.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1075 /* Distinct.swift */; };
+		OBJ_1439 /* ExactOnSingleWordQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1076 /* ExactOnSingleWordQuery.swift */; };
+		OBJ_1440 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1077 /* Language.swift */; };
+		OBJ_1441 /* LanguageFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1078 /* LanguageFeature.swift */; };
+		OBJ_1442 /* NumericAttributeFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1079 /* NumericAttributeFilter.swift */; };
+		OBJ_1443 /* QueryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1080 /* QueryType.swift */; };
+		OBJ_1444 /* RankingCriterion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1081 /* RankingCriterion.swift */; };
+		OBJ_1445 /* RemoveWordIfNoResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1082 /* RemoveWordIfNoResults.swift */; };
+		OBJ_1446 /* SearchableAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1083 /* SearchableAttribute.swift */; };
+		OBJ_1447 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1084 /* Snippet.swift */; };
+		OBJ_1448 /* SortFacetsBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1085 /* SortFacetsBy.swift */; };
+		OBJ_1449 /* TypoTolerance.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1086 /* TypoTolerance.swift */; };
+		OBJ_1450 /* Settings+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1087 /* Settings+CustomStringConvertible.swift */; };
+		OBJ_1451 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1088 /* Settings.swift */; };
+		OBJ_1452 /* SettingsParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1089 /* SettingsParameters.swift */; };
+		OBJ_1453 /* SettingsParametersCodingKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1090 /* SettingsParametersCodingKeys.swift */; };
+		OBJ_1454 /* SettingsParametersStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1091 /* SettingsParametersStorage.swift */; };
+		OBJ_1455 /* Synonym.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1093 /* Synonym.swift */; };
+		OBJ_1456 /* SynonymQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1094 /* SynonymQuery.swift */; };
+		OBJ_1457 /* SynonymRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1095 /* SynonymRevision.swift */; };
+		OBJ_1458 /* SynonymSearchResponse+Hit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1096 /* SynonymSearchResponse+Hit.swift */; };
+		OBJ_1459 /* SynonymSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1097 /* SynonymSearchResponse.swift */; };
+		OBJ_1460 /* SynonymType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1098 /* SynonymType.swift */; };
+		OBJ_1461 /* AppTaskID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1100 /* AppTaskID.swift */; };
+		OBJ_1462 /* AppTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1102 /* AppTask.swift */; };
+		OBJ_1463 /* IndexTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1103 /* IndexTask.swift */; };
+		OBJ_1464 /* TaskInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1104 /* TaskInfo.swift */; };
+		OBJ_1465 /* TaskStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1105 /* TaskStatus.swift */; };
+		OBJ_1466 /* IndexDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1107 /* IndexDeletion.swift */; };
+		OBJ_1467 /* IndexRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1108 /* IndexRevision.swift */; };
+		OBJ_1468 /* IndexedTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1109 /* IndexedTask.swift */; };
+		OBJ_1469 /* ObjectCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1111 /* ObjectCreation.swift */; };
+		OBJ_1470 /* ObjectDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1112 /* ObjectDeletion.swift */; };
+		OBJ_1471 /* ObjectRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1113 /* ObjectRevision.swift */; };
+		OBJ_1472 /* TaskID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1114 /* TaskID.swift */; };
+		OBJ_1473 /* Transport+CustomRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1117 /* Transport+CustomRequest.swift */; };
+		OBJ_1474 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1118 /* Transport.swift */; };
+		OBJ_1475 /* TransportContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1119 /* TransportContainer.swift */; };
+		OBJ_1476 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1121 /* HTTPRequest.swift */; };
+		OBJ_1477 /* HTTPRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1122 /* HTTPRequestBuilder.swift */; };
+		OBJ_1478 /* HTTPRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1123 /* HTTPRequester.swift */; };
+		OBJ_1479 /* HTTPTransport+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1124 /* HTTPTransport+Error.swift */; };
+		OBJ_1480 /* HTTPTransport+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1125 /* HTTPTransport+Result.swift */; };
+		OBJ_1481 /* HTTPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1126 /* HTTPTransport.swift */; };
+		OBJ_1482 /* OperationLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1127 /* OperationLauncher.swift */; };
+		OBJ_1483 /* AlgoliaRetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1129 /* AlgoliaRetryStrategy.swift */; };
+		OBJ_1484 /* HostIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1130 /* HostIterator.swift */; };
+		OBJ_1485 /* HostSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1131 /* HostSwitcher.swift */; };
+		OBJ_1486 /* RetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1132 /* RetryStrategy.swift */; };
+		OBJ_1487 /* RetryableHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1133 /* RetryableHost.swift */; };
+		OBJ_1488 /* URLRequest+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1135 /* URLRequest+Convenience.swift */; };
+		OBJ_1489 /* URLSession+HTTPRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1136 /* URLSession+HTTPRequester.swift */; };
+		OBJ_1491 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_1499 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1137 /* Package.swift */; };
+		OBJ_1505 /* MultiIndexSearchConnector+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* MultiIndexSearchConnector+UIKit.swift */; };
+		OBJ_1506 /* SearchConnector+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* SearchConnector+UIKit.swift */; };
+		OBJ_1507 /* ClearRefinementsButtonController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* ClearRefinementsButtonController.swift */; };
+		OBJ_1508 /* CurrentFiltersSearchTextFieldController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* CurrentFiltersSearchTextFieldController.swift */; };
+		OBJ_1509 /* CurrentFiltersTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* CurrentFiltersTableViewController.swift */; };
+		OBJ_1510 /* DynamicFacetListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* DynamicFacetListTableViewController.swift */; };
+		OBJ_1511 /* FacetListTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* FacetListTableController.swift */; };
+		OBJ_1512 /* FilterListTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* FilterListTableController.swift */; };
+		OBJ_1513 /* UICollectionView+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* UICollectionView+Convenience.swift */; };
+		OBJ_1514 /* UITableView+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* UITableView+Convenience.swift */; };
+		OBJ_1515 /* HierarchicalTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* HierarchicalTableViewController.swift */; };
+		OBJ_1516 /* CellConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* CellConfigurable.swift */; };
+		OBJ_1517 /* HitsCollectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* HitsCollectionController.swift */; };
+		OBJ_1518 /* HitsCollectionViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* HitsCollectionViewContainer.swift */; };
+		OBJ_1519 /* HitsCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* HitsCollectionViewController.swift */; };
+		OBJ_1520 /* HitsCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* HitsCollectionViewDataSource.swift */; };
+		OBJ_1521 /* HitsCollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* HitsCollectionViewDelegate.swift */; };
+		OBJ_1522 /* UICollectionViewController+HitsCollectionViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* UICollectionViewController+HitsCollectionViewContainer.swift */; };
+		OBJ_1523 /* HitsTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* HitsTableController.swift */; };
+		OBJ_1524 /* HitsTableViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* HitsTableViewContainer.swift */; };
+		OBJ_1525 /* HitsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* HitsTableViewController.swift */; };
+		OBJ_1526 /* HitsTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* HitsTableViewDataSource.swift */; };
+		OBJ_1527 /* HitsTableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* HitsTableViewDelegate.swift */; };
+		OBJ_1528 /* UITableViewController+HitsTableViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* UITableViewController+HitsTableViewContainer.swift */; };
+		OBJ_1529 /* ActivityIndicatorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* ActivityIndicatorController.swift */; };
+		OBJ_1530 /* Logger+InstantSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* Logger+InstantSearch.swift */; };
+		OBJ_1531 /* MultiIndexHitsCollectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* MultiIndexHitsCollectionController.swift */; };
+		OBJ_1532 /* MultiIndexHitsCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* MultiIndexHitsCollectionViewDataSource.swift */; };
+		OBJ_1533 /* MultiIndexHitsCollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* MultiIndexHitsCollectionViewDelegate.swift */; };
+		OBJ_1534 /* MultiIndexHitsTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* MultiIndexHitsTableController.swift */; };
+		OBJ_1535 /* MultiIndexHitsTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* MultiIndexHitsTableViewDataSource.swift */; };
+		OBJ_1536 /* MultiIndexHitsTableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* MultiIndexHitsTableViewDelegate.swift */; };
+		OBJ_1537 /* NumericRatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* NumericRatingController.swift */; };
+		OBJ_1538 /* NumericRatingRangeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* NumericRatingRangeController.swift */; };
+		OBJ_1539 /* NumericStepperController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* NumericStepperController.swift */; };
+		OBJ_1540 /* NumericTextFieldController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* NumericTextFieldController.swift */; };
+		OBJ_1541 /* RatingControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* RatingControl.swift */; };
+		OBJ_1542 /* QuerySuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* QuerySuggestionsViewController.swift */; };
+		OBJ_1543 /* ButtonRelevantSortController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_66 /* ButtonRelevantSortController.swift */; };
+		OBJ_1544 /* SearchBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* SearchBarController.swift */; };
+		OBJ_1545 /* TextFieldController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* TextFieldController.swift */; };
+		OBJ_1546 /* SegmentedController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* SegmentedController.swift */; };
+		OBJ_1547 /* FilterSwitchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* FilterSwitchController.swift */; };
+		OBJ_1548 /* SelectableFilterButtonController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* SelectableFilterButtonController.swift */; };
+		OBJ_1549 /* SelectIndexController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* SelectIndexController.swift */; };
+		OBJ_1550 /* SwitchIndexAlertControllerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* SwitchIndexAlertControllerBuilder.swift */; };
+		OBJ_1551 /* LabelStatsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_79 /* LabelStatsController.swift */; };
+		OBJ_1553 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */; };
+		OBJ_1554 /* InstantSearchTelemetry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */; };
+		OBJ_1555 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_1556 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_1557 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_1558 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_1573 /* MultiIndexSearchConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_82 /* MultiIndexSearchConnector.swift */; };
+		OBJ_1574 /* SearchConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_83 /* SearchConnector.swift */; };
+		OBJ_1575 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_85 /* AsyncOperation.swift */; };
+		OBJ_1576 /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_86 /* Attribute.swift */; };
+		OBJ_1577 /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* Connection.swift */; };
+		OBJ_1578 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_88 /* Constants.swift */; };
+		OBJ_1579 /* EventInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* EventInteractor.swift */; };
+		OBJ_1580 /* GeoLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_91 /* GeoLocation.swift */; };
+		OBJ_1581 /* Geolocated.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_92 /* Geolocated.swift */; };
+		OBJ_1582 /* Hit+Place.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_93 /* Hit+Place.swift */; };
+		OBJ_1583 /* IndexNameSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_94 /* IndexNameSettable.swift */; };
+		OBJ_1584 /* IndexQueryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_95 /* IndexQueryState.swift */; };
+		OBJ_1585 /* ItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_97 /* ItemController.swift */; };
+		OBJ_1586 /* ItemInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_98 /* ItemInteractor+Controller.swift */; };
+		OBJ_1587 /* ItemInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_99 /* ItemInteractor.swift */; };
+		OBJ_1588 /* Boundable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_101 /* Boundable.swift */; };
+		OBJ_1589 /* DoubleRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_102 /* DoubleRepresentable.swift */; };
+		OBJ_1590 /* Point+CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_103 /* Point+CoreLocation.swift */; };
+		OBJ_1591 /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_105 /* Presenter.swift */; };
+		OBJ_1592 /* QuerySuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* QuerySuggestion.swift */; };
+		OBJ_1593 /* Reloadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_107 /* Reloadable.swift */; };
+		OBJ_1594 /* ResultUpdatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* ResultUpdatable.swift */; };
+		OBJ_1595 /* SelectableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* SelectableController.swift */; };
+		OBJ_1596 /* SelectableInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* SelectableInteractor.swift */; };
+		OBJ_1597 /* SelectableListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* SelectableListController.swift */; };
+		OBJ_1598 /* SelectableListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* SelectableListInteractor.swift */; };
+		OBJ_1599 /* SelectableSegmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_116 /* SelectableSegmentController.swift */; };
+		OBJ_1600 /* SelectableSegmentInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_117 /* SelectableSegmentInteractor.swift */; };
+		OBJ_1601 /* CurrentFiltersConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* CurrentFiltersConnector+Controller.swift */; };
+		OBJ_1602 /* CurrentFiltersConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* CurrentFiltersConnector.swift */; };
+		OBJ_1603 /* CurrentFiltersInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* CurrentFiltersInteractor+FilterState.swift */; };
+		OBJ_1604 /* CurrentFiltersInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* CurrentFiltersInteractor.swift */; };
+		OBJ_1605 /* CurrentFiltersListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* CurrentFiltersListController.swift */; };
+		OBJ_1606 /* ItemListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* ItemListController.swift */; };
+		OBJ_1607 /* ItemListInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* ItemListInteractor+Controller.swift */; };
+		OBJ_1608 /* ItemsListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* ItemsListInteractor.swift */; };
+		OBJ_1609 /* AttributedFacets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_129 /* AttributedFacets.swift */; };
+		OBJ_1610 /* DynamicFacetListConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* DynamicFacetListConnector+Controller.swift */; };
+		OBJ_1611 /* DynamicFacetListConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* DynamicFacetListConnector.swift */; };
+		OBJ_1612 /* DynamicFacetListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* DynamicFacetListController.swift */; };
+		OBJ_1613 /* DynamicFacetListInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_134 /* DynamicFacetListInteractor+Controller.swift */; };
+		OBJ_1614 /* DynamicFacetListInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* DynamicFacetListInteractor+FilterState.swift */; };
+		OBJ_1615 /* DynamicFacetListInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_136 /* DynamicFacetListInteractor+Searcher.swift */; };
+		OBJ_1616 /* DynamicFacetListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* DynamicFacetListInteractor.swift */; };
+		OBJ_1617 /* FacetsOrderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_138 /* FacetsOrderer.swift */; };
+		OBJ_1618 /* Optional+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* Optional+Collection.swift */; };
+		OBJ_1619 /* Optional+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* Optional+String.swift */; };
+		OBJ_1620 /* Query+Facets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* Query+Facets.swift */; };
+		OBJ_1621 /* Result+ConvenientInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* Result+ConvenientInit.swift */; };
+		OBJ_1622 /* Sequence+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* Sequence+Convenience.swift */; };
+		OBJ_1623 /* FacetListConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* FacetListConnector+Controller.swift */; };
+		OBJ_1624 /* FacetListConnector+FacetSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_148 /* FacetListConnector+FacetSearcher.swift */; };
+		OBJ_1625 /* FacetListConnector+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* FacetListConnector+HitsSearcher.swift */; };
+		OBJ_1626 /* FacetListConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* FacetListConnector.swift */; };
+		OBJ_1627 /* FacetListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* FacetListController.swift */; };
+		OBJ_1628 /* FacetListInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* FacetListInteractor+Controller.swift */; };
+		OBJ_1629 /* FacetListInteractor+FacetSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_153 /* FacetListInteractor+FacetSearcher.swift */; };
+		OBJ_1630 /* FacetListInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* FacetListInteractor+FilterState.swift */; };
+		OBJ_1631 /* FacetListInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* FacetListInteractor+HitsSearcher.swift */; };
+		OBJ_1632 /* FacetListInteractor+MultiIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_156 /* FacetListInteractor+MultiIndexSearcher.swift */; };
+		OBJ_1633 /* FacetListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* FacetListInteractor.swift */; };
+		OBJ_1634 /* FacetListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_158 /* FacetListPresenter.swift */; };
+		OBJ_1635 /* FilterClearConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_161 /* FilterClearConnector+Controller.swift */; };
+		OBJ_1636 /* FilterClearConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* FilterClearConnector.swift */; };
+		OBJ_1637 /* FilterClearController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_163 /* FilterClearController.swift */; };
+		OBJ_1638 /* FilterClearInteractor+FilterClearController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_164 /* FilterClearInteractor+FilterClearController.swift */; };
+		OBJ_1639 /* FilterClearInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_165 /* FilterClearInteractor+FilterState.swift */; };
+		OBJ_1640 /* FilterClearInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_166 /* FilterClearInteractor.swift */; };
+		OBJ_1641 /* FacetFilterListConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_169 /* FacetFilterListConnector.swift */; };
+		OBJ_1642 /* FilterListConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_170 /* FilterListConnector+Controller.swift */; };
+		OBJ_1643 /* FilterListConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_171 /* FilterListConnector.swift */; };
+		OBJ_1644 /* FilterTypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* FilterTypeAliases.swift */; };
+		OBJ_1645 /* NumericFilterListConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* NumericFilterListConnector.swift */; };
+		OBJ_1646 /* TagFilterListConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_174 /* TagFilterListConnector.swift */; };
+		OBJ_1647 /* FilterListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_175 /* FilterListController.swift */; };
+		OBJ_1648 /* FilterListInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_176 /* FilterListInteractor+Controller.swift */; };
+		OBJ_1649 /* FilterListInteractor+Facet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_177 /* FilterListInteractor+Facet.swift */; };
+		OBJ_1650 /* FilterListInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* FilterListInteractor+FilterState.swift */; };
+		OBJ_1651 /* FilterListInteractor+Numeric.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_179 /* FilterListInteractor+Numeric.swift */; };
+		OBJ_1652 /* FilterListInteractor+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* FilterListInteractor+Tag.swift */; };
+		OBJ_1653 /* FilterListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_181 /* FilterListInteractor.swift */; };
+		OBJ_1654 /* FilterMapConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_184 /* FilterMapConnector+Controller.swift */; };
+		OBJ_1655 /* FilterMapConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* FilterMapConnector.swift */; };
+		OBJ_1656 /* FilterMapInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_186 /* FilterMapInteractor+Controller.swift */; };
+		OBJ_1657 /* FilterMapInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* FilterMapInteractor+FilterState.swift */; };
+		OBJ_1658 /* FilterMapInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_188 /* FilterMapInteractor+Searcher.swift */; };
+		OBJ_1659 /* FilterMapInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* FilterMapInteractor.swift */; };
+		OBJ_1660 /* AndGroupAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_192 /* AndGroupAccessor.swift */; };
+		OBJ_1661 /* GroupAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* GroupAccessor.swift */; };
+		OBJ_1662 /* HierarchicalGroupAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_194 /* HierarchicalGroupAccessor.swift */; };
+		OBJ_1663 /* OrGroupAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* OrGroupAccessor.swift */; };
+		OBJ_1664 /* SpecializedAndGroupAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_196 /* SpecializedAndGroupAccessor.swift */; };
+		OBJ_1665 /* FilterConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_199 /* FilterConverter.swift */; };
+		OBJ_1666 /* FilterGroupConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* FilterGroupConverter.swift */; };
+		OBJ_1667 /* LegacySyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* LegacySyntax.swift */; };
+		OBJ_1668 /* SQLSyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_202 /* SQLSyntax.swift */; };
+		OBJ_1669 /* FacetFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* FacetFilter.swift */; };
+		OBJ_1670 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_204 /* Filter.swift */; };
+		OBJ_1671 /* AndFilterGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_206 /* AndFilterGroup.swift */; };
+		OBJ_1672 /* FilterGroupType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_207 /* FilterGroupType.swift */; };
+		OBJ_1673 /* HierarchicalFilterGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* HierarchicalFilterGroup.swift */; };
+		OBJ_1674 /* OrFilterGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_209 /* OrFilterGroup.swift */; };
+		OBJ_1675 /* NumericFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* NumericFilter.swift */; };
+		OBJ_1676 /* TagFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* TagFilter.swift */; };
+		OBJ_1677 /* FilterGroupID.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* FilterGroupID.swift */; };
+		OBJ_1678 /* FilterGroupsConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* FilterGroupsConvertible.swift */; };
+		OBJ_1679 /* FilterState+Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_214 /* FilterState+Commands.swift */; };
+		OBJ_1680 /* FilterState+DisjunctiveFaceting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_215 /* FilterState+DisjunctiveFaceting.swift */; };
+		OBJ_1681 /* FilterState+FiltersReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_216 /* FilterState+FiltersReadable.swift */; };
+		OBJ_1682 /* FilterState+FiltersWritable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* FilterState+FiltersWritable.swift */; };
+		OBJ_1683 /* FilterState+HierarchicalFaceting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* FilterState+HierarchicalFaceting.swift */; };
+		OBJ_1684 /* FilterState+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* FilterState+Searcher.swift */; };
+		OBJ_1685 /* FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_220 /* FilterState.swift */; };
+		OBJ_1686 /* FilterStateDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_221 /* FilterStateDSL.swift */; };
+		OBJ_1687 /* FiltersReadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_222 /* FiltersReadable.swift */; };
+		OBJ_1688 /* FiltersSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* FiltersSettable.swift */; };
+		OBJ_1689 /* FiltersWritable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_224 /* FiltersWritable.swift */; };
+		OBJ_1690 /* GroupStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_225 /* GroupStorage.swift */; };
+		OBJ_1691 /* HierarchicalManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_226 /* HierarchicalManageable.swift */; };
+		OBJ_1692 /* Decodable+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_228 /* Decodable+JSON.swift */; };
+		OBJ_1693 /* UserAgentSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_229 /* UserAgentSetter.swift */; };
+		OBJ_1694 /* Version+Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_230 /* Version+Current.swift */; };
+		OBJ_1695 /* HierarchicalConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_233 /* HierarchicalConnector+Controller.swift */; };
+		OBJ_1696 /* HierarchicalConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_234 /* HierarchicalConnector.swift */; };
+		OBJ_1697 /* HierarchicalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_235 /* HierarchicalController.swift */; };
+		OBJ_1698 /* HierarchicalInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_236 /* HierarchicalInteractor+Controller.swift */; };
+		OBJ_1699 /* HierarchicalInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_237 /* HierarchicalInteractor+FilterState.swift */; };
+		OBJ_1700 /* HierarchicalInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_238 /* HierarchicalInteractor+HitsSearcher.swift */; };
+		OBJ_1701 /* HierarchicalInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_239 /* HierarchicalInteractor.swift */; };
+		OBJ_1702 /* NSAttributedString+TaggedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_241 /* NSAttributedString+TaggedString.swift */; };
+		OBJ_1703 /* AnyHitsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_243 /* AnyHitsInteractor.swift */; };
+		OBJ_1704 /* HitsConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_245 /* HitsConnector+Controller.swift */; };
+		OBJ_1705 /* HitsConnector+GeoSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_246 /* HitsConnector+GeoSearch.swift */; };
+		OBJ_1706 /* HitsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_247 /* HitsConnector.swift */; };
+		OBJ_1707 /* GeoHitsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_248 /* GeoHitsController.swift */; };
+		OBJ_1708 /* HitsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_249 /* HitsController.swift */; };
+		OBJ_1709 /* HitsExtractable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_250 /* HitsExtractable.swift */; };
+		OBJ_1710 /* HitsInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_251 /* HitsInteractor+Controller.swift */; };
+		OBJ_1711 /* HitsInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_252 /* HitsInteractor+FilterState.swift */; };
+		OBJ_1712 /* HitsInteractor+GeoHitsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_253 /* HitsInteractor+GeoHitsController.swift */; };
+		OBJ_1713 /* HitsInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_254 /* HitsInteractor+HitsSearcher.swift */; };
+		OBJ_1714 /* HitsInteractor+PlacesSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_255 /* HitsInteractor+PlacesSearcher.swift */; };
+		OBJ_1715 /* HitsInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_256 /* HitsInteractor+Searcher.swift */; };
+		OBJ_1716 /* HitsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_257 /* HitsInteractor.swift */; };
+		OBJ_1717 /* HitsSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_258 /* HitsSource.swift */; };
+		OBJ_1718 /* MultiSourceReloadNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_259 /* MultiSourceReloadNotifier.swift */; };
+		OBJ_1719 /* MatchingPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_261 /* MatchingPattern.swift */; };
+		OBJ_1720 /* RelatedItemsInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_262 /* RelatedItemsInteractor+HitsSearcher.swift */; };
+		OBJ_1721 /* InfiniteScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_264 /* InfiniteScrollable.swift */; };
+		OBJ_1722 /* InfiniteScrollingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_265 /* InfiniteScrollingController.swift */; };
+		OBJ_1723 /* LoadingConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_268 /* LoadingConnector+Controller.swift */; };
+		OBJ_1724 /* LoadingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_269 /* LoadingConnector.swift */; };
+		OBJ_1725 /* LoadingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_270 /* LoadingController.swift */; };
+		OBJ_1726 /* LoadingInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_271 /* LoadingInteractor+Controller.swift */; };
+		OBJ_1727 /* LoadingInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_272 /* LoadingInteractor+Searcher.swift */; };
+		OBJ_1728 /* LoadingInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_273 /* LoadingInteractor.swift */; };
+		OBJ_1729 /* DecodingErrorPrettyPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_275 /* DecodingErrorPrettyPrinter.swift */; };
+		OBJ_1730 /* Logger+InstantSearchCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_276 /* Logger+InstantSearchCore.swift */; };
+		OBJ_1731 /* MultiIndexHitsConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_279 /* MultiIndexHitsConnector+Controller.swift */; };
+		OBJ_1732 /* MultiIndexHitsConnector+IndexModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_280 /* MultiIndexHitsConnector+IndexModule.swift */; };
+		OBJ_1733 /* MultiIndexHitsConnector+Suggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_281 /* MultiIndexHitsConnector+Suggestions.swift */; };
+		OBJ_1734 /* MultiIndexHitsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_282 /* MultiIndexHitsConnector.swift */; };
+		OBJ_1735 /* MultiIndexHitsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_283 /* MultiIndexHitsController.swift */; };
+		OBJ_1736 /* MultiIndexHitsInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_284 /* MultiIndexHitsInteractor+Controller.swift */; };
+		OBJ_1737 /* MultiIndexHitsInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_285 /* MultiIndexHitsInteractor+FilterState.swift */; };
+		OBJ_1738 /* MultiIndexHitsInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_286 /* MultiIndexHitsInteractor+Searcher.swift */; };
+		OBJ_1739 /* MultiIndexHitsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_287 /* MultiIndexHitsInteractor.swift */; };
+		OBJ_1740 /* MultiIndexHitsSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_288 /* MultiIndexHitsSource.swift */; };
+		OBJ_1741 /* Boundable+SearchResultProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_290 /* Boundable+SearchResultProvider.swift */; };
+		OBJ_1742 /* Computation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_291 /* Computation.swift */; };
+		OBJ_1743 /* FilterComparisonConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_293 /* FilterComparisonConnector+Controller.swift */; };
+		OBJ_1744 /* FilterComparisonConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* FilterComparisonConnector.swift */; };
+		OBJ_1745 /* FilterComparison+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* FilterComparison+Controller.swift */; };
+		OBJ_1746 /* FilterComparison+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* FilterComparison+FilterState.swift */; };
+		OBJ_1747 /* FilterComparisonComputeBounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* FilterComparisonComputeBounds.swift */; };
+		OBJ_1748 /* NumberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_298 /* NumberController.swift */; };
+		OBJ_1749 /* NumberInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* NumberInteractor.swift */; };
+		OBJ_1750 /* NumberRangeConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_302 /* NumberRangeConnector+Controller.swift */; };
+		OBJ_1751 /* NumberRangeConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_303 /* NumberRangeConnector.swift */; };
+		OBJ_1752 /* NumberRangeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_304 /* NumberRangeController.swift */; };
+		OBJ_1753 /* NumberRangeInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_305 /* NumberRangeInteractor+Controller.swift */; };
+		OBJ_1754 /* NumberRangeInteractor+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_306 /* NumberRangeInteractor+FilterState.swift */; };
+		OBJ_1755 /* NumberRangeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_307 /* NumberRangeInteractor.swift */; };
+		OBJ_1756 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_309 /* Observable.swift */; };
+		OBJ_1757 /* Observation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_310 /* Observation.swift */; };
+		OBJ_1758 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_311 /* Observer.swift */; };
+		OBJ_1759 /* Signals+Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_312 /* Signals+Observable.swift */; };
+		OBJ_1760 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_313 /* Subscription.swift */; };
+		OBJ_1761 /* PageLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_315 /* PageLoadable.swift */; };
+		OBJ_1762 /* PageMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_316 /* PageMap.swift */; };
+		OBJ_1763 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_317 /* Paginator.swift */; };
+		OBJ_1764 /* SearchResults+PageMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_318 /* SearchResults+PageMap.swift */; };
+		OBJ_1765 /* SynchronizedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_319 /* SynchronizedSet.swift */; };
+		OBJ_1766 /* DefaultPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_321 /* DefaultPresenter.swift */; };
+		OBJ_1767 /* FacetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_322 /* FacetPresenter.swift */; };
+		OBJ_1768 /* FilterPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_323 /* FilterPresenter.swift */; };
+		OBJ_1769 /* HierarchicalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_324 /* HierarchicalPresenter.swift */; };
+		OBJ_1770 /* IndexNamePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_325 /* IndexNamePresenter.swift */; };
+		OBJ_1771 /* IndexPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_326 /* IndexPresenter.swift */; };
+		OBJ_1772 /* RelevantSortPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_327 /* RelevantSortPresenter.swift */; };
+		OBJ_1773 /* StatsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_328 /* StatsPresenter.swift */; };
+		OBJ_1774 /* QueryBuilder+DisjunctiveFaceting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_330 /* QueryBuilder+DisjunctiveFaceting.swift */; };
+		OBJ_1775 /* QueryBuilder+HierarchicalFaceting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_331 /* QueryBuilder+HierarchicalFaceting.swift */; };
+		OBJ_1776 /* QueryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_332 /* QueryBuilder.swift */; };
+		OBJ_1777 /* QueryRuleCustomDataConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_335 /* QueryRuleCustomDataConnector+Controller.swift */; };
+		OBJ_1778 /* QueryRuleCustomDataConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_336 /* QueryRuleCustomDataConnector.swift */; };
+		OBJ_1779 /* QueryRuleCustomData+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_337 /* QueryRuleCustomData+Searcher.swift */; };
+		OBJ_1780 /* QueryRuleCustomDataInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_338 /* QueryRuleCustomDataInteractor+HitsSearcher.swift */; };
+		OBJ_1781 /* QueryRuleCustomDataInteractor+MultiIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_339 /* QueryRuleCustomDataInteractor+MultiIndexSearcher.swift */; };
+		OBJ_1782 /* QueryRuleCustomDataInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_340 /* QueryRuleCustomDataInteractor.swift */; };
+		OBJ_1783 /* RelevantSortConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_343 /* RelevantSortConnector+Controller.swift */; };
+		OBJ_1784 /* RelevantSortConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_344 /* RelevantSortConnector.swift */; };
+		OBJ_1785 /* RelevantSortInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_345 /* RelevantSortInteractor+Controller.swift */; };
+		OBJ_1786 /* RelevantSortInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_346 /* RelevantSortInteractor+HitsSearcher.swift */; };
+		OBJ_1787 /* RelevantSortInteractor+MultiIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_347 /* RelevantSortInteractor+MultiIndexSearcher.swift */; };
+		OBJ_1788 /* RelevantSortInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_348 /* RelevantSortInteractor.swift */; };
+		OBJ_1789 /* RelevantSortPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_349 /* RelevantSortPriority.swift */; };
+		OBJ_1790 /* SearchBoxConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_352 /* SearchBoxConnector+Controller.swift */; };
+		OBJ_1791 /* SearchBoxConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_353 /* SearchBoxConnector.swift */; };
+		OBJ_1792 /* QuerySettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_354 /* QuerySettable.swift */; };
+		OBJ_1793 /* SearchBoxController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_355 /* SearchBoxController.swift */; };
+		OBJ_1794 /* SearchBoxInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_356 /* SearchBoxInteractor+Controller.swift */; };
+		OBJ_1795 /* SearchBoxInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_357 /* SearchBoxInteractor+Searcher.swift */; };
+		OBJ_1796 /* SearchBoxInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_358 /* SearchBoxInteractor.swift */; };
+		OBJ_1797 /* SearchTriggeringMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_359 /* SearchTriggeringMode.swift */; };
+		OBJ_1798 /* AbstractSearcher+TextualQueryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_361 /* AbstractSearcher+TextualQueryProvider.swift */; };
+		OBJ_1799 /* AbstractSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_362 /* AbstractSearcher.swift */; };
+		OBJ_1800 /* AnswersSearcher+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_364 /* AnswersSearcher+FilterState.swift */; };
+		OBJ_1801 /* AnswersSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_365 /* AnswersSearcher.swift */; };
+		OBJ_1802 /* DisjunctiveFacetingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_366 /* DisjunctiveFacetingDelegate.swift */; };
+		OBJ_1803 /* FacetSearcher+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_368 /* FacetSearcher+FilterState.swift */; };
+		OBJ_1804 /* FacetSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_369 /* FacetSearcher.swift */; };
+		OBJ_1805 /* HierarchicalFacetingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_370 /* HierarchicalFacetingDelegate.swift */; };
+		OBJ_1806 /* HitsSearcher+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_372 /* HitsSearcher+FilterState.swift */; };
+		OBJ_1807 /* HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_373 /* HitsSearcher.swift */; };
+		OBJ_1808 /* IndexNameProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_374 /* IndexNameProvider.swift */; };
+		OBJ_1809 /* IndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_375 /* IndexSearcher.swift */; };
+		OBJ_1810 /* AbstractMultiSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_377 /* AbstractMultiSearcher.swift */; };
+		OBJ_1811 /* MultiRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_378 /* MultiRequest.swift */; };
+		OBJ_1812 /* MultiResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_379 /* MultiResult.swift */; };
+		OBJ_1813 /* MultiSearchComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* MultiSearchComponent.swift */; };
+		OBJ_1814 /* MultiSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* MultiSearchService.swift */; };
+		OBJ_1815 /* MultiSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* MultiSearcher.swift */; };
+		OBJ_1816 /* MultiIndexSearcher+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_384 /* MultiIndexSearcher+FilterState.swift */; };
+		OBJ_1817 /* MultiIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_385 /* MultiIndexSearcher.swift */; };
+		OBJ_1818 /* PlacesSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_387 /* PlacesSearcher.swift */; };
+		OBJ_1819 /* AlgoliaAnswersSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_389 /* AlgoliaAnswersSearchService.swift */; };
+		OBJ_1820 /* AlgoliaMultiSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_390 /* AlgoliaMultiSearchService.swift */; };
+		OBJ_1821 /* AlgoliaPlacesSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_391 /* AlgoliaPlacesSearchService.swift */; };
+		OBJ_1822 /* AlgoliaRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_392 /* AlgoliaRequest.swift */; };
+		OBJ_1823 /* AlgoliaSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_393 /* AlgoliaSearchService.swift */; };
+		OBJ_1824 /* FacetSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_394 /* FacetSearchService.swift */; };
+		OBJ_1825 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_395 /* SearchService.swift */; };
+		OBJ_1826 /* Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_396 /* Searcher.swift */; };
+		OBJ_1827 /* TextualQueryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_397 /* TextualQueryProvider.swift */; };
+		OBJ_1828 /* Sequencer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_399 /* Sequencer.swift */; };
+		OBJ_1829 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_400 /* Signal.swift */; };
+		OBJ_1830 /* SortByConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_403 /* SortByConnector+Controller.swift */; };
+		OBJ_1831 /* SortByConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_404 /* SortByConnector.swift */; };
+		OBJ_1832 /* IndexSegmentInteractor+AnswersSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_406 /* IndexSegmentInteractor+AnswersSearcher.swift */; };
+		OBJ_1833 /* IndexSegmentInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_407 /* IndexSegmentInteractor+Controller.swift */; };
+		OBJ_1834 /* IndexSegmentInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_408 /* IndexSegmentInteractor+HitsSearcher.swift */; };
+		OBJ_1835 /* IndexSegmentInteractor+MultiIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_409 /* IndexSegmentInteractor+MultiIndexSearcher.swift */; };
+		OBJ_1836 /* IndexSegmentInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_410 /* IndexSegmentInteractor.swift */; };
+		OBJ_1837 /* SortByInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_411 /* SortByInteractor+Controller.swift */; };
+		OBJ_1838 /* SortByInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_412 /* SortByInteractor+Searcher.swift */; };
+		OBJ_1839 /* SortByInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_413 /* SortByInteractor.swift */; };
+		OBJ_1840 /* StatsConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_416 /* StatsConnector+Controller.swift */; };
+		OBJ_1841 /* StatsConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_417 /* StatsConnector.swift */; };
+		OBJ_1842 /* SearchStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_418 /* SearchStats.swift */; };
+		OBJ_1843 /* SearchStatsConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_419 /* SearchStatsConvertible.swift */; };
+		OBJ_1844 /* StatsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_420 /* StatsController.swift */; };
+		OBJ_1845 /* StatsInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_421 /* StatsInteractor+Controller.swift */; };
+		OBJ_1846 /* StatsInteractor+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_422 /* StatsInteractor+HitsSearcher.swift */; };
+		OBJ_1847 /* StatsInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_423 /* StatsInteractor+Searcher.swift */; };
+		OBJ_1848 /* StatsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_424 /* StatsInteractor.swift */; };
+		OBJ_1849 /* SwitchIndexInteractor+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_426 /* SwitchIndexInteractor+Controller.swift */; };
+		OBJ_1850 /* SwitchIndexInteractor+Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_427 /* SwitchIndexInteractor+Searcher.swift */; };
+		OBJ_1851 /* SwitchIndexInteractor.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_428 /* SwitchIndexInteractor.swift.swift */; };
+		OBJ_1852 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_430 /* Telemetry.swift */; };
+		OBJ_1853 /* FilterToggleConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_433 /* FilterToggleConnector+Controller.swift */; };
+		OBJ_1854 /* FilterToggleConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_434 /* FilterToggleConnector.swift */; };
+		OBJ_1855 /* FilgerToggle+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_435 /* FilgerToggle+Controller.swift */; };
+		OBJ_1856 /* FilterToggle+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_436 /* FilterToggle+FilterState.swift */; };
+		OBJ_1857 /* FilterTrackable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_438 /* FilterTrackable.swift */; };
+		OBJ_1858 /* FilterTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_439 /* FilterTracker.swift */; };
+		OBJ_1859 /* HitsAfterSearchTrackable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_440 /* HitsAfterSearchTrackable.swift */; };
+		OBJ_1860 /* HitsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_441 /* HitsTracker.swift */; };
+		OBJ_1861 /* InsightsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_442 /* InsightsTracker.swift */; };
+		OBJ_1862 /* TrackableSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_443 /* TrackableSearcher.swift */; };
+		OBJ_1864 /* InstantSearchTelemetry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */; };
+		OBJ_1865 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_1866 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_1867 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_1868 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_1879 /* JSONDecoder+Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_512 /* JSONDecoder+Resource.swift */; };
+		OBJ_1880 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_513 /* String+Random.swift */; };
+		OBJ_1881 /* InstantSearchCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_514 /* InstantSearchCoreTests.swift */; };
+		OBJ_1882 /* DisjuncitveAndHierarchicalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_516 /* DisjuncitveAndHierarchicalIntegrationTests.swift */; };
+		OBJ_1883 /* DisjunctiveFacetingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_517 /* DisjunctiveFacetingIntegrationTests.swift */; };
+		OBJ_1884 /* HierarchicalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_518 /* HierarchicalIntegrationTests.swift */; };
+		OBJ_1885 /* OnlineTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_519 /* OnlineTestCase.swift */; };
+		OBJ_1886 /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_520 /* TestCredentials.swift */; };
+		OBJ_1887 /* Data+FileAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_522 /* Data+FileAccess.swift */; };
+		OBJ_1888 /* AttributedStringWithTaggedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_524 /* AttributedStringWithTaggedStringTests.swift */; };
+		OBJ_1889 /* MultiIndexSearchConnectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_526 /* MultiIndexSearchConnectorTests.swift */; };
+		OBJ_1890 /* SearchConnectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_527 /* SearchConnectorTests.swift */; };
+		OBJ_1891 /* SortByConnectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_528 /* SortByConnectorTests.swift */; };
+		OBJ_1892 /* CurrentFiltersControllerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_530 /* CurrentFiltersControllerConnectionTests.swift */; };
+		OBJ_1893 /* CurrentFiltersFilterStateConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_531 /* CurrentFiltersFilterStateConnectionTests.swift */; };
+		OBJ_1894 /* TestCurrentFiltersController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_532 /* TestCurrentFiltersController.swift */; };
+		OBJ_1895 /* DecodingErrorPrettyPrinterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_533 /* DecodingErrorPrettyPrinterTests.swift */; };
+		OBJ_1896 /* DisjunctiveFacetingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_534 /* DisjunctiveFacetingsTests.swift */; };
+		OBJ_1897 /* FacetsOrdererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_536 /* FacetsOrdererTests.swift */; };
+		OBJ_1898 /* Array+Facet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_538 /* Array+Facet.swift */; };
+		OBJ_1899 /* FacetListControllerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_539 /* FacetListControllerConnectionTests.swift */; };
+		OBJ_1900 /* FacetListFacetSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_540 /* FacetListFacetSearcherConnectionTests.swift */; };
+		OBJ_1901 /* FacetListFilterStateConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_541 /* FacetListFilterStateConnectionTests.swift */; };
+		OBJ_1902 /* FacetListHitsSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_542 /* FacetListHitsSearcherConnectionTests.swift */; };
+		OBJ_1903 /* FacetListInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_543 /* FacetListInteractorTests.swift */; };
+		OBJ_1904 /* FacetListPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_544 /* FacetListPresenterTests.swift */; };
+		OBJ_1905 /* TestFacetListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_545 /* TestFacetListController.swift */; };
+		OBJ_1906 /* FilterGroupCollectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_547 /* FilterGroupCollectionsTests.swift */; };
+		OBJ_1907 /* FilterGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_548 /* FilterGroupTests.swift */; };
+		OBJ_1908 /* FilterStateGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_549 /* FilterStateGroupTests.swift */; };
+		OBJ_1909 /* FilterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_550 /* FilterStateTests.swift */; };
+		OBJ_1910 /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_551 /* FilterTests.swift */; };
+		OBJ_1911 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_552 /* Helpers.swift */; };
+		OBJ_1912 /* HitsInteractorControllerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_554 /* HitsInteractorControllerConnectionTests.swift */; };
+		OBJ_1913 /* HitsInteractorFilterStateConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_555 /* HitsInteractorFilterStateConnectionTests.swift */; };
+		OBJ_1914 /* HitsInteractorRelatedItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_556 /* HitsInteractorRelatedItemsTests.swift */; };
+		OBJ_1915 /* HitsInteractorSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_557 /* HitsInteractorSearcherConnectionTests.swift */; };
+		OBJ_1916 /* HitsInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_558 /* HitsInteractorTests.swift */; };
+		OBJ_1917 /* TestHitsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_559 /* TestHitsController.swift */; };
+		OBJ_1918 /* TestInfiniteScrollingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_560 /* TestInfiniteScrollingController.swift */; };
+		OBJ_1919 /* InfiniteScrollingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_561 /* InfiniteScrollingControllerTests.swift */; };
+		OBJ_1920 /* ItemInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_562 /* ItemInteractorTests.swift */; };
+		OBJ_1921 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_563 /* LoggingTests.swift */; };
+		OBJ_1922 /* MultiIndexHitsInteractorControllerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_565 /* MultiIndexHitsInteractorControllerConnectionTests.swift */; };
+		OBJ_1923 /* MultiIndexHitsInteractorSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_566 /* MultiIndexHitsInteractorSearcherConnectionTests.swift */; };
+		OBJ_1924 /* MultiIndexHitsInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_567 /* MultiIndexHitsInteractorTests.swift */; };
+		OBJ_1925 /* MultiSourceHitsReloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_568 /* MultiSourceHitsReloaderTests.swift */; };
+		OBJ_1926 /* NumberInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_570 /* NumberInteractorTests.swift */; };
+		OBJ_1927 /* NumberRangeInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_571 /* NumberRangeInteractorTests.swift */; };
+		OBJ_1928 /* PageMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_572 /* PageMapTests.swift */; };
+		OBJ_1929 /* PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_573 /* PaginatorTests.swift */; };
+		OBJ_1930 /* QueryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_574 /* QueryBuilderTests.swift */; };
+		OBJ_1931 /* SearchBoxControllerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_576 /* SearchBoxControllerConnectionTests.swift */; };
+		OBJ_1932 /* SearchBoxInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_577 /* SearchBoxInteractorTests.swift */; };
+		OBJ_1933 /* SearchBoxSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_578 /* SearchBoxSearcherConnectionTests.swift */; };
+		OBJ_1934 /* TestSearchBoxController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_579 /* TestSearchBoxController.swift */; };
+		OBJ_1935 /* TestSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_580 /* TestSearcher.swift */; };
+		OBJ_1936 /* QueryRuleCustomDataSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_582 /* QueryRuleCustomDataSearcherConnectionTests.swift */; };
+		OBJ_1937 /* RelevantSortControllerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_584 /* RelevantSortControllerConnectionTests.swift */; };
+		OBJ_1938 /* RelevantSortHitsSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_585 /* RelevantSortHitsSearcherConnectionTests.swift */; };
+		OBJ_1939 /* RelevantSortInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_586 /* RelevantSortInteractorTests.swift */; };
+		OBJ_1940 /* RelevantSortMultiIndexSearcherConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_587 /* RelevantSortMultiIndexSearcherConnectionTests.swift */; };
+		OBJ_1941 /* AnswersSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_589 /* AnswersSearcherTests.swift */; };
+		OBJ_1942 /* HitsSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_590 /* HitsSearcherTests.swift */; };
+		OBJ_1943 /* MultiIndexSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_591 /* MultiIndexSearcherTests.swift */; };
+		OBJ_1944 /* SelectableInteractorConnectorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_592 /* SelectableInteractorConnectorsTests.swift */; };
+		OBJ_1945 /* SelectableInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_593 /* SelectableInteractorTests.swift */; };
+		OBJ_1946 /* SelectableListInteractorFilterConnectorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_594 /* SelectableListInteractorFilterConnectorsTests.swift */; };
+		OBJ_1947 /* SelectableListInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_595 /* SelectableListInteractorTests.swift */; };
+		OBJ_1948 /* SelectableSegmentInteractorConnectorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_597 /* SelectableSegmentInteractorConnectorsTests.swift */; };
+		OBJ_1949 /* SelectableSegmentInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_598 /* SelectableSegmentInteractorTests.swift */; };
+		OBJ_1950 /* TestSelectableSegmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_599 /* TestSelectableSegmentController.swift */; };
+		OBJ_1951 /* SequencerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_600 /* SequencerTest.swift */; };
+		OBJ_1952 /* StatsInteractorConnectorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_601 /* StatsInteractorConnectorsTests.swift */; };
+		OBJ_1953 /* TelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_602 /* TelemetryTests.swift */; };
+		OBJ_1954 /* FilterTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_604 /* FilterTrackerTests.swift */; };
+		OBJ_1955 /* HitsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_605 /* HitsTrackerTests.swift */; };
+		OBJ_1956 /* TestFiltersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_606 /* TestFiltersTracker.swift */; };
+		OBJ_1957 /* TestHitsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_607 /* TestHitsTracker.swift */; };
+		OBJ_1958 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_608 /* XCTestManifests.swift */; };
+		OBJ_1960 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */; };
+		OBJ_1961 /* InstantSearchTelemetry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */; };
+		OBJ_1962 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_1963 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_1964 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_1965 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_1976 /* Date+Milliseconds.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_447 /* Date+Milliseconds.swift */; };
+		OBJ_1977 /* Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_448 /* Encodable.swift */; };
+		OBJ_1978 /* JSONFilePackageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_450 /* JSONFilePackageStorage.swift */; };
+		OBJ_1979 /* TimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_451 /* TimerController.swift */; };
+		OBJ_1980 /* LogCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_453 /* LogCollector.swift */; };
+		OBJ_1981 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_454 /* LogLevel.swift */; };
+		OBJ_1982 /* LogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_455 /* LogService.swift */; };
+		OBJ_1983 /* Logger+InstantSearchInsights.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_456 /* Logger+InstantSearchInsights.swift */; };
+		OBJ_1984 /* PrefixedLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_457 /* PrefixedLogger.swift */; };
+		OBJ_1985 /* SwiftLog+LogService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_458 /* SwiftLog+LogService.swift */; };
+		OBJ_1986 /* EventProcessor+AlgoliaClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_460 /* EventProcessor+AlgoliaClient.swift */; };
+		OBJ_1987 /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_461 /* EventProcessor.swift */; };
+		OBJ_1988 /* EventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_462 /* EventTracker.swift */; };
+		OBJ_1989 /* Insights+EventTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_463 /* Insights+EventTracking.swift */; };
+		OBJ_1990 /* Insights+SearchEventTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_464 /* Insights+SearchEventTracking.swift */; };
+		OBJ_1991 /* Insights.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_465 /* Insights.swift */; };
+		OBJ_1992 /* InsightsClient+EventService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_466 /* InsightsClient+EventService.swift */; };
+		OBJ_1993 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_468 /* Config.swift */; };
+		OBJ_1994 /* Package+InsightsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_469 /* Package+InsightsEvent.swift */; };
+		OBJ_1995 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_470 /* Package.swift */; };
+		OBJ_1996 /* Packager+InsightsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_471 /* Packager+InsightsEvent.swift */; };
+		OBJ_1997 /* Packager.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_472 /* Packager.swift */; };
+		OBJ_1998 /* EventProcessable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_474 /* EventProcessable.swift */; };
+		OBJ_1999 /* EventTrackable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_475 /* EventTrackable.swift */; };
+		OBJ_2000 /* EventsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_476 /* EventsService.swift */; };
+		OBJ_2001 /* Flushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_477 /* Flushable.swift */; };
+		OBJ_2002 /* PackageManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_478 /* PackageManageable.swift */; };
+		OBJ_2003 /* Packaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_479 /* Packaging.swift */; };
+		OBJ_2004 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_480 /* Storage.swift */; };
+		OBJ_2006 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_2007 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_2015 /* MockEventService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_611 /* MockEventService.swift */; };
+		OBJ_2016 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_612 /* String+Random.swift */; };
+		OBJ_2017 /* TestEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_613 /* TestEvent.swift */; };
+		OBJ_2018 /* TestEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_614 /* TestEventProcessor.swift */; };
+		OBJ_2019 /* TestEventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_615 /* TestEventTracker.swift */; };
+		OBJ_2020 /* TestPackageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_616 /* TestPackageStorage.swift */; };
+		OBJ_2021 /* XCTest+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_617 /* XCTest+Codable.swift */; };
+		OBJ_2022 /* EventTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_619 /* EventTrackerTests.swift */; };
+		OBJ_2023 /* EventsProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_620 /* EventsProcessorTests.swift */; };
+		OBJ_2024 /* InsightsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_621 /* InsightsTests.swift */; };
+		OBJ_2025 /* JSONFilePackageStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_622 /* JSONFilePackageStorageTests.swift */; };
+		OBJ_2026 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_623 /* LoggingTests.swift */; };
+		OBJ_2027 /* PackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_624 /* PackageTests.swift */; };
+		OBJ_2028 /* PackagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_625 /* PackagerTests.swift */; };
+		OBJ_2029 /* TimerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_626 /* TimerControllerTests.swift */; };
+		OBJ_2031 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_2032 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_2033 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_2042 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_2058 /* CurrentFiltersObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_483 /* CurrentFiltersObservableController.swift */; };
+		OBJ_2059 /* DynamicFacetListObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_484 /* DynamicFacetListObservableController.swift */; };
+		OBJ_2060 /* FacetListObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_485 /* FacetListObservableController.swift */; };
+		OBJ_2061 /* FilterClearObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_486 /* FilterClearObservableController.swift */; };
+		OBJ_2062 /* FilterListObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_487 /* FilterListObservableController.swift */; };
+		OBJ_2063 /* FilterToggleObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_488 /* FilterToggleObservableController.swift */; };
+		OBJ_2064 /* HierarchicalObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_489 /* HierarchicalObservableController.swift */; };
+		OBJ_2065 /* HitsObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_490 /* HitsObservableController.swift */; };
+		OBJ_2066 /* LoadingObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_491 /* LoadingObservableController.swift */; };
+		OBJ_2067 /* NumberRangeObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_492 /* NumberRangeObservableController.swift */; };
+		OBJ_2068 /* RelevantSortObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_493 /* RelevantSortObservableController.swift */; };
+		OBJ_2069 /* SearchBoxObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_494 /* SearchBoxObservableController.swift */; };
+		OBJ_2070 /* SelectableSegmentObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_495 /* SelectableSegmentObservableController.swift */; };
+		OBJ_2071 /* StatsObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_496 /* StatsObservableController.swift */; };
+		OBJ_2072 /* StatsTextObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_497 /* StatsTextObservableController.swift */; };
+		OBJ_2073 /* SwitchIndexObservableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_498 /* SwitchIndexObservableController.swift */; };
+		OBJ_2074 /* FacetList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_500 /* FacetList.swift */; };
+		OBJ_2075 /* FacetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_501 /* FacetRow.swift */; };
+		OBJ_2076 /* FilterList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_502 /* FilterList.swift */; };
+		OBJ_2077 /* HierarchicalFacetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_503 /* HierarchicalFacetRow.swift */; };
+		OBJ_2078 /* HierarchicalList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_504 /* HierarchicalList.swift */; };
+		OBJ_2079 /* HitsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_505 /* HitsList.swift */; };
+		OBJ_2080 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_506 /* SearchBar.swift */; };
+		OBJ_2081 /* SuggestionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_507 /* SuggestionRow.swift */; };
+		OBJ_2082 /* Text+Highlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_508 /* Text+Highlighting.swift */; };
+		OBJ_2084 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */; };
+		OBJ_2085 /* InstantSearchTelemetry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */; };
+		OBJ_2086 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_2087 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_2088 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_2089 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_2100 /* ObservableControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_628 /* ObservableControllerTests.swift */; };
+		OBJ_2102 /* InstantSearchSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchSwiftUI::Product" /* InstantSearchSwiftUI.framework */; };
+		OBJ_2103 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */; };
+		OBJ_2104 /* InstantSearchTelemetry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */; };
+		OBJ_2105 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_2106 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_2107 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_2108 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_2120 /* CRC32.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_659 /* CRC32.swift */; };
+		OBJ_2121 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_660 /* Data+Gzip.swift */; };
+		OBJ_2122 /* Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_661 /* Gzip.swift */; };
+		OBJ_2123 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_662 /* Telemetry.swift */; };
+		OBJ_2124 /* telemetry.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_663 /* telemetry.pb.swift */; };
+		OBJ_2126 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_2133 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_664 /* Package.swift */; };
+		OBJ_2138 /* String+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_631 /* String+Random.swift */; };
+		OBJ_2139 /* InstantSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_632 /* InstantSearchTests.swift */; };
+		OBJ_2140 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_633 /* LoggingTests.swift */; };
+		OBJ_2141 /* BannerGuideSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_635 /* BannerGuideSnippets.swift */; };
+		OBJ_2142 /* CurrentRefinementsSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_636 /* CurrentRefinementsSnippets.swift */; };
+		OBJ_2143 /* FacetFilterListSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_637 /* FacetFilterListSnippets.swift */; };
+		OBJ_2144 /* FacetListConnectorSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_638 /* FacetListConnectorSnippets.swift */; };
+		OBJ_2145 /* FilterClearSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_639 /* FilterClearSnippets.swift */; };
+		OBJ_2146 /* HierarchicalSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_640 /* HierarchicalSnippets.swift */; };
+		OBJ_2147 /* HitsSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_641 /* HitsSnippets.swift */; };
+		OBJ_2148 /* LoadingSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_642 /* LoadingSnippets.swift */; };
+		OBJ_2149 /* MultiIndexHitsSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_643 /* MultiIndexHitsSnippets.swift */; };
+		OBJ_2150 /* NumberRangeSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_644 /* NumberRangeSnippets.swift */; };
+		OBJ_2151 /* NumericFilterListSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_645 /* NumericFilterListSnippets.swift */; };
+		OBJ_2152 /* QueryRuleCustomDataSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_646 /* QueryRuleCustomDataSnippets.swift */; };
+		OBJ_2153 /* RedirectGuideSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_647 /* RedirectGuideSnippets.swift */; };
+		OBJ_2154 /* SearchBoxSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_648 /* SearchBoxSnippets.swift */; };
+		OBJ_2155 /* SortBySnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_649 /* SortBySnippets.swift */; };
+		OBJ_2156 /* StatsSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_650 /* StatsSnippets.swift */; };
+		OBJ_2157 /* TagFilterListSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_651 /* TagFilterListSnippets.swift */; };
+		OBJ_2158 /* ToggleFilterSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_652 /* ToggleFilterSnippets.swift */; };
+		OBJ_2159 /* TestHitsSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_653 /* TestHitsSource.swift */; };
+		OBJ_2160 /* TestMultiHitsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_654 /* TestMultiHitsDataSource.swift */; };
+		OBJ_2161 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_655 /* XCTestManifests.swift */; };
+		OBJ_2163 /* InstantSearch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearch::Product" /* InstantSearch.framework */; };
+		OBJ_2164 /* InstantSearchCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */; };
+		OBJ_2165 /* InstantSearchTelemetry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */; };
+		OBJ_2166 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
+		OBJ_2167 /* InstantSearchInsights.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */; };
+		OBJ_2168 /* AlgoliaSearchClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */; };
+		OBJ_2169 /* Logging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "swift-log::Logging::Product" /* Logging.framework */; };
+		OBJ_2181 /* Locks.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1140 /* Locks.swift */; };
+		OBJ_2182 /* LogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1141 /* LogHandler.swift */; };
+		OBJ_2183 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1142 /* Logging.swift */; };
+		OBJ_2189 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_667 /* AnyMessageStorage.swift */; };
+		OBJ_2190 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_668 /* AnyUnpackError.swift */; };
+		OBJ_2191 /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_669 /* BinaryDecoder.swift */; };
+		OBJ_2192 /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_670 /* BinaryDecodingError.swift */; };
+		OBJ_2193 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_671 /* BinaryDecodingOptions.swift */; };
+		OBJ_2194 /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_672 /* BinaryDelimited.swift */; };
+		OBJ_2195 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_673 /* BinaryEncoder.swift */; };
+		OBJ_2196 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_674 /* BinaryEncodingError.swift */; };
+		OBJ_2197 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_675 /* BinaryEncodingSizeVisitor.swift */; };
+		OBJ_2198 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_676 /* BinaryEncodingVisitor.swift */; };
+		OBJ_2199 /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_677 /* CustomJSONCodable.swift */; };
+		OBJ_2200 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_678 /* Data+Extensions.swift */; };
+		OBJ_2201 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_679 /* Decoder.swift */; };
+		OBJ_2202 /* DoubleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_680 /* DoubleParser.swift */; };
+		OBJ_2203 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_681 /* Enum.swift */; };
+		OBJ_2204 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_682 /* ExtensibleMessage.swift */; };
+		OBJ_2205 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_683 /* ExtensionFieldValueSet.swift */; };
+		OBJ_2206 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_684 /* ExtensionFields.swift */; };
+		OBJ_2207 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_685 /* ExtensionMap.swift */; };
+		OBJ_2208 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_686 /* FieldTag.swift */; };
+		OBJ_2209 /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_687 /* FieldTypes.swift */; };
+		OBJ_2210 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_688 /* Google_Protobuf_Any+Extensions.swift */; };
+		OBJ_2211 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_689 /* Google_Protobuf_Any+Registry.swift */; };
+		OBJ_2212 /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_690 /* Google_Protobuf_Duration+Extensions.swift */; };
+		OBJ_2213 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_691 /* Google_Protobuf_FieldMask+Extensions.swift */; };
+		OBJ_2214 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_692 /* Google_Protobuf_ListValue+Extensions.swift */; };
+		OBJ_2215 /* Google_Protobuf_NullValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_693 /* Google_Protobuf_NullValue+Extensions.swift */; };
+		OBJ_2216 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_694 /* Google_Protobuf_Struct+Extensions.swift */; };
+		OBJ_2217 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_695 /* Google_Protobuf_Timestamp+Extensions.swift */; };
+		OBJ_2218 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_696 /* Google_Protobuf_Value+Extensions.swift */; };
+		OBJ_2219 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_697 /* Google_Protobuf_Wrappers+Extensions.swift */; };
+		OBJ_2220 /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_698 /* HashVisitor.swift */; };
+		OBJ_2221 /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_699 /* Internal.swift */; };
+		OBJ_2222 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_700 /* JSONDecoder.swift */; };
+		OBJ_2223 /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_701 /* JSONDecodingError.swift */; };
+		OBJ_2224 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_702 /* JSONDecodingOptions.swift */; };
+		OBJ_2225 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_703 /* JSONEncoder.swift */; };
+		OBJ_2226 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_704 /* JSONEncodingError.swift */; };
+		OBJ_2227 /* JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_705 /* JSONEncodingOptions.swift */; };
+		OBJ_2228 /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_706 /* JSONEncodingVisitor.swift */; };
+		OBJ_2229 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_707 /* JSONMapEncodingVisitor.swift */; };
+		OBJ_2230 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_708 /* JSONScanner.swift */; };
+		OBJ_2231 /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_709 /* MathUtils.swift */; };
+		OBJ_2232 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_710 /* Message+AnyAdditions.swift */; };
+		OBJ_2233 /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_711 /* Message+BinaryAdditions.swift */; };
+		OBJ_2234 /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_712 /* Message+JSONAdditions.swift */; };
+		OBJ_2235 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_713 /* Message+JSONArrayAdditions.swift */; };
+		OBJ_2236 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_714 /* Message+TextFormatAdditions.swift */; };
+		OBJ_2237 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_715 /* Message.swift */; };
+		OBJ_2238 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_716 /* MessageExtension.swift */; };
+		OBJ_2239 /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_717 /* NameMap.swift */; };
+		OBJ_2240 /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_718 /* ProtoNameProviding.swift */; };
+		OBJ_2241 /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_719 /* ProtobufAPIVersionCheck.swift */; };
+		OBJ_2242 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_720 /* ProtobufMap.swift */; };
+		OBJ_2243 /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_721 /* SelectiveVisitor.swift */; };
+		OBJ_2244 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_722 /* SimpleExtensionMap.swift */; };
+		OBJ_2245 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_723 /* StringUtils.swift */; };
+		OBJ_2246 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_724 /* TextFormatDecoder.swift */; };
+		OBJ_2247 /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_725 /* TextFormatDecodingError.swift */; };
+		OBJ_2248 /* TextFormatDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_726 /* TextFormatDecodingOptions.swift */; };
+		OBJ_2249 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_727 /* TextFormatEncoder.swift */; };
+		OBJ_2250 /* TextFormatEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_728 /* TextFormatEncodingOptions.swift */; };
+		OBJ_2251 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_729 /* TextFormatEncodingVisitor.swift */; };
+		OBJ_2252 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_730 /* TextFormatScanner.swift */; };
+		OBJ_2253 /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_731 /* TimeUtils.swift */; };
+		OBJ_2254 /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_732 /* UnknownStorage.swift */; };
+		OBJ_2255 /* UnsafeBufferPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_733 /* UnsafeBufferPointer+Shims.swift */; };
+		OBJ_2256 /* UnsafeRawPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_734 /* UnsafeRawPointer+Shims.swift */; };
+		OBJ_2257 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_735 /* Varint.swift */; };
+		OBJ_2258 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_736 /* Version.swift */; };
+		OBJ_2259 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_737 /* Visitor.swift */; };
+		OBJ_2260 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_738 /* WireFormat.swift */; };
+		OBJ_2261 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_739 /* ZigZag.swift */; };
+		OBJ_2262 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_740 /* any.pb.swift */; };
+		OBJ_2263 /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_741 /* api.pb.swift */; };
+		OBJ_2264 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_742 /* descriptor.pb.swift */; };
+		OBJ_2265 /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_743 /* duration.pb.swift */; };
+		OBJ_2266 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_744 /* empty.pb.swift */; };
+		OBJ_2267 /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_745 /* field_mask.pb.swift */; };
+		OBJ_2268 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_746 /* source_context.pb.swift */; };
+		OBJ_2269 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_747 /* struct.pb.swift */; };
+		OBJ_2270 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_748 /* timestamp.pb.swift */; };
+		OBJ_2271 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_749 /* type.pb.swift */; };
+		OBJ_2272 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_750 /* wrappers.pb.swift */; };
+		OBJ_2279 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_753 /* Package.swift */; };
+		OBJ_2285 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1143 /* Package.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		403811F4284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchCore";
+			remoteInfo = InstantSearchCore;
+		};
+		403811F5284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-telemetry-native::InstantSearchTelemetry";
+			remoteInfo = InstantSearchTelemetry;
+		};
+		403811F6284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		403811F7284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		403811F8284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		403811F9284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		403811FA284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		403811FB284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		403811FC284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		403811FD284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		403811FE284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-telemetry-native::InstantSearchTelemetry";
+			remoteInfo = InstantSearchTelemetry;
+		};
+		403811FF284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		40381200284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		40381201284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		40381202284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		40381203284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchCore";
+			remoteInfo = InstantSearchCore;
+		};
+		40381204284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-telemetry-native::InstantSearchTelemetry";
+			remoteInfo = InstantSearchTelemetry;
+		};
+		40381205284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		40381206284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		40381207284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		40381208284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		40381209284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchCore";
+			remoteInfo = InstantSearchCore;
+		};
+		4038120A284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-telemetry-native::InstantSearchTelemetry";
+			remoteInfo = InstantSearchTelemetry;
+		};
+		4038120B284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		4038120C284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		4038120D284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		4038120E284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		4038120F284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		40381210284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		40381211284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		40381212284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchSwiftUI";
+			remoteInfo = InstantSearchSwiftUI;
+		};
+		40381213284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchCore";
+			remoteInfo = InstantSearchCore;
+		};
+		40381214284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-telemetry-native::InstantSearchTelemetry";
+			remoteInfo = InstantSearchTelemetry;
+		};
+		40381215284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		40381216284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		40381217284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		40381218284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		40381219284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearch";
+			remoteInfo = InstantSearch;
+		};
+		4038121A284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchCore";
+			remoteInfo = InstantSearchCore;
+		};
+		4038121B284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-telemetry-native::InstantSearchTelemetry";
+			remoteInfo = InstantSearchTelemetry;
+		};
+		4038121C284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-protobuf::SwiftProtobuf";
+			remoteInfo = SwiftProtobuf;
+		};
+		4038121D284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsights";
+			remoteInfo = InstantSearchInsights;
+		};
+		4038121E284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "algoliasearch-client-swift::AlgoliaSearchClient";
+			remoteInfo = AlgoliaSearchClient;
+		};
+		4038121F284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "swift-log::Logging";
+			remoteInfo = Logging;
+		};
+		40381220284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchTests";
+			remoteInfo = InstantSearchTests;
+		};
+		40381221284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchSwiftUITests";
+			remoteInfo = InstantSearchSwiftUITests;
+		};
+		40381222284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchInsightsTests";
+			remoteInfo = InstantSearchInsightsTests;
+		};
+		40381223284007E60060B8D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "instantsearch-ios::InstantSearchCoreTests";
+			remoteInfo = InstantSearchCoreTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		OBJ_10 /* MultiIndexSearchConnector+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexSearchConnector+UIKit.swift"; sourceTree = "<group>"; };
+		OBJ_1000 /* SnippetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetResult.swift; sourceTree = "<group>"; };
+		OBJ_1001 /* IndexName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexName.swift; sourceTree = "<group>"; };
+		OBJ_1004 /* BatchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchOperation.swift; sourceTree = "<group>"; };
+		OBJ_1005 /* BatchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchResponse.swift; sourceTree = "<group>"; };
+		OBJ_1006 /* IndexBatchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexBatchOperation.swift; sourceTree = "<group>"; };
+		OBJ_1007 /* Cursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cursor.swift; sourceTree = "<group>"; };
+		OBJ_1008 /* IndexOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexOperation.swift; sourceTree = "<group>"; };
+		OBJ_1009 /* ObjectRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectRequest.swift; sourceTree = "<group>"; };
+		OBJ_101 /* Boundable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Boundable.swift; sourceTree = "<group>"; };
+		OBJ_1010 /* ObjectWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectWrapper.swift; sourceTree = "<group>"; };
+		OBJ_1011 /* PartialUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialUpdate.swift; sourceTree = "<group>"; };
+		OBJ_1012 /* PartialUpdateAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialUpdateAction.swift; sourceTree = "<group>"; };
+		OBJ_1013 /* Scope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scope.swift; sourceTree = "<group>"; };
+		OBJ_1015 /* BatchesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchesResponse.swift; sourceTree = "<group>"; };
+		OBJ_1016 /* IndexedFacetQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedFacetQuery.swift; sourceTree = "<group>"; };
+		OBJ_1017 /* IndexedQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedQuery.swift; sourceTree = "<group>"; };
+		OBJ_1018 /* IndicesListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicesListResponse.swift; sourceTree = "<group>"; };
+		OBJ_1019 /* MultiSearchQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSearchQuery.swift; sourceTree = "<group>"; };
+		OBJ_102 /* DoubleRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleRepresentable.swift; sourceTree = "<group>"; };
+		OBJ_1020 /* MultipleQueriesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleQueriesRequest.swift; sourceTree = "<group>"; };
+		OBJ_1021 /* MultipleQueriesStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleQueriesStrategy.swift; sourceTree = "<group>"; };
+		OBJ_1022 /* SearchesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchesResponse.swift; sourceTree = "<group>"; };
+		OBJ_1025 /* AroundPrecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AroundPrecision.swift; sourceTree = "<group>"; };
+		OBJ_1026 /* AroundRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AroundRadius.swift; sourceTree = "<group>"; };
+		OBJ_1027 /* BoundingBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundingBox.swift; sourceTree = "<group>"; };
+		OBJ_1028 /* ExplainModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplainModule.swift; sourceTree = "<group>"; };
+		OBJ_1029 /* FiltersStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersStorage.swift; sourceTree = "<group>"; };
+		OBJ_103 /* Point+CoreLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Point+CoreLocation.swift"; sourceTree = "<group>"; };
+		OBJ_1030 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
+		OBJ_1031 /* Polygon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Polygon.swift; sourceTree = "<group>"; };
+		OBJ_1032 /* DeleteByQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteByQuery.swift; sourceTree = "<group>"; };
+		OBJ_1033 /* Query+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Query+Codable.swift"; sourceTree = "<group>"; };
+		OBJ_1034 /* Query+URLEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Query+URLEncodable.swift"; sourceTree = "<group>"; };
+		OBJ_1035 /* Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
+		OBJ_1036 /* QueryID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryID.swift; sourceTree = "<group>"; };
+		OBJ_1038 /* FacetSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetSearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_1039 /* HitWithPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitWithPosition.swift; sourceTree = "<group>"; };
+		OBJ_1040 /* MultiSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_1041 /* ObjectsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectsResponse.swift; sourceTree = "<group>"; };
+		OBJ_1045 /* Alternative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alternative.swift; sourceTree = "<group>"; };
+		OBJ_1046 /* AlternativeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeType.swift; sourceTree = "<group>"; };
+		OBJ_1047 /* Explain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Explain.swift; sourceTree = "<group>"; };
+		OBJ_1048 /* QueryMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryMatch.swift; sourceTree = "<group>"; };
+		OBJ_105 /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
+		OBJ_1050 /* Facet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Facet.swift; sourceTree = "<group>"; };
+		OBJ_1051 /* FacetsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetsStorage.swift; sourceTree = "<group>"; };
+		OBJ_1053 /* FacetStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetStats.swift; sourceTree = "<group>"; };
+		OBJ_1054 /* FacetStatsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetStatsStorage.swift; sourceTree = "<group>"; };
+		OBJ_1056 /* HighlightedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedString.swift; sourceTree = "<group>"; };
+		OBJ_1057 /* TaggedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaggedString.swift; sourceTree = "<group>"; };
+		OBJ_106 /* QuerySuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuerySuggestion.swift; sourceTree = "<group>"; };
+		OBJ_1060 /* FacetOrdering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetOrdering.swift; sourceTree = "<group>"; };
+		OBJ_1061 /* FacetValuesOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetValuesOrder.swift; sourceTree = "<group>"; };
+		OBJ_1062 /* FacetsOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetsOrder.swift; sourceTree = "<group>"; };
+		OBJ_1063 /* SearchResponse+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResponse+Codable.swift"; sourceTree = "<group>"; };
+		OBJ_1064 /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_1065 /* SearchConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_1066 /* SearchParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchParameters.swift; sourceTree = "<group>"; };
+		OBJ_1067 /* SearchParametersStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchParametersStorage.swift; sourceTree = "<group>"; };
+		OBJ_107 /* Reloadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reloadable.swift; sourceTree = "<group>"; };
+		OBJ_1070 /* AdvancedSyntaxFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSyntaxFeatures.swift; sourceTree = "<group>"; };
+		OBJ_1071 /* AlternativesAsExact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativesAsExact.swift; sourceTree = "<group>"; };
+		OBJ_1072 /* AttributeForFaceting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeForFaceting.swift; sourceTree = "<group>"; };
+		OBJ_1073 /* CustomRankingCriterion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRankingCriterion.swift; sourceTree = "<group>"; };
+		OBJ_1074 /* DecompoundedAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecompoundedAttributes.swift; sourceTree = "<group>"; };
+		OBJ_1075 /* Distinct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Distinct.swift; sourceTree = "<group>"; };
+		OBJ_1076 /* ExactOnSingleWordQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExactOnSingleWordQuery.swift; sourceTree = "<group>"; };
+		OBJ_1077 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
+		OBJ_1078 /* LanguageFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageFeature.swift; sourceTree = "<group>"; };
+		OBJ_1079 /* NumericAttributeFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericAttributeFilter.swift; sourceTree = "<group>"; };
+		OBJ_108 /* ResultUpdatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultUpdatable.swift; sourceTree = "<group>"; };
+		OBJ_1080 /* QueryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryType.swift; sourceTree = "<group>"; };
+		OBJ_1081 /* RankingCriterion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingCriterion.swift; sourceTree = "<group>"; };
+		OBJ_1082 /* RemoveWordIfNoResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveWordIfNoResults.swift; sourceTree = "<group>"; };
+		OBJ_1083 /* SearchableAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableAttribute.swift; sourceTree = "<group>"; };
+		OBJ_1084 /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
+		OBJ_1085 /* SortFacetsBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortFacetsBy.swift; sourceTree = "<group>"; };
+		OBJ_1086 /* TypoTolerance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypoTolerance.swift; sourceTree = "<group>"; };
+		OBJ_1087 /* Settings+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Settings+CustomStringConvertible.swift"; sourceTree = "<group>"; };
+		OBJ_1088 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
+		OBJ_1089 /* SettingsParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsParameters.swift; sourceTree = "<group>"; };
+		OBJ_1090 /* SettingsParametersCodingKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsParametersCodingKeys.swift; sourceTree = "<group>"; };
+		OBJ_1091 /* SettingsParametersStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsParametersStorage.swift; sourceTree = "<group>"; };
+		OBJ_1093 /* Synonym.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Synonym.swift; sourceTree = "<group>"; };
+		OBJ_1094 /* SynonymQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynonymQuery.swift; sourceTree = "<group>"; };
+		OBJ_1095 /* SynonymRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynonymRevision.swift; sourceTree = "<group>"; };
+		OBJ_1096 /* SynonymSearchResponse+Hit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SynonymSearchResponse+Hit.swift"; sourceTree = "<group>"; };
+		OBJ_1097 /* SynonymSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynonymSearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_1098 /* SynonymType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynonymType.swift; sourceTree = "<group>"; };
+		OBJ_11 /* SearchConnector+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchConnector+UIKit.swift"; sourceTree = "<group>"; };
+		OBJ_110 /* SelectableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableController.swift; sourceTree = "<group>"; };
+		OBJ_1100 /* AppTaskID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTaskID.swift; sourceTree = "<group>"; };
+		OBJ_1102 /* AppTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTask.swift; sourceTree = "<group>"; };
+		OBJ_1103 /* IndexTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexTask.swift; sourceTree = "<group>"; };
+		OBJ_1104 /* TaskInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInfo.swift; sourceTree = "<group>"; };
+		OBJ_1105 /* TaskStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStatus.swift; sourceTree = "<group>"; };
+		OBJ_1107 /* IndexDeletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexDeletion.swift; sourceTree = "<group>"; };
+		OBJ_1108 /* IndexRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexRevision.swift; sourceTree = "<group>"; };
+		OBJ_1109 /* IndexedTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedTask.swift; sourceTree = "<group>"; };
+		OBJ_111 /* SelectableInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableInteractor.swift; sourceTree = "<group>"; };
+		OBJ_1111 /* ObjectCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectCreation.swift; sourceTree = "<group>"; };
+		OBJ_1112 /* ObjectDeletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectDeletion.swift; sourceTree = "<group>"; };
+		OBJ_1113 /* ObjectRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectRevision.swift; sourceTree = "<group>"; };
+		OBJ_1114 /* TaskID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskID.swift; sourceTree = "<group>"; };
+		OBJ_1117 /* Transport+CustomRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transport+CustomRequest.swift"; sourceTree = "<group>"; };
+		OBJ_1118 /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		OBJ_1119 /* TransportContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportContainer.swift; sourceTree = "<group>"; };
+		OBJ_1121 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
+		OBJ_1122 /* HTTPRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestBuilder.swift; sourceTree = "<group>"; };
+		OBJ_1123 /* HTTPRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequester.swift; sourceTree = "<group>"; };
+		OBJ_1124 /* HTTPTransport+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPTransport+Error.swift"; sourceTree = "<group>"; };
+		OBJ_1125 /* HTTPTransport+Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPTransport+Result.swift"; sourceTree = "<group>"; };
+		OBJ_1126 /* HTTPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTransport.swift; sourceTree = "<group>"; };
+		OBJ_1127 /* OperationLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationLauncher.swift; sourceTree = "<group>"; };
+		OBJ_1129 /* AlgoliaRetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaRetryStrategy.swift; sourceTree = "<group>"; };
+		OBJ_113 /* SelectableListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableListController.swift; sourceTree = "<group>"; };
+		OBJ_1130 /* HostIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostIterator.swift; sourceTree = "<group>"; };
+		OBJ_1131 /* HostSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostSwitcher.swift; sourceTree = "<group>"; };
+		OBJ_1132 /* RetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryStrategy.swift; sourceTree = "<group>"; };
+		OBJ_1133 /* RetryableHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryableHost.swift; sourceTree = "<group>"; };
+		OBJ_1135 /* URLRequest+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_1136 /* URLSession+HTTPRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+HTTPRequester.swift"; sourceTree = "<group>"; };
+		OBJ_1137 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/vladislav.fitc/Workspace/algolia/instantsearch-ios/.build/checkouts/algoliasearch-client-swift/Package.swift"; sourceTree = "<group>"; };
+		OBJ_114 /* SelectableListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableListInteractor.swift; sourceTree = "<group>"; };
+		OBJ_1140 /* Locks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locks.swift; sourceTree = "<group>"; };
+		OBJ_1141 /* LogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogHandler.swift; sourceTree = "<group>"; };
+		OBJ_1142 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		OBJ_1143 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/vladislav.fitc/Workspace/algolia/instantsearch-ios/.build/checkouts/swift-log/Package.swift"; sourceTree = "<group>"; };
+		OBJ_1157 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = SOURCE_ROOT; };
+		OBJ_1158 /* Examples */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Examples; sourceTree = SOURCE_ROOT; };
+		OBJ_1159 /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = SOURCE_ROOT; };
+		OBJ_116 /* SelectableSegmentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableSegmentController.swift; sourceTree = "<group>"; };
+		OBJ_1160 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
+		OBJ_1161 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		OBJ_1162 /* carthage-prebuild */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-prebuild"; sourceTree = "<group>"; };
+		OBJ_1163 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
+		OBJ_1164 /* generate_changelog */ = {isa = PBXFileReference; lastKnownFileType = text; path = generate_changelog; sourceTree = "<group>"; };
+		OBJ_1165 /* InstantSearch.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = InstantSearch.podspec; sourceTree = "<group>"; };
+		OBJ_1166 /* Readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
+		OBJ_1167 /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
+		OBJ_1168 /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
+		OBJ_1169 /* generate_version */ = {isa = PBXFileReference; lastKnownFileType = text; path = generate_version; sourceTree = "<group>"; };
+		OBJ_117 /* SelectableSegmentInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableSegmentInteractor.swift; sourceTree = "<group>"; };
+		OBJ_120 /* CurrentFiltersConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentFiltersConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_121 /* CurrentFiltersConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersConnector.swift; sourceTree = "<group>"; };
+		OBJ_122 /* CurrentFiltersInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentFiltersInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_123 /* CurrentFiltersInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersInteractor.swift; sourceTree = "<group>"; };
+		OBJ_124 /* CurrentFiltersListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersListController.swift; sourceTree = "<group>"; };
+		OBJ_125 /* ItemListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListController.swift; sourceTree = "<group>"; };
+		OBJ_126 /* ItemListInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ItemListInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_127 /* ItemsListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsListInteractor.swift; sourceTree = "<group>"; };
+		OBJ_129 /* AttributedFacets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedFacets.swift; sourceTree = "<group>"; };
+		OBJ_13 /* ClearRefinementsButtonController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearRefinementsButtonController.swift; sourceTree = "<group>"; };
+		OBJ_131 /* DynamicFacetListConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DynamicFacetListConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_132 /* DynamicFacetListConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFacetListConnector.swift; sourceTree = "<group>"; };
+		OBJ_133 /* DynamicFacetListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFacetListController.swift; sourceTree = "<group>"; };
+		OBJ_134 /* DynamicFacetListInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DynamicFacetListInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_135 /* DynamicFacetListInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DynamicFacetListInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_136 /* DynamicFacetListInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DynamicFacetListInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_137 /* DynamicFacetListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFacetListInteractor.swift; sourceTree = "<group>"; };
+		OBJ_138 /* FacetsOrderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetsOrderer.swift; sourceTree = "<group>"; };
+		OBJ_140 /* Optional+Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Collection.swift"; sourceTree = "<group>"; };
+		OBJ_141 /* Optional+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+String.swift"; sourceTree = "<group>"; };
+		OBJ_142 /* Query+Facets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Query+Facets.swift"; sourceTree = "<group>"; };
+		OBJ_143 /* Result+ConvenientInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenientInit.swift"; sourceTree = "<group>"; };
+		OBJ_144 /* Sequence+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_147 /* FacetListConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_148 /* FacetListConnector+FacetSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListConnector+FacetSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_149 /* FacetListConnector+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListConnector+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_15 /* CurrentFiltersSearchTextFieldController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersSearchTextFieldController.swift; sourceTree = "<group>"; };
+		OBJ_150 /* FacetListConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListConnector.swift; sourceTree = "<group>"; };
+		OBJ_151 /* FacetListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListController.swift; sourceTree = "<group>"; };
+		OBJ_152 /* FacetListInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_153 /* FacetListInteractor+FacetSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListInteractor+FacetSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_154 /* FacetListInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_155 /* FacetListInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_156 /* FacetListInteractor+MultiIndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetListInteractor+MultiIndexSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_157 /* FacetListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListInteractor.swift; sourceTree = "<group>"; };
+		OBJ_158 /* FacetListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListPresenter.swift; sourceTree = "<group>"; };
+		OBJ_16 /* CurrentFiltersTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersTableViewController.swift; sourceTree = "<group>"; };
+		OBJ_161 /* FilterClearConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterClearConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_162 /* FilterClearConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterClearConnector.swift; sourceTree = "<group>"; };
+		OBJ_163 /* FilterClearController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterClearController.swift; sourceTree = "<group>"; };
+		OBJ_164 /* FilterClearInteractor+FilterClearController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterClearInteractor+FilterClearController.swift"; sourceTree = "<group>"; };
+		OBJ_165 /* FilterClearInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterClearInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_166 /* FilterClearInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterClearInteractor.swift; sourceTree = "<group>"; };
+		OBJ_169 /* FacetFilterListConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetFilterListConnector.swift; sourceTree = "<group>"; };
+		OBJ_170 /* FilterListConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterListConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_171 /* FilterListConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListConnector.swift; sourceTree = "<group>"; };
+		OBJ_172 /* FilterTypeAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTypeAliases.swift; sourceTree = "<group>"; };
+		OBJ_173 /* NumericFilterListConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericFilterListConnector.swift; sourceTree = "<group>"; };
+		OBJ_174 /* TagFilterListConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFilterListConnector.swift; sourceTree = "<group>"; };
+		OBJ_175 /* FilterListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListController.swift; sourceTree = "<group>"; };
+		OBJ_176 /* FilterListInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterListInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_177 /* FilterListInteractor+Facet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterListInteractor+Facet.swift"; sourceTree = "<group>"; };
+		OBJ_178 /* FilterListInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterListInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_179 /* FilterListInteractor+Numeric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterListInteractor+Numeric.swift"; sourceTree = "<group>"; };
+		OBJ_18 /* DynamicFacetListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFacetListTableViewController.swift; sourceTree = "<group>"; };
+		OBJ_180 /* FilterListInteractor+Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterListInteractor+Tag.swift"; sourceTree = "<group>"; };
+		OBJ_181 /* FilterListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListInteractor.swift; sourceTree = "<group>"; };
+		OBJ_184 /* FilterMapConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterMapConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_185 /* FilterMapConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMapConnector.swift; sourceTree = "<group>"; };
+		OBJ_186 /* FilterMapInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterMapInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_187 /* FilterMapInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterMapInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_188 /* FilterMapInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterMapInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_189 /* FilterMapInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMapInteractor.swift; sourceTree = "<group>"; };
+		OBJ_192 /* AndGroupAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndGroupAccessor.swift; sourceTree = "<group>"; };
+		OBJ_193 /* GroupAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupAccessor.swift; sourceTree = "<group>"; };
+		OBJ_194 /* HierarchicalGroupAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalGroupAccessor.swift; sourceTree = "<group>"; };
+		OBJ_195 /* OrGroupAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrGroupAccessor.swift; sourceTree = "<group>"; };
+		OBJ_196 /* SpecializedAndGroupAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecializedAndGroupAccessor.swift; sourceTree = "<group>"; };
+		OBJ_199 /* FilterConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterConverter.swift; sourceTree = "<group>"; };
+		OBJ_20 /* FacetListTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListTableController.swift; sourceTree = "<group>"; };
+		OBJ_200 /* FilterGroupConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupConverter.swift; sourceTree = "<group>"; };
+		OBJ_201 /* LegacySyntax.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacySyntax.swift; sourceTree = "<group>"; };
+		OBJ_202 /* SQLSyntax.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLSyntax.swift; sourceTree = "<group>"; };
+		OBJ_203 /* FacetFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetFilter.swift; sourceTree = "<group>"; };
+		OBJ_204 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		OBJ_206 /* AndFilterGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndFilterGroup.swift; sourceTree = "<group>"; };
+		OBJ_207 /* FilterGroupType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupType.swift; sourceTree = "<group>"; };
+		OBJ_208 /* HierarchicalFilterGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalFilterGroup.swift; sourceTree = "<group>"; };
+		OBJ_209 /* OrFilterGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrFilterGroup.swift; sourceTree = "<group>"; };
+		OBJ_210 /* NumericFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericFilter.swift; sourceTree = "<group>"; };
+		OBJ_211 /* TagFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFilter.swift; sourceTree = "<group>"; };
+		OBJ_212 /* FilterGroupID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupID.swift; sourceTree = "<group>"; };
+		OBJ_213 /* FilterGroupsConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupsConvertible.swift; sourceTree = "<group>"; };
+		OBJ_214 /* FilterState+Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterState+Commands.swift"; sourceTree = "<group>"; };
+		OBJ_215 /* FilterState+DisjunctiveFaceting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterState+DisjunctiveFaceting.swift"; sourceTree = "<group>"; };
+		OBJ_216 /* FilterState+FiltersReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterState+FiltersReadable.swift"; sourceTree = "<group>"; };
+		OBJ_217 /* FilterState+FiltersWritable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterState+FiltersWritable.swift"; sourceTree = "<group>"; };
+		OBJ_218 /* FilterState+HierarchicalFaceting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterState+HierarchicalFaceting.swift"; sourceTree = "<group>"; };
+		OBJ_219 /* FilterState+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterState+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_22 /* FilterListTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListTableController.swift; sourceTree = "<group>"; };
+		OBJ_220 /* FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterState.swift; sourceTree = "<group>"; };
+		OBJ_221 /* FilterStateDSL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterStateDSL.swift; sourceTree = "<group>"; };
+		OBJ_222 /* FiltersReadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersReadable.swift; sourceTree = "<group>"; };
+		OBJ_223 /* FiltersSettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersSettable.swift; sourceTree = "<group>"; };
+		OBJ_224 /* FiltersWritable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiltersWritable.swift; sourceTree = "<group>"; };
+		OBJ_225 /* GroupStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupStorage.swift; sourceTree = "<group>"; };
+		OBJ_226 /* HierarchicalManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalManageable.swift; sourceTree = "<group>"; };
+		OBJ_228 /* Decodable+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+JSON.swift"; sourceTree = "<group>"; };
+		OBJ_229 /* UserAgentSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentSetter.swift; sourceTree = "<group>"; };
+		OBJ_230 /* Version+Current.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Version+Current.swift"; sourceTree = "<group>"; };
+		OBJ_233 /* HierarchicalConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HierarchicalConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_234 /* HierarchicalConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalConnector.swift; sourceTree = "<group>"; };
+		OBJ_235 /* HierarchicalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalController.swift; sourceTree = "<group>"; };
+		OBJ_236 /* HierarchicalInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HierarchicalInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_237 /* HierarchicalInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HierarchicalInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_238 /* HierarchicalInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HierarchicalInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_239 /* HierarchicalInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalInteractor.swift; sourceTree = "<group>"; };
+		OBJ_24 /* UICollectionView+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_241 /* NSAttributedString+TaggedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+TaggedString.swift"; sourceTree = "<group>"; };
+		OBJ_243 /* AnyHitsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyHitsInteractor.swift; sourceTree = "<group>"; };
+		OBJ_245 /* HitsConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_246 /* HitsConnector+GeoSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsConnector+GeoSearch.swift"; sourceTree = "<group>"; };
+		OBJ_247 /* HitsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsConnector.swift; sourceTree = "<group>"; };
+		OBJ_248 /* GeoHitsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoHitsController.swift; sourceTree = "<group>"; };
+		OBJ_249 /* HitsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsController.swift; sourceTree = "<group>"; };
+		OBJ_25 /* UITableView+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_250 /* HitsExtractable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsExtractable.swift; sourceTree = "<group>"; };
+		OBJ_251 /* HitsInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_252 /* HitsInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_253 /* HitsInteractor+GeoHitsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+GeoHitsController.swift"; sourceTree = "<group>"; };
+		OBJ_254 /* HitsInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_255 /* HitsInteractor+PlacesSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+PlacesSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_256 /* HitsInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_257 /* HitsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractor.swift; sourceTree = "<group>"; };
+		OBJ_258 /* HitsSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsSource.swift; sourceTree = "<group>"; };
+		OBJ_259 /* MultiSourceReloadNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSourceReloadNotifier.swift; sourceTree = "<group>"; };
+		OBJ_261 /* MatchingPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchingPattern.swift; sourceTree = "<group>"; };
+		OBJ_262 /* RelatedItemsInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelatedItemsInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_264 /* InfiniteScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollable.swift; sourceTree = "<group>"; };
+		OBJ_265 /* InfiniteScrollingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollingController.swift; sourceTree = "<group>"; };
+		OBJ_268 /* LoadingConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoadingConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_269 /* LoadingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingConnector.swift; sourceTree = "<group>"; };
+		OBJ_27 /* HierarchicalTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalTableViewController.swift; sourceTree = "<group>"; };
+		OBJ_270 /* LoadingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingController.swift; sourceTree = "<group>"; };
+		OBJ_271 /* LoadingInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoadingInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_272 /* LoadingInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoadingInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_273 /* LoadingInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingInteractor.swift; sourceTree = "<group>"; };
+		OBJ_275 /* DecodingErrorPrettyPrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorPrettyPrinter.swift; sourceTree = "<group>"; };
+		OBJ_276 /* Logger+InstantSearchCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+InstantSearchCore.swift"; sourceTree = "<group>"; };
+		OBJ_279 /* MultiIndexHitsConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_280 /* MultiIndexHitsConnector+IndexModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsConnector+IndexModule.swift"; sourceTree = "<group>"; };
+		OBJ_281 /* MultiIndexHitsConnector+Suggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsConnector+Suggestions.swift"; sourceTree = "<group>"; };
+		OBJ_282 /* MultiIndexHitsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsConnector.swift; sourceTree = "<group>"; };
+		OBJ_283 /* MultiIndexHitsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsController.swift; sourceTree = "<group>"; };
+		OBJ_284 /* MultiIndexHitsInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_285 /* MultiIndexHitsInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_286 /* MultiIndexHitsInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_287 /* MultiIndexHitsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsInteractor.swift; sourceTree = "<group>"; };
+		OBJ_288 /* MultiIndexHitsSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsSource.swift; sourceTree = "<group>"; };
+		OBJ_29 /* CellConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfigurable.swift; sourceTree = "<group>"; };
+		OBJ_290 /* Boundable+SearchResultProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Boundable+SearchResultProvider.swift"; sourceTree = "<group>"; };
+		OBJ_291 /* Computation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Computation.swift; sourceTree = "<group>"; };
+		OBJ_293 /* FilterComparisonConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterComparisonConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_294 /* FilterComparisonConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterComparisonConnector.swift; sourceTree = "<group>"; };
+		OBJ_295 /* FilterComparison+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterComparison+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_296 /* FilterComparison+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterComparison+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_297 /* FilterComparisonComputeBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterComparisonComputeBounds.swift; sourceTree = "<group>"; };
+		OBJ_298 /* NumberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberController.swift; sourceTree = "<group>"; };
+		OBJ_299 /* NumberInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberInteractor.swift; sourceTree = "<group>"; };
+		OBJ_302 /* NumberRangeConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberRangeConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_303 /* NumberRangeConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberRangeConnector.swift; sourceTree = "<group>"; };
+		OBJ_304 /* NumberRangeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberRangeController.swift; sourceTree = "<group>"; };
+		OBJ_305 /* NumberRangeInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberRangeInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_306 /* NumberRangeInteractor+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberRangeInteractor+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_307 /* NumberRangeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberRangeInteractor.swift; sourceTree = "<group>"; };
+		OBJ_309 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
+		OBJ_31 /* HitsCollectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsCollectionController.swift; sourceTree = "<group>"; };
+		OBJ_310 /* Observation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observation.swift; sourceTree = "<group>"; };
+		OBJ_311 /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
+		OBJ_312 /* Signals+Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signals+Observable.swift"; sourceTree = "<group>"; };
+		OBJ_313 /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
+		OBJ_315 /* PageLoadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageLoadable.swift; sourceTree = "<group>"; };
+		OBJ_316 /* PageMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageMap.swift; sourceTree = "<group>"; };
+		OBJ_317 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
+		OBJ_318 /* SearchResults+PageMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResults+PageMap.swift"; sourceTree = "<group>"; };
+		OBJ_319 /* SynchronizedSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedSet.swift; sourceTree = "<group>"; };
+		OBJ_32 /* HitsCollectionViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsCollectionViewContainer.swift; sourceTree = "<group>"; };
+		OBJ_321 /* DefaultPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPresenter.swift; sourceTree = "<group>"; };
+		OBJ_322 /* FacetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetPresenter.swift; sourceTree = "<group>"; };
+		OBJ_323 /* FilterPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterPresenter.swift; sourceTree = "<group>"; };
+		OBJ_324 /* HierarchicalPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalPresenter.swift; sourceTree = "<group>"; };
+		OBJ_325 /* IndexNamePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexNamePresenter.swift; sourceTree = "<group>"; };
+		OBJ_326 /* IndexPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexPresenter.swift; sourceTree = "<group>"; };
+		OBJ_327 /* RelevantSortPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortPresenter.swift; sourceTree = "<group>"; };
+		OBJ_328 /* StatsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPresenter.swift; sourceTree = "<group>"; };
+		OBJ_33 /* HitsCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsCollectionViewController.swift; sourceTree = "<group>"; };
+		OBJ_330 /* QueryBuilder+DisjunctiveFaceting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryBuilder+DisjunctiveFaceting.swift"; sourceTree = "<group>"; };
+		OBJ_331 /* QueryBuilder+HierarchicalFaceting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryBuilder+HierarchicalFaceting.swift"; sourceTree = "<group>"; };
+		OBJ_332 /* QueryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryBuilder.swift; sourceTree = "<group>"; };
+		OBJ_335 /* QueryRuleCustomDataConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryRuleCustomDataConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_336 /* QueryRuleCustomDataConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryRuleCustomDataConnector.swift; sourceTree = "<group>"; };
+		OBJ_337 /* QueryRuleCustomData+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryRuleCustomData+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_338 /* QueryRuleCustomDataInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryRuleCustomDataInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_339 /* QueryRuleCustomDataInteractor+MultiIndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QueryRuleCustomDataInteractor+MultiIndexSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_34 /* HitsCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		OBJ_340 /* QueryRuleCustomDataInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryRuleCustomDataInteractor.swift; sourceTree = "<group>"; };
+		OBJ_343 /* RelevantSortConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelevantSortConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_344 /* RelevantSortConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortConnector.swift; sourceTree = "<group>"; };
+		OBJ_345 /* RelevantSortInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelevantSortInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_346 /* RelevantSortInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelevantSortInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_347 /* RelevantSortInteractor+MultiIndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelevantSortInteractor+MultiIndexSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_348 /* RelevantSortInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortInteractor.swift; sourceTree = "<group>"; };
+		OBJ_349 /* RelevantSortPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortPriority.swift; sourceTree = "<group>"; };
+		OBJ_35 /* HitsCollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsCollectionViewDelegate.swift; sourceTree = "<group>"; };
+		OBJ_352 /* SearchBoxConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchBoxConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_353 /* SearchBoxConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxConnector.swift; sourceTree = "<group>"; };
+		OBJ_354 /* QuerySettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuerySettable.swift; sourceTree = "<group>"; };
+		OBJ_355 /* SearchBoxController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxController.swift; sourceTree = "<group>"; };
+		OBJ_356 /* SearchBoxInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchBoxInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_357 /* SearchBoxInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchBoxInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_358 /* SearchBoxInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxInteractor.swift; sourceTree = "<group>"; };
+		OBJ_359 /* SearchTriggeringMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTriggeringMode.swift; sourceTree = "<group>"; };
+		OBJ_36 /* UICollectionViewController+HitsCollectionViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewController+HitsCollectionViewContainer.swift"; sourceTree = "<group>"; };
+		OBJ_361 /* AbstractSearcher+TextualQueryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractSearcher+TextualQueryProvider.swift"; sourceTree = "<group>"; };
+		OBJ_362 /* AbstractSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractSearcher.swift; sourceTree = "<group>"; };
+		OBJ_364 /* AnswersSearcher+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnswersSearcher+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_365 /* AnswersSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswersSearcher.swift; sourceTree = "<group>"; };
+		OBJ_366 /* DisjunctiveFacetingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisjunctiveFacetingDelegate.swift; sourceTree = "<group>"; };
+		OBJ_368 /* FacetSearcher+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FacetSearcher+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_369 /* FacetSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetSearcher.swift; sourceTree = "<group>"; };
+		OBJ_370 /* HierarchicalFacetingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalFacetingDelegate.swift; sourceTree = "<group>"; };
+		OBJ_372 /* HitsSearcher+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HitsSearcher+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_373 /* HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsSearcher.swift; sourceTree = "<group>"; };
+		OBJ_374 /* IndexNameProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexNameProvider.swift; sourceTree = "<group>"; };
+		OBJ_375 /* IndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSearcher.swift; sourceTree = "<group>"; };
+		OBJ_377 /* AbstractMultiSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractMultiSearcher.swift; sourceTree = "<group>"; };
+		OBJ_378 /* MultiRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiRequest.swift; sourceTree = "<group>"; };
+		OBJ_379 /* MultiResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiResult.swift; sourceTree = "<group>"; };
+		OBJ_38 /* HitsTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTableController.swift; sourceTree = "<group>"; };
+		OBJ_380 /* MultiSearchComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSearchComponent.swift; sourceTree = "<group>"; };
+		OBJ_381 /* MultiSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSearchService.swift; sourceTree = "<group>"; };
+		OBJ_382 /* MultiSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSearcher.swift; sourceTree = "<group>"; };
+		OBJ_384 /* MultiIndexSearcher+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexSearcher+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_385 /* MultiIndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexSearcher.swift; sourceTree = "<group>"; };
+		OBJ_387 /* PlacesSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesSearcher.swift; sourceTree = "<group>"; };
+		OBJ_389 /* AlgoliaAnswersSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaAnswersSearchService.swift; sourceTree = "<group>"; };
+		OBJ_39 /* HitsTableViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTableViewContainer.swift; sourceTree = "<group>"; };
+		OBJ_390 /* AlgoliaMultiSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaMultiSearchService.swift; sourceTree = "<group>"; };
+		OBJ_391 /* AlgoliaPlacesSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaPlacesSearchService.swift; sourceTree = "<group>"; };
+		OBJ_392 /* AlgoliaRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaRequest.swift; sourceTree = "<group>"; };
+		OBJ_393 /* AlgoliaSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaSearchService.swift; sourceTree = "<group>"; };
+		OBJ_394 /* FacetSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetSearchService.swift; sourceTree = "<group>"; };
+		OBJ_395 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
+		OBJ_396 /* Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Searcher.swift; sourceTree = "<group>"; };
+		OBJ_397 /* TextualQueryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextualQueryProvider.swift; sourceTree = "<group>"; };
+		OBJ_399 /* Sequencer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequencer.swift; sourceTree = "<group>"; };
+		OBJ_40 /* HitsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTableViewController.swift; sourceTree = "<group>"; };
+		OBJ_400 /* Signal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
+		OBJ_403 /* SortByConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SortByConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_404 /* SortByConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortByConnector.swift; sourceTree = "<group>"; };
+		OBJ_406 /* IndexSegmentInteractor+AnswersSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexSegmentInteractor+AnswersSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_407 /* IndexSegmentInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexSegmentInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_408 /* IndexSegmentInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexSegmentInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_409 /* IndexSegmentInteractor+MultiIndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexSegmentInteractor+MultiIndexSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_41 /* HitsTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTableViewDataSource.swift; sourceTree = "<group>"; };
+		OBJ_410 /* IndexSegmentInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSegmentInteractor.swift; sourceTree = "<group>"; };
+		OBJ_411 /* SortByInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SortByInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_412 /* SortByInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SortByInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_413 /* SortByInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortByInteractor.swift; sourceTree = "<group>"; };
+		OBJ_416 /* StatsConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_417 /* StatsConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConnector.swift; sourceTree = "<group>"; };
+		OBJ_418 /* SearchStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStats.swift; sourceTree = "<group>"; };
+		OBJ_419 /* SearchStatsConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStatsConvertible.swift; sourceTree = "<group>"; };
+		OBJ_42 /* HitsTableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTableViewDelegate.swift; sourceTree = "<group>"; };
+		OBJ_420 /* StatsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsController.swift; sourceTree = "<group>"; };
+		OBJ_421 /* StatsInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_422 /* StatsInteractor+HitsSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsInteractor+HitsSearcher.swift"; sourceTree = "<group>"; };
+		OBJ_423 /* StatsInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_424 /* StatsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsInteractor.swift; sourceTree = "<group>"; };
+		OBJ_426 /* SwitchIndexInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwitchIndexInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_427 /* SwitchIndexInteractor+Searcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwitchIndexInteractor+Searcher.swift"; sourceTree = "<group>"; };
+		OBJ_428 /* SwitchIndexInteractor.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchIndexInteractor.swift.swift; sourceTree = "<group>"; };
+		OBJ_43 /* UITableViewController+HitsTableViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+HitsTableViewContainer.swift"; sourceTree = "<group>"; };
+		OBJ_430 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
+		OBJ_433 /* FilterToggleConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterToggleConnector+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_434 /* FilterToggleConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterToggleConnector.swift; sourceTree = "<group>"; };
+		OBJ_435 /* FilgerToggle+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilgerToggle+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_436 /* FilterToggle+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterToggle+FilterState.swift"; sourceTree = "<group>"; };
+		OBJ_438 /* FilterTrackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTrackable.swift; sourceTree = "<group>"; };
+		OBJ_439 /* FilterTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTracker.swift; sourceTree = "<group>"; };
+		OBJ_440 /* HitsAfterSearchTrackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsAfterSearchTrackable.swift; sourceTree = "<group>"; };
+		OBJ_441 /* HitsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTracker.swift; sourceTree = "<group>"; };
+		OBJ_442 /* InsightsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsTracker.swift; sourceTree = "<group>"; };
+		OBJ_443 /* TrackableSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableSearcher.swift; sourceTree = "<group>"; };
+		OBJ_445 /* Readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
+		OBJ_447 /* Date+Milliseconds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Milliseconds.swift"; sourceTree = "<group>"; };
+		OBJ_448 /* Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encodable.swift; sourceTree = "<group>"; };
+		OBJ_45 /* ActivityIndicatorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorController.swift; sourceTree = "<group>"; };
+		OBJ_450 /* JSONFilePackageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFilePackageStorage.swift; sourceTree = "<group>"; };
+		OBJ_451 /* TimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerController.swift; sourceTree = "<group>"; };
+		OBJ_453 /* LogCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogCollector.swift; sourceTree = "<group>"; };
+		OBJ_454 /* LogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
+		OBJ_455 /* LogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogService.swift; sourceTree = "<group>"; };
+		OBJ_456 /* Logger+InstantSearchInsights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+InstantSearchInsights.swift"; sourceTree = "<group>"; };
+		OBJ_457 /* PrefixedLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedLogger.swift; sourceTree = "<group>"; };
+		OBJ_458 /* SwiftLog+LogService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftLog+LogService.swift"; sourceTree = "<group>"; };
+		OBJ_460 /* EventProcessor+AlgoliaClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventProcessor+AlgoliaClient.swift"; sourceTree = "<group>"; };
+		OBJ_461 /* EventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessor.swift; sourceTree = "<group>"; };
+		OBJ_462 /* EventTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTracker.swift; sourceTree = "<group>"; };
+		OBJ_463 /* Insights+EventTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Insights+EventTracking.swift"; sourceTree = "<group>"; };
+		OBJ_464 /* Insights+SearchEventTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Insights+SearchEventTracking.swift"; sourceTree = "<group>"; };
+		OBJ_465 /* Insights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Insights.swift; sourceTree = "<group>"; };
+		OBJ_466 /* InsightsClient+EventService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightsClient+EventService.swift"; sourceTree = "<group>"; };
+		OBJ_468 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		OBJ_469 /* Package+InsightsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package+InsightsEvent.swift"; sourceTree = "<group>"; };
+		OBJ_47 /* Logger+InstantSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+InstantSearch.swift"; sourceTree = "<group>"; };
+		OBJ_470 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_471 /* Packager+InsightsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Packager+InsightsEvent.swift"; sourceTree = "<group>"; };
+		OBJ_472 /* Packager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Packager.swift; sourceTree = "<group>"; };
+		OBJ_474 /* EventProcessable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessable.swift; sourceTree = "<group>"; };
+		OBJ_475 /* EventTrackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTrackable.swift; sourceTree = "<group>"; };
+		OBJ_476 /* EventsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsService.swift; sourceTree = "<group>"; };
+		OBJ_477 /* Flushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flushable.swift; sourceTree = "<group>"; };
+		OBJ_478 /* PackageManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageManageable.swift; sourceTree = "<group>"; };
+		OBJ_479 /* Packaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Packaging.swift; sourceTree = "<group>"; };
+		OBJ_480 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
+		OBJ_483 /* CurrentFiltersObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersObservableController.swift; sourceTree = "<group>"; };
+		OBJ_484 /* DynamicFacetListObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicFacetListObservableController.swift; sourceTree = "<group>"; };
+		OBJ_485 /* FacetListObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListObservableController.swift; sourceTree = "<group>"; };
+		OBJ_486 /* FilterClearObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterClearObservableController.swift; sourceTree = "<group>"; };
+		OBJ_487 /* FilterListObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListObservableController.swift; sourceTree = "<group>"; };
+		OBJ_488 /* FilterToggleObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterToggleObservableController.swift; sourceTree = "<group>"; };
+		OBJ_489 /* HierarchicalObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalObservableController.swift; sourceTree = "<group>"; };
+		OBJ_490 /* HitsObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsObservableController.swift; sourceTree = "<group>"; };
+		OBJ_491 /* LoadingObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingObservableController.swift; sourceTree = "<group>"; };
+		OBJ_492 /* NumberRangeObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberRangeObservableController.swift; sourceTree = "<group>"; };
+		OBJ_493 /* RelevantSortObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortObservableController.swift; sourceTree = "<group>"; };
+		OBJ_494 /* SearchBoxObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxObservableController.swift; sourceTree = "<group>"; };
+		OBJ_495 /* SelectableSegmentObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableSegmentObservableController.swift; sourceTree = "<group>"; };
+		OBJ_496 /* StatsObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsObservableController.swift; sourceTree = "<group>"; };
+		OBJ_497 /* StatsTextObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTextObservableController.swift; sourceTree = "<group>"; };
+		OBJ_498 /* SwitchIndexObservableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchIndexObservableController.swift; sourceTree = "<group>"; };
+		OBJ_50 /* MultiIndexHitsCollectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsCollectionController.swift; sourceTree = "<group>"; };
+		OBJ_500 /* FacetList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetList.swift; sourceTree = "<group>"; };
+		OBJ_501 /* FacetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetRow.swift; sourceTree = "<group>"; };
+		OBJ_502 /* FilterList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterList.swift; sourceTree = "<group>"; };
+		OBJ_503 /* HierarchicalFacetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalFacetRow.swift; sourceTree = "<group>"; };
+		OBJ_504 /* HierarchicalList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalList.swift; sourceTree = "<group>"; };
+		OBJ_505 /* HitsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsList.swift; sourceTree = "<group>"; };
+		OBJ_506 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		OBJ_507 /* SuggestionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionRow.swift; sourceTree = "<group>"; };
+		OBJ_508 /* Text+Highlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Highlighting.swift"; sourceTree = "<group>"; };
+		OBJ_51 /* MultiIndexHitsCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		OBJ_512 /* JSONDecoder+Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Resource.swift"; sourceTree = "<group>"; };
+		OBJ_513 /* String+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		OBJ_514 /* InstantSearchCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantSearchCoreTests.swift; sourceTree = "<group>"; };
+		OBJ_516 /* DisjuncitveAndHierarchicalIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisjuncitveAndHierarchicalIntegrationTests.swift; sourceTree = "<group>"; };
+		OBJ_517 /* DisjunctiveFacetingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisjunctiveFacetingIntegrationTests.swift; sourceTree = "<group>"; };
+		OBJ_518 /* HierarchicalIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalIntegrationTests.swift; sourceTree = "<group>"; };
+		OBJ_519 /* OnlineTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineTestCase.swift; sourceTree = "<group>"; };
+		OBJ_52 /* MultiIndexHitsCollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsCollectionViewDelegate.swift; sourceTree = "<group>"; };
+		OBJ_520 /* TestCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCredentials.swift; sourceTree = "<group>"; };
+		OBJ_522 /* Data+FileAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+FileAccess.swift"; sourceTree = "<group>"; };
+		OBJ_524 /* AttributedStringWithTaggedStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringWithTaggedStringTests.swift; sourceTree = "<group>"; };
+		OBJ_526 /* MultiIndexSearchConnectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexSearchConnectorTests.swift; sourceTree = "<group>"; };
+		OBJ_527 /* SearchConnectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchConnectorTests.swift; sourceTree = "<group>"; };
+		OBJ_528 /* SortByConnectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortByConnectorTests.swift; sourceTree = "<group>"; };
+		OBJ_530 /* CurrentFiltersControllerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersControllerConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_531 /* CurrentFiltersFilterStateConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentFiltersFilterStateConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_532 /* TestCurrentFiltersController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCurrentFiltersController.swift; sourceTree = "<group>"; };
+		OBJ_533 /* DecodingErrorPrettyPrinterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorPrettyPrinterTests.swift; sourceTree = "<group>"; };
+		OBJ_534 /* DisjunctiveFacetingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisjunctiveFacetingsTests.swift; sourceTree = "<group>"; };
+		OBJ_536 /* FacetsOrdererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetsOrdererTests.swift; sourceTree = "<group>"; };
+		OBJ_538 /* Array+Facet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Facet.swift"; sourceTree = "<group>"; };
+		OBJ_539 /* FacetListControllerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListControllerConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_54 /* MultiIndexHitsTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsTableController.swift; sourceTree = "<group>"; };
+		OBJ_540 /* FacetListFacetSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListFacetSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_541 /* FacetListFilterStateConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListFilterStateConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_542 /* FacetListHitsSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListHitsSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_543 /* FacetListInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_544 /* FacetListPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListPresenterTests.swift; sourceTree = "<group>"; };
+		OBJ_545 /* TestFacetListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFacetListController.swift; sourceTree = "<group>"; };
+		OBJ_547 /* FilterGroupCollectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupCollectionsTests.swift; sourceTree = "<group>"; };
+		OBJ_548 /* FilterGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupTests.swift; sourceTree = "<group>"; };
+		OBJ_549 /* FilterStateGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterStateGroupTests.swift; sourceTree = "<group>"; };
+		OBJ_55 /* MultiIndexHitsTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsTableViewDataSource.swift; sourceTree = "<group>"; };
+		OBJ_550 /* FilterStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterStateTests.swift; sourceTree = "<group>"; };
+		OBJ_551 /* FilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTests.swift; sourceTree = "<group>"; };
+		OBJ_552 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
+		OBJ_554 /* HitsInteractorControllerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractorControllerConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_555 /* HitsInteractorFilterStateConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractorFilterStateConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_556 /* HitsInteractorRelatedItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractorRelatedItemsTests.swift; sourceTree = "<group>"; };
+		OBJ_557 /* HitsInteractorSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractorSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_558 /* HitsInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_559 /* TestHitsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHitsController.swift; sourceTree = "<group>"; };
+		OBJ_56 /* MultiIndexHitsTableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsTableViewDelegate.swift; sourceTree = "<group>"; };
+		OBJ_560 /* TestInfiniteScrollingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestInfiniteScrollingController.swift; sourceTree = "<group>"; };
+		OBJ_561 /* InfiniteScrollingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollingControllerTests.swift; sourceTree = "<group>"; };
+		OBJ_562 /* ItemInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_563 /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
+		OBJ_565 /* MultiIndexHitsInteractorControllerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsInteractorControllerConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_566 /* MultiIndexHitsInteractorSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsInteractorSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_567 /* MultiIndexHitsInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_568 /* MultiSourceHitsReloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSourceHitsReloaderTests.swift; sourceTree = "<group>"; };
+		OBJ_570 /* NumberInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_571 /* NumberRangeInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberRangeInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_572 /* PageMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageMapTests.swift; sourceTree = "<group>"; };
+		OBJ_573 /* PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
+		OBJ_574 /* QueryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryBuilderTests.swift; sourceTree = "<group>"; };
+		OBJ_576 /* SearchBoxControllerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxControllerConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_577 /* SearchBoxInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_578 /* SearchBoxSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_579 /* TestSearchBoxController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSearchBoxController.swift; sourceTree = "<group>"; };
+		OBJ_58 /* NumericRatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericRatingController.swift; sourceTree = "<group>"; };
+		OBJ_580 /* TestSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSearcher.swift; sourceTree = "<group>"; };
+		OBJ_582 /* QueryRuleCustomDataSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryRuleCustomDataSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_584 /* RelevantSortControllerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortControllerConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_585 /* RelevantSortHitsSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortHitsSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_586 /* RelevantSortInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_587 /* RelevantSortMultiIndexSearcherConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelevantSortMultiIndexSearcherConnectionTests.swift; sourceTree = "<group>"; };
+		OBJ_589 /* AnswersSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswersSearcherTests.swift; sourceTree = "<group>"; };
+		OBJ_59 /* NumericRatingRangeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericRatingRangeController.swift; sourceTree = "<group>"; };
+		OBJ_590 /* HitsSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsSearcherTests.swift; sourceTree = "<group>"; };
+		OBJ_591 /* MultiIndexSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexSearcherTests.swift; sourceTree = "<group>"; };
+		OBJ_592 /* SelectableInteractorConnectorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableInteractorConnectorsTests.swift; sourceTree = "<group>"; };
+		OBJ_593 /* SelectableInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_594 /* SelectableListInteractorFilterConnectorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableListInteractorFilterConnectorsTests.swift; sourceTree = "<group>"; };
+		OBJ_595 /* SelectableListInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableListInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_597 /* SelectableSegmentInteractorConnectorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableSegmentInteractorConnectorsTests.swift; sourceTree = "<group>"; };
+		OBJ_598 /* SelectableSegmentInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableSegmentInteractorTests.swift; sourceTree = "<group>"; };
+		OBJ_599 /* TestSelectableSegmentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSelectableSegmentController.swift; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_60 /* NumericStepperController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericStepperController.swift; sourceTree = "<group>"; };
+		OBJ_600 /* SequencerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequencerTest.swift; sourceTree = "<group>"; };
+		OBJ_601 /* StatsInteractorConnectorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsInteractorConnectorsTests.swift; sourceTree = "<group>"; };
+		OBJ_602 /* TelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryTests.swift; sourceTree = "<group>"; };
+		OBJ_604 /* FilterTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTrackerTests.swift; sourceTree = "<group>"; };
+		OBJ_605 /* HitsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsTrackerTests.swift; sourceTree = "<group>"; };
+		OBJ_606 /* TestFiltersTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFiltersTracker.swift; sourceTree = "<group>"; };
+		OBJ_607 /* TestHitsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHitsTracker.swift; sourceTree = "<group>"; };
+		OBJ_608 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_61 /* NumericTextFieldController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericTextFieldController.swift; sourceTree = "<group>"; };
+		OBJ_611 /* MockEventService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEventService.swift; sourceTree = "<group>"; };
+		OBJ_612 /* String+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		OBJ_613 /* TestEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEvent.swift; sourceTree = "<group>"; };
+		OBJ_614 /* TestEventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEventProcessor.swift; sourceTree = "<group>"; };
+		OBJ_615 /* TestEventTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEventTracker.swift; sourceTree = "<group>"; };
+		OBJ_616 /* TestPackageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPackageStorage.swift; sourceTree = "<group>"; };
+		OBJ_617 /* XCTest+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Codable.swift"; sourceTree = "<group>"; };
+		OBJ_619 /* EventTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTrackerTests.swift; sourceTree = "<group>"; };
+		OBJ_62 /* RatingControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingControl.swift; sourceTree = "<group>"; };
+		OBJ_620 /* EventsProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsProcessorTests.swift; sourceTree = "<group>"; };
+		OBJ_621 /* InsightsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsTests.swift; sourceTree = "<group>"; };
+		OBJ_622 /* JSONFilePackageStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFilePackageStorageTests.swift; sourceTree = "<group>"; };
+		OBJ_623 /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
+		OBJ_624 /* PackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageTests.swift; sourceTree = "<group>"; };
+		OBJ_625 /* PackagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackagerTests.swift; sourceTree = "<group>"; };
+		OBJ_626 /* TimerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerControllerTests.swift; sourceTree = "<group>"; };
+		OBJ_628 /* ObservableControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableControllerTests.swift; sourceTree = "<group>"; };
+		OBJ_631 /* String+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Random.swift"; sourceTree = "<group>"; };
+		OBJ_632 /* InstantSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantSearchTests.swift; sourceTree = "<group>"; };
+		OBJ_633 /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
+		OBJ_635 /* BannerGuideSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerGuideSnippets.swift; sourceTree = "<group>"; };
+		OBJ_636 /* CurrentRefinementsSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentRefinementsSnippets.swift; sourceTree = "<group>"; };
+		OBJ_637 /* FacetFilterListSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetFilterListSnippets.swift; sourceTree = "<group>"; };
+		OBJ_638 /* FacetListConnectorSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetListConnectorSnippets.swift; sourceTree = "<group>"; };
+		OBJ_639 /* FilterClearSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterClearSnippets.swift; sourceTree = "<group>"; };
+		OBJ_64 /* QuerySuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuerySuggestionsViewController.swift; sourceTree = "<group>"; };
+		OBJ_640 /* HierarchicalSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchicalSnippets.swift; sourceTree = "<group>"; };
+		OBJ_641 /* HitsSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsSnippets.swift; sourceTree = "<group>"; };
+		OBJ_642 /* LoadingSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingSnippets.swift; sourceTree = "<group>"; };
+		OBJ_643 /* MultiIndexHitsSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexHitsSnippets.swift; sourceTree = "<group>"; };
+		OBJ_644 /* NumberRangeSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberRangeSnippets.swift; sourceTree = "<group>"; };
+		OBJ_645 /* NumericFilterListSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericFilterListSnippets.swift; sourceTree = "<group>"; };
+		OBJ_646 /* QueryRuleCustomDataSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryRuleCustomDataSnippets.swift; sourceTree = "<group>"; };
+		OBJ_647 /* RedirectGuideSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectGuideSnippets.swift; sourceTree = "<group>"; };
+		OBJ_648 /* SearchBoxSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxSnippets.swift; sourceTree = "<group>"; };
+		OBJ_649 /* SortBySnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBySnippets.swift; sourceTree = "<group>"; };
+		OBJ_650 /* StatsSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsSnippets.swift; sourceTree = "<group>"; };
+		OBJ_651 /* TagFilterListSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFilterListSnippets.swift; sourceTree = "<group>"; };
+		OBJ_652 /* ToggleFilterSnippets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleFilterSnippets.swift; sourceTree = "<group>"; };
+		OBJ_653 /* TestHitsSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHitsSource.swift; sourceTree = "<group>"; };
+		OBJ_654 /* TestMultiHitsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMultiHitsDataSource.swift; sourceTree = "<group>"; };
+		OBJ_655 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_659 /* CRC32.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRC32.swift; sourceTree = "<group>"; };
+		OBJ_66 /* ButtonRelevantSortController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonRelevantSortController.swift; sourceTree = "<group>"; };
+		OBJ_660 /* Data+Gzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
+		OBJ_661 /* Gzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gzip.swift; sourceTree = "<group>"; };
+		OBJ_662 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
+		OBJ_663 /* telemetry.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = telemetry.pb.swift; sourceTree = "<group>"; };
+		OBJ_664 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/vladislav.fitc/Workspace/algolia/instantsearch-ios/.build/checkouts/instantsearch-telemetry-native/Package.swift"; sourceTree = "<group>"; };
+		OBJ_667 /* AnyMessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyMessageStorage.swift; sourceTree = "<group>"; };
+		OBJ_668 /* AnyUnpackError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyUnpackError.swift; sourceTree = "<group>"; };
+		OBJ_669 /* BinaryDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecoder.swift; sourceTree = "<group>"; };
+		OBJ_670 /* BinaryDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecodingError.swift; sourceTree = "<group>"; };
+		OBJ_671 /* BinaryDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_672 /* BinaryDelimited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDelimited.swift; sourceTree = "<group>"; };
+		OBJ_673 /* BinaryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncoder.swift; sourceTree = "<group>"; };
+		OBJ_674 /* BinaryEncodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncodingError.swift; sourceTree = "<group>"; };
+		OBJ_675 /* BinaryEncodingSizeVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncodingSizeVisitor.swift; sourceTree = "<group>"; };
+		OBJ_676 /* BinaryEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_677 /* CustomJSONCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomJSONCodable.swift; sourceTree = "<group>"; };
+		OBJ_678 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_679 /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
+		OBJ_68 /* SearchBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarController.swift; sourceTree = "<group>"; };
+		OBJ_680 /* DoubleParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleParser.swift; sourceTree = "<group>"; };
+		OBJ_681 /* Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enum.swift; sourceTree = "<group>"; };
+		OBJ_682 /* ExtensibleMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensibleMessage.swift; sourceTree = "<group>"; };
+		OBJ_683 /* ExtensionFieldValueSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFieldValueSet.swift; sourceTree = "<group>"; };
+		OBJ_684 /* ExtensionFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFields.swift; sourceTree = "<group>"; };
+		OBJ_685 /* ExtensionMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionMap.swift; sourceTree = "<group>"; };
+		OBJ_686 /* FieldTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldTag.swift; sourceTree = "<group>"; };
+		OBJ_687 /* FieldTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldTypes.swift; sourceTree = "<group>"; };
+		OBJ_688 /* Google_Protobuf_Any+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_689 /* Google_Protobuf_Any+Registry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Registry.swift"; sourceTree = "<group>"; };
+		OBJ_69 /* TextFieldController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldController.swift; sourceTree = "<group>"; };
+		OBJ_690 /* Google_Protobuf_Duration+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Duration+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_691 /* Google_Protobuf_FieldMask+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_FieldMask+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_692 /* Google_Protobuf_ListValue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_ListValue+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_693 /* Google_Protobuf_NullValue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_NullValue+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_694 /* Google_Protobuf_Struct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Struct+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_695 /* Google_Protobuf_Timestamp+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Timestamp+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_696 /* Google_Protobuf_Value+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Value+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_697 /* Google_Protobuf_Wrappers+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Wrappers+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_698 /* HashVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashVisitor.swift; sourceTree = "<group>"; };
+		OBJ_699 /* Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Internal.swift; sourceTree = "<group>"; };
+		OBJ_700 /* JSONDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoder.swift; sourceTree = "<group>"; };
+		OBJ_701 /* JSONDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingError.swift; sourceTree = "<group>"; };
+		OBJ_702 /* JSONDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_703 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		OBJ_704 /* JSONEncodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodingError.swift; sourceTree = "<group>"; };
+		OBJ_705 /* JSONEncodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_706 /* JSONEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_707 /* JSONMapEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONMapEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_708 /* JSONScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONScanner.swift; sourceTree = "<group>"; };
+		OBJ_709 /* MathUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathUtils.swift; sourceTree = "<group>"; };
+		OBJ_71 /* SegmentedController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedController.swift; sourceTree = "<group>"; };
+		OBJ_710 /* Message+AnyAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+AnyAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_711 /* Message+BinaryAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+BinaryAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_712 /* Message+JSONAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+JSONAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_713 /* Message+JSONArrayAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+JSONArrayAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_714 /* Message+TextFormatAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+TextFormatAdditions.swift"; sourceTree = "<group>"; };
+		OBJ_715 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		OBJ_716 /* MessageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageExtension.swift; sourceTree = "<group>"; };
+		OBJ_717 /* NameMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameMap.swift; sourceTree = "<group>"; };
+		OBJ_718 /* ProtoNameProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtoNameProviding.swift; sourceTree = "<group>"; };
+		OBJ_719 /* ProtobufAPIVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufAPIVersionCheck.swift; sourceTree = "<group>"; };
+		OBJ_720 /* ProtobufMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufMap.swift; sourceTree = "<group>"; };
+		OBJ_721 /* SelectiveVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveVisitor.swift; sourceTree = "<group>"; };
+		OBJ_722 /* SimpleExtensionMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleExtensionMap.swift; sourceTree = "<group>"; };
+		OBJ_723 /* StringUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
+		OBJ_724 /* TextFormatDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatDecoder.swift; sourceTree = "<group>"; };
+		OBJ_725 /* TextFormatDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatDecodingError.swift; sourceTree = "<group>"; };
+		OBJ_726 /* TextFormatDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatDecodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_727 /* TextFormatEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatEncoder.swift; sourceTree = "<group>"; };
+		OBJ_728 /* TextFormatEncodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatEncodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_729 /* TextFormatEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatEncodingVisitor.swift; sourceTree = "<group>"; };
+		OBJ_73 /* FilterSwitchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSwitchController.swift; sourceTree = "<group>"; };
+		OBJ_730 /* TextFormatScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatScanner.swift; sourceTree = "<group>"; };
+		OBJ_731 /* TimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
+		OBJ_732 /* UnknownStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownStorage.swift; sourceTree = "<group>"; };
+		OBJ_733 /* UnsafeBufferPointer+Shims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnsafeBufferPointer+Shims.swift"; sourceTree = "<group>"; };
+		OBJ_734 /* UnsafeRawPointer+Shims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnsafeRawPointer+Shims.swift"; sourceTree = "<group>"; };
+		OBJ_735 /* Varint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Varint.swift; sourceTree = "<group>"; };
+		OBJ_736 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_737 /* Visitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visitor.swift; sourceTree = "<group>"; };
+		OBJ_738 /* WireFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireFormat.swift; sourceTree = "<group>"; };
+		OBJ_739 /* ZigZag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZigZag.swift; sourceTree = "<group>"; };
+		OBJ_74 /* SelectableFilterButtonController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableFilterButtonController.swift; sourceTree = "<group>"; };
+		OBJ_740 /* any.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = any.pb.swift; sourceTree = "<group>"; };
+		OBJ_741 /* api.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = api.pb.swift; sourceTree = "<group>"; };
+		OBJ_742 /* descriptor.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = descriptor.pb.swift; sourceTree = "<group>"; };
+		OBJ_743 /* duration.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = duration.pb.swift; sourceTree = "<group>"; };
+		OBJ_744 /* empty.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.pb.swift; sourceTree = "<group>"; };
+		OBJ_745 /* field_mask.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = field_mask.pb.swift; sourceTree = "<group>"; };
+		OBJ_746 /* source_context.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = source_context.pb.swift; sourceTree = "<group>"; };
+		OBJ_747 /* struct.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = struct.pb.swift; sourceTree = "<group>"; };
+		OBJ_748 /* timestamp.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timestamp.pb.swift; sourceTree = "<group>"; };
+		OBJ_749 /* type.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = type.pb.swift; sourceTree = "<group>"; };
+		OBJ_750 /* wrappers.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrappers.pb.swift; sourceTree = "<group>"; };
+		OBJ_753 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/vladislav.fitc/Workspace/algolia/instantsearch-ios/.build/checkouts/swift-protobuf/Package.swift"; sourceTree = "<group>"; };
+		OBJ_757 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
+		OBJ_758 /* WaitTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitTask.swift; sourceTree = "<group>"; };
+		OBJ_76 /* SelectIndexController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectIndexController.swift; sourceTree = "<group>"; };
+		OBJ_760 /* AccountClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountClient.swift; sourceTree = "<group>"; };
+		OBJ_761 /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
+		OBJ_762 /* InsightsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsClient.swift; sourceTree = "<group>"; };
+		OBJ_763 /* PersonalizationClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalizationClient.swift; sourceTree = "<group>"; };
+		OBJ_764 /* PlacesClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesClient.swift; sourceTree = "<group>"; };
+		OBJ_765 /* RecommendClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendClient.swift; sourceTree = "<group>"; };
+		OBJ_767 /* SearchClient+APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+APIKey.swift"; sourceTree = "<group>"; };
+		OBJ_768 /* SearchClient+Dictionaries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+Dictionaries.swift"; sourceTree = "<group>"; };
+		OBJ_769 /* SearchClient+Logs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+Logs.swift"; sourceTree = "<group>"; };
+		OBJ_77 /* SwitchIndexAlertControllerBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchIndexAlertControllerBuilder.swift; sourceTree = "<group>"; };
+		OBJ_770 /* SearchClient+Management.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+Management.swift"; sourceTree = "<group>"; };
+		OBJ_771 /* SearchClient+MultiCluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+MultiCluster.swift"; sourceTree = "<group>"; };
+		OBJ_772 /* SearchClient+MultiIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+MultiIndex.swift"; sourceTree = "<group>"; };
+		OBJ_773 /* SearchClient+SecuredAPIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+SecuredAPIKey.swift"; sourceTree = "<group>"; };
+		OBJ_774 /* SearchClient+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchClient+Wait.swift"; sourceTree = "<group>"; };
+		OBJ_775 /* SearchClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchClient.swift; sourceTree = "<group>"; };
+		OBJ_777 /* AlgoliaCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaCommand.swift; sourceTree = "<group>"; };
+		OBJ_778 /* Command+ABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+ABTest.swift"; sourceTree = "<group>"; };
+		OBJ_779 /* Command+APIKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+APIKeys.swift"; sourceTree = "<group>"; };
+		OBJ_780 /* Command+Advanced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Advanced.swift"; sourceTree = "<group>"; };
+		OBJ_781 /* Command+Answers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Answers.swift"; sourceTree = "<group>"; };
+		OBJ_782 /* Command+Custom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Custom.swift"; sourceTree = "<group>"; };
+		OBJ_783 /* Command+Dictionaries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Dictionaries.swift"; sourceTree = "<group>"; };
+		OBJ_784 /* Command+Index.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Index.swift"; sourceTree = "<group>"; };
+		OBJ_785 /* Command+Indexing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Indexing.swift"; sourceTree = "<group>"; };
+		OBJ_786 /* Command+Insights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Insights.swift"; sourceTree = "<group>"; };
+		OBJ_787 /* Command+MultiCluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+MultiCluster.swift"; sourceTree = "<group>"; };
+		OBJ_788 /* Command+MultipleIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+MultipleIndex.swift"; sourceTree = "<group>"; };
+		OBJ_789 /* Command+Personalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Personalization.swift"; sourceTree = "<group>"; };
+		OBJ_79 /* LabelStatsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelStatsController.swift; sourceTree = "<group>"; };
+		OBJ_790 /* Command+Places.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Places.swift"; sourceTree = "<group>"; };
+		OBJ_791 /* Command+Recommend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Recommend.swift"; sourceTree = "<group>"; };
+		OBJ_792 /* Command+Rule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Rule.swift"; sourceTree = "<group>"; };
+		OBJ_793 /* Command+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Search.swift"; sourceTree = "<group>"; };
+		OBJ_794 /* Command+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Settings.swift"; sourceTree = "<group>"; };
+		OBJ_795 /* Command+Synonym.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Command+Synonym.swift"; sourceTree = "<group>"; };
+		OBJ_796 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		OBJ_798 /* AssertionTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertionTestHelper.swift; sourceTree = "<group>"; };
+		OBJ_800 /* CustomParametersCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomParametersCoder.swift; sourceTree = "<group>"; };
+		OBJ_802 /* ClientDateCodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientDateCodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_803 /* KeyedDecodingContainer+DateFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+DateFormat.swift"; sourceTree = "<group>"; };
+		OBJ_804 /* KeyedEncodingContainer+DateFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainer+DateFormat.swift"; sourceTree = "<group>"; };
+		OBJ_805 /* DecodingErrorPrettyPrinter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorPrettyPrinter.swift; sourceTree = "<group>"; };
+		OBJ_806 /* DynamicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicKey.swift; sourceTree = "<group>"; };
+		OBJ_807 /* Encodiable+HTTPBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodiable+HTTPBody.swift"; sourceTree = "<group>"; };
+		OBJ_808 /* KeyedDecodingContainer+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_810 /* BoolContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolContainer.swift; sourceTree = "<group>"; };
+		OBJ_811 /* CustomKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomKey.swift; sourceTree = "<group>"; };
+		OBJ_812 /* StringNumberContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringNumberContainer.swift; sourceTree = "<group>"; };
+		OBJ_814 /* HMAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMAC.swift; sourceTree = "<group>"; };
+		OBJ_815 /* String+HMAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HMAC.swift"; sourceTree = "<group>"; };
+		OBJ_817 /* Array+Chunks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Chunks.swift"; sourceTree = "<group>"; };
+		OBJ_818 /* Data+JSONString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+JSONString.swift"; sourceTree = "<group>"; };
+		OBJ_819 /* Dictionary+Merging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merging.swift"; sourceTree = "<group>"; };
+		OBJ_82 /* MultiIndexSearchConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiIndexSearchConnector.swift; sourceTree = "<group>"; };
+		OBJ_820 /* Optional+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_821 /* TimeInterval+Minutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Minutes.swift"; sourceTree = "<group>"; };
+		OBJ_822 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		OBJ_823 /* ObjectIDChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectIDChecker.swift; sourceTree = "<group>"; };
+		OBJ_825 /* Builder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Builder.swift; sourceTree = "<group>"; };
+		OBJ_826 /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
+		OBJ_827 /* ResultContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultContainer.swift; sourceTree = "<group>"; };
+		OBJ_828 /* URLEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodable.swift; sourceTree = "<group>"; };
+		OBJ_829 /* ResultCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultCallback.swift; sourceTree = "<group>"; };
+		OBJ_83 /* SearchConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchConnector.swift; sourceTree = "<group>"; };
+		OBJ_831 /* String+Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Base64.swift"; sourceTree = "<group>"; };
+		OBJ_832 /* String+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Environment.swift"; sourceTree = "<group>"; };
+		OBJ_833 /* String+Wrapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Wrapping.swift"; sourceTree = "<group>"; };
+		OBJ_835 /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
+		OBJ_836 /* UserAgentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentController.swift; sourceTree = "<group>"; };
+		OBJ_837 /* Version+Current.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Version+Current.swift"; sourceTree = "<group>"; };
+		OBJ_838 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_840 /* AnyWaitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyWaitable.swift; sourceTree = "<group>"; };
+		OBJ_841 /* TaskWaitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskWaitable.swift; sourceTree = "<group>"; };
+		OBJ_842 /* Waitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waitable.swift; sourceTree = "<group>"; };
+		OBJ_843 /* WaitableWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitableWrapper.swift; sourceTree = "<group>"; };
+		OBJ_845 /* Index+Advanced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Advanced.swift"; sourceTree = "<group>"; };
+		OBJ_846 /* Index+Answers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Answers.swift"; sourceTree = "<group>"; };
+		OBJ_847 /* Index+Export.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Export.swift"; sourceTree = "<group>"; };
+		OBJ_848 /* Index+Index.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Index.swift"; sourceTree = "<group>"; };
+		OBJ_849 /* Index+Indexing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Indexing.swift"; sourceTree = "<group>"; };
+		OBJ_85 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
+		OBJ_850 /* Index+Logs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Logs.swift"; sourceTree = "<group>"; };
+		OBJ_851 /* Index+Rule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Rule.swift"; sourceTree = "<group>"; };
+		OBJ_852 /* Index+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Search.swift"; sourceTree = "<group>"; };
+		OBJ_853 /* Index+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Settings.swift"; sourceTree = "<group>"; };
+		OBJ_854 /* Index+Synonym.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Index+Synonym.swift"; sourceTree = "<group>"; };
+		OBJ_855 /* Index.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Index.swift; sourceTree = "<group>"; };
+		OBJ_858 /* ACL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACL.swift; sourceTree = "<group>"; };
+		OBJ_859 /* APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKey.swift; sourceTree = "<group>"; };
+		OBJ_86 /* Attribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attribute.swift; sourceTree = "<group>"; };
+		OBJ_860 /* APIKeyCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyCreation.swift; sourceTree = "<group>"; };
+		OBJ_861 /* APIKeyDeletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyDeletion.swift; sourceTree = "<group>"; };
+		OBJ_862 /* APIKeyParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyParameters.swift; sourceTree = "<group>"; };
+		OBJ_863 /* APIKeyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyResponse.swift; sourceTree = "<group>"; };
+		OBJ_864 /* APIKeyRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyRevision.swift; sourceTree = "<group>"; };
+		OBJ_865 /* ListAPIKeysResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAPIKeysResponse.swift; sourceTree = "<group>"; };
+		OBJ_867 /* SecuredAPIKeyRestriction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuredAPIKeyRestriction.swift; sourceTree = "<group>"; };
+		OBJ_87 /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
+		OBJ_870 /* ABTest+Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ABTest+Variant.swift"; sourceTree = "<group>"; };
+		OBJ_871 /* ABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTest.swift; sourceTree = "<group>"; };
+		OBJ_872 /* ABTestID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestID.swift; sourceTree = "<group>"; };
+		OBJ_873 /* ABTestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestStatus.swift; sourceTree = "<group>"; };
+		OBJ_875 /* ABTestResponse+Variant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ABTestResponse+Variant.swift"; sourceTree = "<group>"; };
+		OBJ_876 /* ABTestResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestResponse.swift; sourceTree = "<group>"; };
+		OBJ_877 /* ABTestShortResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestShortResponse.swift; sourceTree = "<group>"; };
+		OBJ_878 /* ABTestsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestsResponse.swift; sourceTree = "<group>"; };
+		OBJ_88 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		OBJ_880 /* ABTestCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestCreation.swift; sourceTree = "<group>"; };
+		OBJ_881 /* ABTestDeletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestDeletion.swift; sourceTree = "<group>"; };
+		OBJ_882 /* ABTestRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestRevision.swift; sourceTree = "<group>"; };
+		OBJ_883 /* AnalyticsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_885 /* AnswersQuery+Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnswersQuery+Language.swift"; sourceTree = "<group>"; };
+		OBJ_886 /* AnswersQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswersQuery.swift; sourceTree = "<group>"; };
+		OBJ_888 /* AppRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRevision.swift; sourceTree = "<group>"; };
+		OBJ_889 /* Attribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attribute.swift; sourceTree = "<group>"; };
+		OBJ_890 /* CommonParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonParameters.swift; sourceTree = "<group>"; };
+		OBJ_892 /* AlgoliaCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgoliaCredentials.swift; sourceTree = "<group>"; };
+		OBJ_893 /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
+		OBJ_894 /* ObjectID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectID.swift; sourceTree = "<group>"; };
+		OBJ_895 /* Region.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
+		OBJ_896 /* RequestOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestOptions.swift; sourceTree = "<group>"; };
+		OBJ_897 /* ResponseField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseField.swift; sourceTree = "<group>"; };
+		OBJ_898 /* Revision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Revision.swift; sourceTree = "<group>"; };
+		OBJ_899 /* StringOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringOption.swift; sourceTree = "<group>"; };
+		OBJ_90 /* EventInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventInteractor.swift; sourceTree = "<group>"; };
+		OBJ_900 /* StringWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringWrapper.swift; sourceTree = "<group>"; };
+		OBJ_901 /* TimeRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeRange.swift; sourceTree = "<group>"; };
+		OBJ_902 /* UserToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserToken.swift; sourceTree = "<group>"; };
+		OBJ_904 /* FieldWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldWrapper.swift; sourceTree = "<group>"; };
+		OBJ_905 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		OBJ_906 /* PrefixedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefixedString.swift; sourceTree = "<group>"; };
+		OBJ_907 /* SingleOrList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleOrList.swift; sourceTree = "<group>"; };
+		OBJ_908 /* TreeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeModel.swift; sourceTree = "<group>"; };
+		OBJ_91 /* GeoLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoLocation.swift; sourceTree = "<group>"; };
+		OBJ_910 /* CompoundsDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompoundsDictionary.swift; sourceTree = "<group>"; };
+		OBJ_911 /* CustomDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDictionary.swift; sourceTree = "<group>"; };
+		OBJ_912 /* DictionaryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryEntry.swift; sourceTree = "<group>"; };
+		OBJ_913 /* DictionaryName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryName.swift; sourceTree = "<group>"; };
+		OBJ_914 /* DictionaryQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryQuery.swift; sourceTree = "<group>"; };
+		OBJ_915 /* DictionaryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryRequest.swift; sourceTree = "<group>"; };
+		OBJ_916 /* DictionaryRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryRevision.swift; sourceTree = "<group>"; };
+		OBJ_917 /* DictionarySearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_918 /* DictionarySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySettings.swift; sourceTree = "<group>"; };
+		OBJ_919 /* PluralsDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluralsDictionary.swift; sourceTree = "<group>"; };
+		OBJ_92 /* Geolocated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geolocated.swift; sourceTree = "<group>"; };
+		OBJ_920 /* StopwordsDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopwordsDictionary.swift; sourceTree = "<group>"; };
+		OBJ_923 /* EventName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventName.swift; sourceTree = "<group>"; };
+		OBJ_924 /* EventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventType.swift; sourceTree = "<group>"; };
+		OBJ_925 /* InsightsEvent+Click.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightsEvent+Click.swift"; sourceTree = "<group>"; };
+		OBJ_926 /* InsightsEvent+Conversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightsEvent+Conversion.swift"; sourceTree = "<group>"; };
+		OBJ_927 /* InsightsEvent+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightsEvent+View.swift"; sourceTree = "<group>"; };
+		OBJ_928 /* InsightsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsEvent.swift; sourceTree = "<group>"; };
+		OBJ_929 /* EventConstructionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventConstructionError.swift; sourceTree = "<group>"; };
+		OBJ_93 /* Hit+Place.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Hit+Place.swift"; sourceTree = "<group>"; };
+		OBJ_930 /* InsightsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_931 /* InsightsEvent+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightsEvent+Resources.swift"; sourceTree = "<group>"; };
+		OBJ_933 /* CallType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallType.swift; sourceTree = "<group>"; };
+		OBJ_934 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		OBJ_935 /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
+		OBJ_937 /* HTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPError.swift; sourceTree = "<group>"; };
+		OBJ_938 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		OBJ_939 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
+		OBJ_94 /* IndexNameSettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexNameSettable.swift; sourceTree = "<group>"; };
+		OBJ_940 /* Hosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hosts.swift; sourceTree = "<group>"; };
+		OBJ_941 /* URL+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Convenience.swift"; sourceTree = "<group>"; };
+		OBJ_943 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		OBJ_944 /* LogType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogType.swift; sourceTree = "<group>"; };
+		OBJ_945 /* LogsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsResponse.swift; sourceTree = "<group>"; };
+		OBJ_947 /* Cluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cluster.swift; sourceTree = "<group>"; };
+		OBJ_948 /* ClusterName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterName.swift; sourceTree = "<group>"; };
+		OBJ_949 /* ClustersListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClustersListResponse.swift; sourceTree = "<group>"; };
+		OBJ_95 /* IndexQueryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexQueryState.swift; sourceTree = "<group>"; };
+		OBJ_950 /* HasPendingMappingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasPendingMappingResponse.swift; sourceTree = "<group>"; };
+		OBJ_952 /* Creation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Creation.swift; sourceTree = "<group>"; };
+		OBJ_953 /* Deletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deletion.swift; sourceTree = "<group>"; };
+		OBJ_954 /* TopUserIDResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopUserIDResponse.swift; sourceTree = "<group>"; };
+		OBJ_955 /* UserID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserID.swift; sourceTree = "<group>"; };
+		OBJ_956 /* UserIDListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIDListResponse.swift; sourceTree = "<group>"; };
+		OBJ_957 /* UserIDQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIDQuery.swift; sourceTree = "<group>"; };
+		OBJ_958 /* UserIDResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIDResponse.swift; sourceTree = "<group>"; };
+		OBJ_959 /* UserIDSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIDSearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_961 /* EventScoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventScoring.swift; sourceTree = "<group>"; };
+		OBJ_962 /* FacetScoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacetScoring.swift; sourceTree = "<group>"; };
+		OBJ_963 /* PersonalizationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalizationConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_964 /* PersonalizationStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalizationStrategy.swift; sourceTree = "<group>"; };
+		OBJ_965 /* SetStrategyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetStrategyResponse.swift; sourceTree = "<group>"; };
+		OBJ_967 /* Country.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
+		OBJ_968 /* MultiLanguagePlace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiLanguagePlace.swift; sourceTree = "<group>"; };
+		OBJ_969 /* Place.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Place.swift; sourceTree = "<group>"; };
+		OBJ_97 /* ItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemController.swift; sourceTree = "<group>"; };
+		OBJ_970 /* PlaceCodingKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceCodingKeys.swift; sourceTree = "<group>"; };
+		OBJ_971 /* PlaceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceType.swift; sourceTree = "<group>"; };
+		OBJ_972 /* PlacesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesConfiguration.swift; sourceTree = "<group>"; };
+		OBJ_973 /* PlacesQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesQuery.swift; sourceTree = "<group>"; };
+		OBJ_974 /* PlacesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesResponse.swift; sourceTree = "<group>"; };
+		OBJ_976 /* RecommendationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationModel.swift; sourceTree = "<group>"; };
+		OBJ_977 /* RecommendationsOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationsOptions.swift; sourceTree = "<group>"; };
+		OBJ_979 /* RenderingContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderingContent.swift; sourceTree = "<group>"; };
+		OBJ_98 /* ItemInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ItemInteractor+Controller.swift"; sourceTree = "<group>"; };
+		OBJ_980 /* Rule+Alternatives.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Alternatives.swift"; sourceTree = "<group>"; };
+		OBJ_981 /* Rule+Anchoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Anchoring.swift"; sourceTree = "<group>"; };
+		OBJ_982 /* Rule+AutomaticFacetFilters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+AutomaticFacetFilters.swift"; sourceTree = "<group>"; };
+		OBJ_983 /* Rule+Condition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Condition.swift"; sourceTree = "<group>"; };
+		OBJ_984 /* Rule+Consequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Consequence.swift"; sourceTree = "<group>"; };
+		OBJ_985 /* Rule+Edit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Edit.swift"; sourceTree = "<group>"; };
+		OBJ_986 /* Rule+Pattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Pattern.swift"; sourceTree = "<group>"; };
+		OBJ_987 /* Rule+Promotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rule+Promotion.swift"; sourceTree = "<group>"; };
+		OBJ_988 /* Rule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rule.swift; sourceTree = "<group>"; };
+		OBJ_989 /* RuleQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleQuery.swift; sourceTree = "<group>"; };
+		OBJ_99 /* ItemInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemInteractor.swift; sourceTree = "<group>"; };
+		OBJ_990 /* RuleSearchResponse+Hit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RuleSearchResponse+Hit.swift"; sourceTree = "<group>"; };
+		OBJ_991 /* RuleSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleSearchResponse.swift; sourceTree = "<group>"; };
+		OBJ_993 /* ApplicationID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationID.swift; sourceTree = "<group>"; };
+		OBJ_995 /* Answer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Answer.swift; sourceTree = "<group>"; };
+		OBJ_996 /* HighlightResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightResult.swift; sourceTree = "<group>"; };
+		OBJ_997 /* Hit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hit.swift; sourceTree = "<group>"; };
+		OBJ_998 /* MatchLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchLevel.swift; sourceTree = "<group>"; };
+		OBJ_999 /* RankingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingInfo.swift; sourceTree = "<group>"; };
+		"algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AlgoliaSearchClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearch::Product" /* InstantSearch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = InstantSearch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = InstantSearchCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchCoreTests::Product" /* InstantSearchCoreTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = InstantSearchCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = InstantSearchInsights.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchInsightsTests::Product" /* InstantSearchInsightsTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = InstantSearchInsightsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchSwiftUI::Product" /* InstantSearchSwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = InstantSearchSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchSwiftUITests::Product" /* InstantSearchSwiftUITests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = InstantSearchSwiftUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-ios::InstantSearchTests::Product" /* InstantSearchTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = InstantSearchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = InstantSearchTelemetry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"swift-log::Logging::Product" /* Logging.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Logging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_1490 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1491 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1552 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1553 /* InstantSearchCore.framework in Frameworks */,
+				OBJ_1554 /* InstantSearchTelemetry.framework in Frameworks */,
+				OBJ_1555 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_1556 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_1557 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_1558 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1863 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1864 /* InstantSearchTelemetry.framework in Frameworks */,
+				OBJ_1865 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_1866 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_1867 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_1868 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1959 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1960 /* InstantSearchCore.framework in Frameworks */,
+				OBJ_1961 /* InstantSearchTelemetry.framework in Frameworks */,
+				OBJ_1962 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_1963 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_1964 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_1965 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2006 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_2007 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2030 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2031 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_2032 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_2033 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2083 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2084 /* InstantSearchCore.framework in Frameworks */,
+				OBJ_2085 /* InstantSearchTelemetry.framework in Frameworks */,
+				OBJ_2086 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_2087 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_2088 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_2089 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2101 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2102 /* InstantSearchSwiftUI.framework in Frameworks */,
+				OBJ_2103 /* InstantSearchCore.framework in Frameworks */,
+				OBJ_2104 /* InstantSearchTelemetry.framework in Frameworks */,
+				OBJ_2105 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_2106 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_2107 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_2108 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2125 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2126 /* SwiftProtobuf.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2162 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2163 /* InstantSearch.framework in Frameworks */,
+				OBJ_2164 /* InstantSearchCore.framework in Frameworks */,
+				OBJ_2165 /* InstantSearchTelemetry.framework in Frameworks */,
+				OBJ_2166 /* SwiftProtobuf.framework in Frameworks */,
+				OBJ_2167 /* InstantSearchInsights.framework in Frameworks */,
+				OBJ_2168 /* AlgoliaSearchClient.framework in Frameworks */,
+				OBJ_2169 /* Logging.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2184 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2273 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_100 /* Number */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_101 /* Boundable.swift */,
+				OBJ_102 /* DoubleRepresentable.swift */,
+			);
+			path = Number;
+			sourceTree = "<group>";
+		};
+		OBJ_1002 /* Indexing */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1003 /* Batch */,
+				OBJ_1007 /* Cursor.swift */,
+				OBJ_1008 /* IndexOperation.swift */,
+				OBJ_1009 /* ObjectRequest.swift */,
+				OBJ_1010 /* ObjectWrapper.swift */,
+				OBJ_1011 /* PartialUpdate.swift */,
+				OBJ_1012 /* PartialUpdateAction.swift */,
+				OBJ_1013 /* Scope.swift */,
+			);
+			path = Indexing;
+			sourceTree = "<group>";
+		};
+		OBJ_1003 /* Batch */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1004 /* BatchOperation.swift */,
+				OBJ_1005 /* BatchResponse.swift */,
+				OBJ_1006 /* IndexBatchOperation.swift */,
+			);
+			path = Batch;
+			sourceTree = "<group>";
+		};
+		OBJ_1014 /* MultipleIndex */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1015 /* BatchesResponse.swift */,
+				OBJ_1016 /* IndexedFacetQuery.swift */,
+				OBJ_1017 /* IndexedQuery.swift */,
+				OBJ_1018 /* IndicesListResponse.swift */,
+				OBJ_1019 /* MultiSearchQuery.swift */,
+				OBJ_1020 /* MultipleQueriesRequest.swift */,
+				OBJ_1021 /* MultipleQueriesStrategy.swift */,
+				OBJ_1022 /* SearchesResponse.swift */,
+			);
+			path = MultipleIndex;
+			sourceTree = "<group>";
+		};
+		OBJ_1023 /* Query */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1024 /* Auxiliary */,
+				OBJ_1032 /* DeleteByQuery.swift */,
+				OBJ_1033 /* Query+Codable.swift */,
+				OBJ_1034 /* Query+URLEncodable.swift */,
+				OBJ_1035 /* Query.swift */,
+				OBJ_1036 /* QueryID.swift */,
+			);
+			path = Query;
+			sourceTree = "<group>";
+		};
+		OBJ_1024 /* Auxiliary */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1025 /* AroundPrecision.swift */,
+				OBJ_1026 /* AroundRadius.swift */,
+				OBJ_1027 /* BoundingBox.swift */,
+				OBJ_1028 /* ExplainModule.swift */,
+				OBJ_1029 /* FiltersStorage.swift */,
+				OBJ_1030 /* Point.swift */,
+				OBJ_1031 /* Polygon.swift */,
+			);
+			path = Auxiliary;
+			sourceTree = "<group>";
+		};
+		OBJ_1037 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1038 /* FacetSearchResponse.swift */,
+				OBJ_1039 /* HitWithPosition.swift */,
+				OBJ_1040 /* MultiSearchResponse.swift */,
+				OBJ_1041 /* ObjectsResponse.swift */,
+				OBJ_1042 /* SearchResponse */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		OBJ_104 /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_105 /* Presenter.swift */,
+			);
+			path = Presenter;
+			sourceTree = "<group>";
+		};
+		OBJ_1042 /* SearchResponse */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1043 /* Auxiliary */,
+				OBJ_1063 /* SearchResponse+Codable.swift */,
+				OBJ_1064 /* SearchResponse.swift */,
+			);
+			path = SearchResponse;
+			sourceTree = "<group>";
+		};
+		OBJ_1043 /* Auxiliary */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1044 /* Alternative */,
+				OBJ_1049 /* Facet */,
+				OBJ_1052 /* FacetStats */,
+				OBJ_1055 /* Highlighting */,
+				OBJ_1058 /* RenderingContent */,
+			);
+			path = Auxiliary;
+			sourceTree = "<group>";
+		};
+		OBJ_1044 /* Alternative */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1045 /* Alternative.swift */,
+				OBJ_1046 /* AlternativeType.swift */,
+				OBJ_1047 /* Explain.swift */,
+				OBJ_1048 /* QueryMatch.swift */,
+			);
+			path = Alternative;
+			sourceTree = "<group>";
+		};
+		OBJ_1049 /* Facet */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1050 /* Facet.swift */,
+				OBJ_1051 /* FacetsStorage.swift */,
+			);
+			path = Facet;
+			sourceTree = "<group>";
+		};
+		OBJ_1052 /* FacetStats */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1053 /* FacetStats.swift */,
+				OBJ_1054 /* FacetStatsStorage.swift */,
+			);
+			path = FacetStats;
+			sourceTree = "<group>";
+		};
+		OBJ_1055 /* Highlighting */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1056 /* HighlightedString.swift */,
+				OBJ_1057 /* TaggedString.swift */,
+			);
+			path = Highlighting;
+			sourceTree = "<group>";
+		};
+		OBJ_1058 /* RenderingContent */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1059 /* FacetOrder */,
+			);
+			path = RenderingContent;
+			sourceTree = "<group>";
+		};
+		OBJ_1059 /* FacetOrder */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1060 /* FacetOrdering.swift */,
+				OBJ_1061 /* FacetValuesOrder.swift */,
+				OBJ_1062 /* FacetsOrder.swift */,
+			);
+			path = FacetOrder;
+			sourceTree = "<group>";
+		};
+		OBJ_1068 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1069 /* Auxiliary */,
+				OBJ_1087 /* Settings+CustomStringConvertible.swift */,
+				OBJ_1088 /* Settings.swift */,
+				OBJ_1089 /* SettingsParameters.swift */,
+				OBJ_1090 /* SettingsParametersCodingKeys.swift */,
+				OBJ_1091 /* SettingsParametersStorage.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		OBJ_1069 /* Auxiliary */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1070 /* AdvancedSyntaxFeatures.swift */,
+				OBJ_1071 /* AlternativesAsExact.swift */,
+				OBJ_1072 /* AttributeForFaceting.swift */,
+				OBJ_1073 /* CustomRankingCriterion.swift */,
+				OBJ_1074 /* DecompoundedAttributes.swift */,
+				OBJ_1075 /* Distinct.swift */,
+				OBJ_1076 /* ExactOnSingleWordQuery.swift */,
+				OBJ_1077 /* Language.swift */,
+				OBJ_1078 /* LanguageFeature.swift */,
+				OBJ_1079 /* NumericAttributeFilter.swift */,
+				OBJ_1080 /* QueryType.swift */,
+				OBJ_1081 /* RankingCriterion.swift */,
+				OBJ_1082 /* RemoveWordIfNoResults.swift */,
+				OBJ_1083 /* SearchableAttribute.swift */,
+				OBJ_1084 /* Snippet.swift */,
+				OBJ_1085 /* SortFacetsBy.swift */,
+				OBJ_1086 /* TypoTolerance.swift */,
+			);
+			path = Auxiliary;
+			sourceTree = "<group>";
+		};
+		OBJ_109 /* Selectable */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_110 /* SelectableController.swift */,
+				OBJ_111 /* SelectableInteractor.swift */,
+			);
+			path = Selectable;
+			sourceTree = "<group>";
+		};
+		OBJ_1092 /* Synonym */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1093 /* Synonym.swift */,
+				OBJ_1094 /* SynonymQuery.swift */,
+				OBJ_1095 /* SynonymRevision.swift */,
+				OBJ_1096 /* SynonymSearchResponse+Hit.swift */,
+				OBJ_1097 /* SynonymSearchResponse.swift */,
+				OBJ_1098 /* SynonymType.swift */,
+			);
+			path = Synonym;
+			sourceTree = "<group>";
+		};
+		OBJ_1099 /* Task */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1100 /* AppTaskID.swift */,
+				OBJ_1101 /* Common */,
+				OBJ_1106 /* Index */,
+				OBJ_1110 /* Object */,
+				OBJ_1114 /* TaskID.swift */,
+			);
+			path = Task;
+			sourceTree = "<group>";
+		};
+		OBJ_1101 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1102 /* AppTask.swift */,
+				OBJ_1103 /* IndexTask.swift */,
+				OBJ_1104 /* TaskInfo.swift */,
+				OBJ_1105 /* TaskStatus.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		OBJ_1106 /* Index */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1107 /* IndexDeletion.swift */,
+				OBJ_1108 /* IndexRevision.swift */,
+				OBJ_1109 /* IndexedTask.swift */,
+			);
+			path = Index;
+			sourceTree = "<group>";
+		};
+		OBJ_1110 /* Object */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1111 /* ObjectCreation.swift */,
+				OBJ_1112 /* ObjectDeletion.swift */,
+				OBJ_1113 /* ObjectRevision.swift */,
+			);
+			path = Object;
+			sourceTree = "<group>";
+		};
+		OBJ_1115 /* Transport */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1116 /* Common */,
+				OBJ_1120 /* HTTP */,
+				OBJ_1127 /* OperationLauncher.swift */,
+				OBJ_1128 /* RetryStrategy */,
+				OBJ_1134 /* URLSession */,
+			);
+			path = Transport;
+			sourceTree = "<group>";
+		};
+		OBJ_1116 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1117 /* Transport+CustomRequest.swift */,
+				OBJ_1118 /* Transport.swift */,
+				OBJ_1119 /* TransportContainer.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		OBJ_112 /* SelectableList */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_113 /* SelectableListController.swift */,
+				OBJ_114 /* SelectableListInteractor.swift */,
+			);
+			path = SelectableList;
+			sourceTree = "<group>";
+		};
+		OBJ_1120 /* HTTP */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1121 /* HTTPRequest.swift */,
+				OBJ_1122 /* HTTPRequestBuilder.swift */,
+				OBJ_1123 /* HTTPRequester.swift */,
+				OBJ_1124 /* HTTPTransport+Error.swift */,
+				OBJ_1125 /* HTTPTransport+Result.swift */,
+				OBJ_1126 /* HTTPTransport.swift */,
+			);
+			path = HTTP;
+			sourceTree = "<group>";
+		};
+		OBJ_1128 /* RetryStrategy */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1129 /* AlgoliaRetryStrategy.swift */,
+				OBJ_1130 /* HostIterator.swift */,
+				OBJ_1131 /* HostSwitcher.swift */,
+				OBJ_1132 /* RetryStrategy.swift */,
+				OBJ_1133 /* RetryableHost.swift */,
+			);
+			path = RetryStrategy;
+			sourceTree = "<group>";
+		};
+		OBJ_1134 /* URLSession */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1135 /* URLRequest+Convenience.swift */,
+				OBJ_1136 /* URLSession+HTTPRequester.swift */,
+			);
+			path = URLSession;
+			sourceTree = "<group>";
+		};
+		OBJ_1138 /* swift-log 1.4.2 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1139 /* Logging */,
+				OBJ_1143 /* Package.swift */,
+			);
+			name = "swift-log 1.4.2";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1139 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_1140 /* Locks.swift */,
+				OBJ_1141 /* LogHandler.swift */,
+				OBJ_1142 /* Logging.swift */,
+			);
+			name = Logging;
+			path = ".build/checkouts/swift-log/Sources/Logging";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_1144 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */,
+				"instantsearch-ios::InstantSearch::Product" /* InstantSearch.framework */,
+				"instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */,
+				"instantsearch-ios::InstantSearchCoreTests::Product" /* InstantSearchCoreTests.xctest */,
+				"instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */,
+				"instantsearch-ios::InstantSearchInsightsTests::Product" /* InstantSearchInsightsTests.xctest */,
+				"instantsearch-ios::InstantSearchSwiftUI::Product" /* InstantSearchSwiftUI.framework */,
+				"instantsearch-ios::InstantSearchSwiftUITests::Product" /* InstantSearchSwiftUITests.xctest */,
+				"instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */,
+				"instantsearch-ios::InstantSearchTests::Product" /* InstantSearchTests.xctest */,
+				"swift-log::Logging::Product" /* Logging.framework */,
+				"swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_115 /* SelectableSegment */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_116 /* SelectableSegmentController.swift */,
+				OBJ_117 /* SelectableSegmentInteractor.swift */,
+			);
+			path = SelectableSegment;
+			sourceTree = "<group>";
+		};
+		OBJ_118 /* CurrentFilters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_119 /* Connector */,
+				OBJ_122 /* CurrentFiltersInteractor+FilterState.swift */,
+				OBJ_123 /* CurrentFiltersInteractor.swift */,
+				OBJ_124 /* CurrentFiltersListController.swift */,
+				OBJ_125 /* ItemListController.swift */,
+				OBJ_126 /* ItemListInteractor+Controller.swift */,
+				OBJ_127 /* ItemsListInteractor.swift */,
+			);
+			path = CurrentFilters;
+			sourceTree = "<group>";
+		};
+		OBJ_119 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_120 /* CurrentFiltersConnector+Controller.swift */,
+				OBJ_121 /* CurrentFiltersConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_12 /* ClearRefinements */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_13 /* ClearRefinementsButtonController.swift */,
+			);
+			path = ClearRefinements;
+			sourceTree = "<group>";
+		};
+		OBJ_128 /* DynamicFacets */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_129 /* AttributedFacets.swift */,
+				OBJ_130 /* Connector */,
+				OBJ_133 /* DynamicFacetListController.swift */,
+				OBJ_134 /* DynamicFacetListInteractor+Controller.swift */,
+				OBJ_135 /* DynamicFacetListInteractor+FilterState.swift */,
+				OBJ_136 /* DynamicFacetListInteractor+Searcher.swift */,
+				OBJ_137 /* DynamicFacetListInteractor.swift */,
+				OBJ_138 /* FacetsOrderer.swift */,
+			);
+			path = DynamicFacets;
+			sourceTree = "<group>";
+		};
+		OBJ_130 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_131 /* DynamicFacetListConnector+Controller.swift */,
+				OBJ_132 /* DynamicFacetListConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_139 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_140 /* Optional+Collection.swift */,
+				OBJ_141 /* Optional+String.swift */,
+				OBJ_142 /* Query+Facets.swift */,
+				OBJ_143 /* Result+ConvenientInit.swift */,
+				OBJ_144 /* Sequence+Convenience.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		OBJ_14 /* CurrentFilters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* CurrentFiltersSearchTextFieldController.swift */,
+				OBJ_16 /* CurrentFiltersTableViewController.swift */,
+			);
+			path = CurrentFilters;
+			sourceTree = "<group>";
+		};
+		OBJ_145 /* FacetList */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_146 /* Connector */,
+				OBJ_151 /* FacetListController.swift */,
+				OBJ_152 /* FacetListInteractor+Controller.swift */,
+				OBJ_153 /* FacetListInteractor+FacetSearcher.swift */,
+				OBJ_154 /* FacetListInteractor+FilterState.swift */,
+				OBJ_155 /* FacetListInteractor+HitsSearcher.swift */,
+				OBJ_156 /* FacetListInteractor+MultiIndexSearcher.swift */,
+				OBJ_157 /* FacetListInteractor.swift */,
+				OBJ_158 /* FacetListPresenter.swift */,
+			);
+			path = FacetList;
+			sourceTree = "<group>";
+		};
+		OBJ_146 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_147 /* FacetListConnector+Controller.swift */,
+				OBJ_148 /* FacetListConnector+FacetSearcher.swift */,
+				OBJ_149 /* FacetListConnector+HitsSearcher.swift */,
+				OBJ_150 /* FacetListConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_159 /* FilterClear */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_160 /* Connector */,
+				OBJ_163 /* FilterClearController.swift */,
+				OBJ_164 /* FilterClearInteractor+FilterClearController.swift */,
+				OBJ_165 /* FilterClearInteractor+FilterState.swift */,
+				OBJ_166 /* FilterClearInteractor.swift */,
+			);
+			path = FilterClear;
+			sourceTree = "<group>";
+		};
+		OBJ_160 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_161 /* FilterClearConnector+Controller.swift */,
+				OBJ_162 /* FilterClearConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_167 /* FilterList */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_168 /* Connector */,
+				OBJ_175 /* FilterListController.swift */,
+				OBJ_176 /* FilterListInteractor+Controller.swift */,
+				OBJ_177 /* FilterListInteractor+Facet.swift */,
+				OBJ_178 /* FilterListInteractor+FilterState.swift */,
+				OBJ_179 /* FilterListInteractor+Numeric.swift */,
+				OBJ_180 /* FilterListInteractor+Tag.swift */,
+				OBJ_181 /* FilterListInteractor.swift */,
+			);
+			path = FilterList;
+			sourceTree = "<group>";
+		};
+		OBJ_168 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_169 /* FacetFilterListConnector.swift */,
+				OBJ_170 /* FilterListConnector+Controller.swift */,
+				OBJ_171 /* FilterListConnector.swift */,
+				OBJ_172 /* FilterTypeAliases.swift */,
+				OBJ_173 /* NumericFilterListConnector.swift */,
+				OBJ_174 /* TagFilterListConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_17 /* DynamicFacets */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_18 /* DynamicFacetListTableViewController.swift */,
+			);
+			path = DynamicFacets;
+			sourceTree = "<group>";
+		};
+		OBJ_182 /* FilterMap */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_183 /* Connector */,
+				OBJ_186 /* FilterMapInteractor+Controller.swift */,
+				OBJ_187 /* FilterMapInteractor+FilterState.swift */,
+				OBJ_188 /* FilterMapInteractor+Searcher.swift */,
+				OBJ_189 /* FilterMapInteractor.swift */,
+			);
+			path = FilterMap;
+			sourceTree = "<group>";
+		};
+		OBJ_183 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_184 /* FilterMapConnector+Controller.swift */,
+				OBJ_185 /* FilterMapConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_19 /* FacetList */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_20 /* FacetListTableController.swift */,
+			);
+			path = FacetList;
+			sourceTree = "<group>";
+		};
+		OBJ_190 /* FilterState */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_191 /* Accessors */,
+				OBJ_197 /* FIlter */,
+				OBJ_212 /* FilterGroupID.swift */,
+				OBJ_213 /* FilterGroupsConvertible.swift */,
+				OBJ_214 /* FilterState+Commands.swift */,
+				OBJ_215 /* FilterState+DisjunctiveFaceting.swift */,
+				OBJ_216 /* FilterState+FiltersReadable.swift */,
+				OBJ_217 /* FilterState+FiltersWritable.swift */,
+				OBJ_218 /* FilterState+HierarchicalFaceting.swift */,
+				OBJ_219 /* FilterState+Searcher.swift */,
+				OBJ_220 /* FilterState.swift */,
+				OBJ_221 /* FilterStateDSL.swift */,
+				OBJ_222 /* FiltersReadable.swift */,
+				OBJ_223 /* FiltersSettable.swift */,
+				OBJ_224 /* FiltersWritable.swift */,
+				OBJ_225 /* GroupStorage.swift */,
+				OBJ_226 /* HierarchicalManageable.swift */,
+			);
+			path = FilterState;
+			sourceTree = "<group>";
+		};
+		OBJ_191 /* Accessors */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_192 /* AndGroupAccessor.swift */,
+				OBJ_193 /* GroupAccessor.swift */,
+				OBJ_194 /* HierarchicalGroupAccessor.swift */,
+				OBJ_195 /* OrGroupAccessor.swift */,
+				OBJ_196 /* SpecializedAndGroupAccessor.swift */,
+			);
+			path = Accessors;
+			sourceTree = "<group>";
+		};
+		OBJ_197 /* FIlter */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_198 /* Converters */,
+				OBJ_203 /* FacetFilter.swift */,
+				OBJ_204 /* Filter.swift */,
+				OBJ_205 /* Groups */,
+				OBJ_210 /* NumericFilter.swift */,
+				OBJ_211 /* TagFilter.swift */,
+			);
+			path = FIlter;
+			sourceTree = "<group>";
+		};
+		OBJ_198 /* Converters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_199 /* FilterConverter.swift */,
+				OBJ_200 /* FilterGroupConverter.swift */,
+				OBJ_201 /* LegacySyntax.swift */,
+				OBJ_202 /* SQLSyntax.swift */,
+			);
+			path = Converters;
+			sourceTree = "<group>";
+		};
+		OBJ_205 /* Groups */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_206 /* AndFilterGroup.swift */,
+				OBJ_207 /* FilterGroupType.swift */,
+				OBJ_208 /* HierarchicalFilterGroup.swift */,
+				OBJ_209 /* OrFilterGroup.swift */,
+			);
+			path = Groups;
+			sourceTree = "<group>";
+		};
+		OBJ_21 /* FilterList */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_22 /* FilterListTableController.swift */,
+			);
+			path = FilterList;
+			sourceTree = "<group>";
+		};
+		OBJ_227 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_228 /* Decodable+JSON.swift */,
+				OBJ_229 /* UserAgentSetter.swift */,
+				OBJ_230 /* Version+Current.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
+		OBJ_23 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_24 /* UICollectionView+Convenience.swift */,
+				OBJ_25 /* UITableView+Convenience.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_231 /* Hierarchical */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_232 /* Connector */,
+				OBJ_235 /* HierarchicalController.swift */,
+				OBJ_236 /* HierarchicalInteractor+Controller.swift */,
+				OBJ_237 /* HierarchicalInteractor+FilterState.swift */,
+				OBJ_238 /* HierarchicalInteractor+HitsSearcher.swift */,
+				OBJ_239 /* HierarchicalInteractor.swift */,
+			);
+			path = Hierarchical;
+			sourceTree = "<group>";
+		};
+		OBJ_232 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_233 /* HierarchicalConnector+Controller.swift */,
+				OBJ_234 /* HierarchicalConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_240 /* Highlighting */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_241 /* NSAttributedString+TaggedString.swift */,
+			);
+			path = Highlighting;
+			sourceTree = "<group>";
+		};
+		OBJ_242 /* Hits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_243 /* AnyHitsInteractor.swift */,
+				OBJ_244 /* Connector */,
+				OBJ_248 /* GeoHitsController.swift */,
+				OBJ_249 /* HitsController.swift */,
+				OBJ_250 /* HitsExtractable.swift */,
+				OBJ_251 /* HitsInteractor+Controller.swift */,
+				OBJ_252 /* HitsInteractor+FilterState.swift */,
+				OBJ_253 /* HitsInteractor+GeoHitsController.swift */,
+				OBJ_254 /* HitsInteractor+HitsSearcher.swift */,
+				OBJ_255 /* HitsInteractor+PlacesSearcher.swift */,
+				OBJ_256 /* HitsInteractor+Searcher.swift */,
+				OBJ_257 /* HitsInteractor.swift */,
+				OBJ_258 /* HitsSource.swift */,
+				OBJ_259 /* MultiSourceReloadNotifier.swift */,
+				OBJ_260 /* Related Items */,
+			);
+			path = Hits;
+			sourceTree = "<group>";
+		};
+		OBJ_244 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_245 /* HitsConnector+Controller.swift */,
+				OBJ_246 /* HitsConnector+GeoSearch.swift */,
+				OBJ_247 /* HitsConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_26 /* Hierarchical */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_27 /* HierarchicalTableViewController.swift */,
+			);
+			path = Hierarchical;
+			sourceTree = "<group>";
+		};
+		OBJ_260 /* Related Items */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_261 /* MatchingPattern.swift */,
+				OBJ_262 /* RelatedItemsInteractor+HitsSearcher.swift */,
+			);
+			path = "Related Items";
+			sourceTree = "<group>";
+		};
+		OBJ_263 /* InfiniteScrolling */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_264 /* InfiniteScrollable.swift */,
+				OBJ_265 /* InfiniteScrollingController.swift */,
+			);
+			path = InfiniteScrolling;
+			sourceTree = "<group>";
+		};
+		OBJ_266 /* Loading */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_267 /* Connector */,
+				OBJ_270 /* LoadingController.swift */,
+				OBJ_271 /* LoadingInteractor+Controller.swift */,
+				OBJ_272 /* LoadingInteractor+Searcher.swift */,
+				OBJ_273 /* LoadingInteractor.swift */,
+			);
+			path = Loading;
+			sourceTree = "<group>";
+		};
+		OBJ_267 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_268 /* LoadingConnector+Controller.swift */,
+				OBJ_269 /* LoadingConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_274 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_275 /* DecodingErrorPrettyPrinter.swift */,
+				OBJ_276 /* Logger+InstantSearchCore.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		OBJ_277 /* MultiIndexHits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_278 /* Connector */,
+				OBJ_283 /* MultiIndexHitsController.swift */,
+				OBJ_284 /* MultiIndexHitsInteractor+Controller.swift */,
+				OBJ_285 /* MultiIndexHitsInteractor+FilterState.swift */,
+				OBJ_286 /* MultiIndexHitsInteractor+Searcher.swift */,
+				OBJ_287 /* MultiIndexHitsInteractor.swift */,
+				OBJ_288 /* MultiIndexHitsSource.swift */,
+			);
+			path = MultiIndexHits;
+			sourceTree = "<group>";
+		};
+		OBJ_278 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_279 /* MultiIndexHitsConnector+Controller.swift */,
+				OBJ_280 /* MultiIndexHitsConnector+IndexModule.swift */,
+				OBJ_281 /* MultiIndexHitsConnector+Suggestions.swift */,
+				OBJ_282 /* MultiIndexHitsConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_28 /* Hits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_29 /* CellConfigurable.swift */,
+				OBJ_30 /* CollectionView */,
+				OBJ_37 /* TableView */,
+			);
+			path = Hits;
+			sourceTree = "<group>";
+		};
+		OBJ_289 /* Number */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_290 /* Boundable+SearchResultProvider.swift */,
+				OBJ_291 /* Computation.swift */,
+				OBJ_292 /* Connector */,
+				OBJ_295 /* FilterComparison+Controller.swift */,
+				OBJ_296 /* FilterComparison+FilterState.swift */,
+				OBJ_297 /* FilterComparisonComputeBounds.swift */,
+				OBJ_298 /* NumberController.swift */,
+				OBJ_299 /* NumberInteractor.swift */,
+			);
+			path = Number;
+			sourceTree = "<group>";
+		};
+		OBJ_292 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_293 /* FilterComparisonConnector+Controller.swift */,
+				OBJ_294 /* FilterComparisonConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_30 /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_31 /* HitsCollectionController.swift */,
+				OBJ_32 /* HitsCollectionViewContainer.swift */,
+				OBJ_33 /* HitsCollectionViewController.swift */,
+				OBJ_34 /* HitsCollectionViewDataSource.swift */,
+				OBJ_35 /* HitsCollectionViewDelegate.swift */,
+				OBJ_36 /* UICollectionViewController+HitsCollectionViewContainer.swift */,
+			);
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
+		OBJ_300 /* NumberRange */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_301 /* Connector */,
+				OBJ_304 /* NumberRangeController.swift */,
+				OBJ_305 /* NumberRangeInteractor+Controller.swift */,
+				OBJ_306 /* NumberRangeInteractor+FilterState.swift */,
+				OBJ_307 /* NumberRangeInteractor.swift */,
+			);
+			path = NumberRange;
+			sourceTree = "<group>";
+		};
+		OBJ_301 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_302 /* NumberRangeConnector+Controller.swift */,
+				OBJ_303 /* NumberRangeConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_308 /* Observations */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_309 /* Observable.swift */,
+				OBJ_310 /* Observation.swift */,
+				OBJ_311 /* Observer.swift */,
+				OBJ_312 /* Signals+Observable.swift */,
+				OBJ_313 /* Subscription.swift */,
+			);
+			path = Observations;
+			sourceTree = "<group>";
+		};
+		OBJ_314 /* Pagination */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_315 /* PageLoadable.swift */,
+				OBJ_316 /* PageMap.swift */,
+				OBJ_317 /* Paginator.swift */,
+				OBJ_318 /* SearchResults+PageMap.swift */,
+				OBJ_319 /* SynchronizedSet.swift */,
+			);
+			path = Pagination;
+			sourceTree = "<group>";
+		};
+		OBJ_320 /* Presenters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_321 /* DefaultPresenter.swift */,
+				OBJ_322 /* FacetPresenter.swift */,
+				OBJ_323 /* FilterPresenter.swift */,
+				OBJ_324 /* HierarchicalPresenter.swift */,
+				OBJ_325 /* IndexNamePresenter.swift */,
+				OBJ_326 /* IndexPresenter.swift */,
+				OBJ_327 /* RelevantSortPresenter.swift */,
+				OBJ_328 /* StatsPresenter.swift */,
+			);
+			path = Presenters;
+			sourceTree = "<group>";
+		};
+		OBJ_329 /* QueryBuilder */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_330 /* QueryBuilder+DisjunctiveFaceting.swift */,
+				OBJ_331 /* QueryBuilder+HierarchicalFaceting.swift */,
+				OBJ_332 /* QueryBuilder.swift */,
+			);
+			path = QueryBuilder;
+			sourceTree = "<group>";
+		};
+		OBJ_333 /* QueryRuleCustomData */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_334 /* Connector */,
+				OBJ_337 /* QueryRuleCustomData+Searcher.swift */,
+				OBJ_338 /* QueryRuleCustomDataInteractor+HitsSearcher.swift */,
+				OBJ_339 /* QueryRuleCustomDataInteractor+MultiIndexSearcher.swift */,
+				OBJ_340 /* QueryRuleCustomDataInteractor.swift */,
+			);
+			path = QueryRuleCustomData;
+			sourceTree = "<group>";
+		};
+		OBJ_334 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_335 /* QueryRuleCustomDataConnector+Controller.swift */,
+				OBJ_336 /* QueryRuleCustomDataConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_341 /* RelevantSort */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_342 /* Connector */,
+				OBJ_345 /* RelevantSortInteractor+Controller.swift */,
+				OBJ_346 /* RelevantSortInteractor+HitsSearcher.swift */,
+				OBJ_347 /* RelevantSortInteractor+MultiIndexSearcher.swift */,
+				OBJ_348 /* RelevantSortInteractor.swift */,
+				OBJ_349 /* RelevantSortPriority.swift */,
+			);
+			path = RelevantSort;
+			sourceTree = "<group>";
+		};
+		OBJ_342 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_343 /* RelevantSortConnector+Controller.swift */,
+				OBJ_344 /* RelevantSortConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_350 /* SearchBox */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_351 /* Connector */,
+				OBJ_354 /* QuerySettable.swift */,
+				OBJ_355 /* SearchBoxController.swift */,
+				OBJ_356 /* SearchBoxInteractor+Controller.swift */,
+				OBJ_357 /* SearchBoxInteractor+Searcher.swift */,
+				OBJ_358 /* SearchBoxInteractor.swift */,
+				OBJ_359 /* SearchTriggeringMode.swift */,
+			);
+			path = SearchBox;
+			sourceTree = "<group>";
+		};
+		OBJ_351 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_352 /* SearchBoxConnector+Controller.swift */,
+				OBJ_353 /* SearchBoxConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_360 /* Searcher */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_361 /* AbstractSearcher+TextualQueryProvider.swift */,
+				OBJ_362 /* AbstractSearcher.swift */,
+				OBJ_363 /* Answers */,
+				OBJ_366 /* DisjunctiveFacetingDelegate.swift */,
+				OBJ_367 /* Facet */,
+				OBJ_370 /* HierarchicalFacetingDelegate.swift */,
+				OBJ_371 /* Hits */,
+				OBJ_374 /* IndexNameProvider.swift */,
+				OBJ_375 /* IndexSearcher.swift */,
+				OBJ_376 /* Multi */,
+				OBJ_383 /* MultiIndex */,
+				OBJ_386 /* Places */,
+				OBJ_388 /* SearchService */,
+				OBJ_396 /* Searcher.swift */,
+				OBJ_397 /* TextualQueryProvider.swift */,
+			);
+			path = Searcher;
+			sourceTree = "<group>";
+		};
+		OBJ_363 /* Answers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_364 /* AnswersSearcher+FilterState.swift */,
+				OBJ_365 /* AnswersSearcher.swift */,
+			);
+			path = Answers;
+			sourceTree = "<group>";
+		};
+		OBJ_367 /* Facet */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_368 /* FacetSearcher+FilterState.swift */,
+				OBJ_369 /* FacetSearcher.swift */,
+			);
+			path = Facet;
+			sourceTree = "<group>";
+		};
+		OBJ_37 /* TableView */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_38 /* HitsTableController.swift */,
+				OBJ_39 /* HitsTableViewContainer.swift */,
+				OBJ_40 /* HitsTableViewController.swift */,
+				OBJ_41 /* HitsTableViewDataSource.swift */,
+				OBJ_42 /* HitsTableViewDelegate.swift */,
+				OBJ_43 /* UITableViewController+HitsTableViewContainer.swift */,
+			);
+			path = TableView;
+			sourceTree = "<group>";
+		};
+		OBJ_371 /* Hits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_372 /* HitsSearcher+FilterState.swift */,
+				OBJ_373 /* HitsSearcher.swift */,
+			);
+			path = Hits;
+			sourceTree = "<group>";
+		};
+		OBJ_376 /* Multi */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_377 /* AbstractMultiSearcher.swift */,
+				OBJ_378 /* MultiRequest.swift */,
+				OBJ_379 /* MultiResult.swift */,
+				OBJ_380 /* MultiSearchComponent.swift */,
+				OBJ_381 /* MultiSearchService.swift */,
+				OBJ_382 /* MultiSearcher.swift */,
+			);
+			path = Multi;
+			sourceTree = "<group>";
+		};
+		OBJ_383 /* MultiIndex */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_384 /* MultiIndexSearcher+FilterState.swift */,
+				OBJ_385 /* MultiIndexSearcher.swift */,
+			);
+			path = MultiIndex;
+			sourceTree = "<group>";
+		};
+		OBJ_386 /* Places */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_387 /* PlacesSearcher.swift */,
+			);
+			path = Places;
+			sourceTree = "<group>";
+		};
+		OBJ_388 /* SearchService */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_389 /* AlgoliaAnswersSearchService.swift */,
+				OBJ_390 /* AlgoliaMultiSearchService.swift */,
+				OBJ_391 /* AlgoliaPlacesSearchService.swift */,
+				OBJ_392 /* AlgoliaRequest.swift */,
+				OBJ_393 /* AlgoliaSearchService.swift */,
+				OBJ_394 /* FacetSearchService.swift */,
+				OBJ_395 /* SearchService.swift */,
+			);
+			path = SearchService;
+			sourceTree = "<group>";
+		};
+		OBJ_398 /* Sequencer */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_399 /* Sequencer.swift */,
+			);
+			path = Sequencer;
+			sourceTree = "<group>";
+		};
+		OBJ_401 /* SortBy */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_402 /* Connector */,
+				OBJ_405 /* IndexSegment */,
+				OBJ_411 /* SortByInteractor+Controller.swift */,
+				OBJ_412 /* SortByInteractor+Searcher.swift */,
+				OBJ_413 /* SortByInteractor.swift */,
+			);
+			path = SortBy;
+			sourceTree = "<group>";
+		};
+		OBJ_402 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_403 /* SortByConnector+Controller.swift */,
+				OBJ_404 /* SortByConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_405 /* IndexSegment */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_406 /* IndexSegmentInteractor+AnswersSearcher.swift */,
+				OBJ_407 /* IndexSegmentInteractor+Controller.swift */,
+				OBJ_408 /* IndexSegmentInteractor+HitsSearcher.swift */,
+				OBJ_409 /* IndexSegmentInteractor+MultiIndexSearcher.swift */,
+				OBJ_410 /* IndexSegmentInteractor.swift */,
+			);
+			path = IndexSegment;
+			sourceTree = "<group>";
+		};
+		OBJ_414 /* Stats */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_415 /* Connector */,
+				OBJ_418 /* SearchStats.swift */,
+				OBJ_419 /* SearchStatsConvertible.swift */,
+				OBJ_420 /* StatsController.swift */,
+				OBJ_421 /* StatsInteractor+Controller.swift */,
+				OBJ_422 /* StatsInteractor+HitsSearcher.swift */,
+				OBJ_423 /* StatsInteractor+Searcher.swift */,
+				OBJ_424 /* StatsInteractor.swift */,
+			);
+			path = Stats;
+			sourceTree = "<group>";
+		};
+		OBJ_415 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_416 /* StatsConnector+Controller.swift */,
+				OBJ_417 /* StatsConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_425 /* SwitchIndex */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_426 /* SwitchIndexInteractor+Controller.swift */,
+				OBJ_427 /* SwitchIndexInteractor+Searcher.swift */,
+				OBJ_428 /* SwitchIndexInteractor.swift.swift */,
+			);
+			path = SwitchIndex;
+			sourceTree = "<group>";
+		};
+		OBJ_429 /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_430 /* Telemetry.swift */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
+		OBJ_431 /* Toggle */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_432 /* Connector */,
+				OBJ_435 /* FilgerToggle+Controller.swift */,
+				OBJ_436 /* FilterToggle+FilterState.swift */,
+			);
+			path = Toggle;
+			sourceTree = "<group>";
+		};
+		OBJ_432 /* Connector */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_433 /* FilterToggleConnector+Controller.swift */,
+				OBJ_434 /* FilterToggleConnector.swift */,
+			);
+			path = Connector;
+			sourceTree = "<group>";
+		};
+		OBJ_437 /* Tracker */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_438 /* FilterTrackable.swift */,
+				OBJ_439 /* FilterTracker.swift */,
+				OBJ_440 /* HitsAfterSearchTrackable.swift */,
+				OBJ_441 /* HitsTracker.swift */,
+				OBJ_442 /* InsightsTracker.swift */,
+				OBJ_443 /* TrackableSearcher.swift */,
+			);
+			path = Tracker;
+			sourceTree = "<group>";
+		};
+		OBJ_44 /* LoadingIndicator */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_45 /* ActivityIndicatorController.swift */,
+			);
+			path = LoadingIndicator;
+			sourceTree = "<group>";
+		};
+		OBJ_444 /* InstantSearchInsights */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_445 /* Readme.md */,
+				OBJ_446 /* Extensions */,
+				OBJ_449 /* Helpers */,
+				OBJ_452 /* Logging */,
+				OBJ_459 /* Logic */,
+				OBJ_467 /* Models */,
+				OBJ_473 /* Protocols */,
+			);
+			name = InstantSearchInsights;
+			path = Sources/InstantSearchInsights;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_446 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_447 /* Date+Milliseconds.swift */,
+				OBJ_448 /* Encodable.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		OBJ_449 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_450 /* JSONFilePackageStorage.swift */,
+				OBJ_451 /* TimerController.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_452 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_453 /* LogCollector.swift */,
+				OBJ_454 /* LogLevel.swift */,
+				OBJ_455 /* LogService.swift */,
+				OBJ_456 /* Logger+InstantSearchInsights.swift */,
+				OBJ_457 /* PrefixedLogger.swift */,
+				OBJ_458 /* SwiftLog+LogService.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		OBJ_459 /* Logic */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_460 /* EventProcessor+AlgoliaClient.swift */,
+				OBJ_461 /* EventProcessor.swift */,
+				OBJ_462 /* EventTracker.swift */,
+				OBJ_463 /* Insights+EventTracking.swift */,
+				OBJ_464 /* Insights+SearchEventTracking.swift */,
+				OBJ_465 /* Insights.swift */,
+				OBJ_466 /* InsightsClient+EventService.swift */,
+			);
+			path = Logic;
+			sourceTree = "<group>";
+		};
+		OBJ_46 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_47 /* Logger+InstantSearch.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		OBJ_467 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_468 /* Config.swift */,
+				OBJ_469 /* Package+InsightsEvent.swift */,
+				OBJ_470 /* Package.swift */,
+				OBJ_471 /* Packager+InsightsEvent.swift */,
+				OBJ_472 /* Packager.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		OBJ_473 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_474 /* EventProcessable.swift */,
+				OBJ_475 /* EventTrackable.swift */,
+				OBJ_476 /* EventsService.swift */,
+				OBJ_477 /* Flushable.swift */,
+				OBJ_478 /* PackageManageable.swift */,
+				OBJ_479 /* Packaging.swift */,
+				OBJ_480 /* Storage.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		OBJ_48 /* MultiIndexHits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_49 /* CollectionView */,
+				OBJ_53 /* TableView */,
+			);
+			path = MultiIndexHits;
+			sourceTree = "<group>";
+		};
+		OBJ_481 /* InstantSearchSwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_482 /* DataModel */,
+				OBJ_499 /* View */,
+			);
+			name = InstantSearchSwiftUI;
+			path = Sources/InstantSearchSwiftUI;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_482 /* DataModel */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_483 /* CurrentFiltersObservableController.swift */,
+				OBJ_484 /* DynamicFacetListObservableController.swift */,
+				OBJ_485 /* FacetListObservableController.swift */,
+				OBJ_486 /* FilterClearObservableController.swift */,
+				OBJ_487 /* FilterListObservableController.swift */,
+				OBJ_488 /* FilterToggleObservableController.swift */,
+				OBJ_489 /* HierarchicalObservableController.swift */,
+				OBJ_490 /* HitsObservableController.swift */,
+				OBJ_491 /* LoadingObservableController.swift */,
+				OBJ_492 /* NumberRangeObservableController.swift */,
+				OBJ_493 /* RelevantSortObservableController.swift */,
+				OBJ_494 /* SearchBoxObservableController.swift */,
+				OBJ_495 /* SelectableSegmentObservableController.swift */,
+				OBJ_496 /* StatsObservableController.swift */,
+				OBJ_497 /* StatsTextObservableController.swift */,
+				OBJ_498 /* SwitchIndexObservableController.swift */,
+			);
+			path = DataModel;
+			sourceTree = "<group>";
+		};
+		OBJ_49 /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_50 /* MultiIndexHitsCollectionController.swift */,
+				OBJ_51 /* MultiIndexHitsCollectionViewDataSource.swift */,
+				OBJ_52 /* MultiIndexHitsCollectionViewDelegate.swift */,
+			);
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
+		OBJ_499 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_500 /* FacetList.swift */,
+				OBJ_501 /* FacetRow.swift */,
+				OBJ_502 /* FilterList.swift */,
+				OBJ_503 /* HierarchicalFacetRow.swift */,
+				OBJ_504 /* HierarchicalList.swift */,
+				OBJ_505 /* HitsList.swift */,
+				OBJ_506 /* SearchBar.swift */,
+				OBJ_507 /* SuggestionRow.swift */,
+				OBJ_508 /* Text+Highlighting.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_509 /* Tests */,
+				OBJ_656 /* Dependencies */,
+				OBJ_1144 /* Products */,
+				OBJ_1157 /* Resources */,
+				OBJ_1158 /* Examples */,
+				OBJ_1159 /* fastlane */,
+				OBJ_1160 /* LICENSE.md */,
+				OBJ_1161 /* CHANGELOG.md */,
+				OBJ_1162 /* carthage-prebuild */,
+				OBJ_1163 /* Cartfile */,
+				OBJ_1164 /* generate_changelog */,
+				OBJ_1165 /* InstantSearch.podspec */,
+				OBJ_1166 /* Readme.md */,
+				OBJ_1167 /* Gemfile */,
+				OBJ_1168 /* Gemfile.lock */,
+				OBJ_1169 /* generate_version */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_509 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_510 /* InstantSearchCoreTests */,
+				OBJ_609 /* InstantSearchInsightsTests */,
+				OBJ_627 /* InstantSearchSwiftUITests */,
+				OBJ_629 /* InstantSearchTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_510 /* InstantSearchCoreTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_511 /* Helpers */,
+				OBJ_514 /* InstantSearchCoreTests.swift */,
+				OBJ_515 /* Integration */,
+				OBJ_521 /* Misc */,
+				OBJ_523 /* Unit */,
+				OBJ_608 /* XCTestManifests.swift */,
+			);
+			name = InstantSearchCoreTests;
+			path = Tests/InstantSearchCoreTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_511 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_512 /* JSONDecoder+Resource.swift */,
+				OBJ_513 /* String+Random.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_515 /* Integration */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_516 /* DisjuncitveAndHierarchicalIntegrationTests.swift */,
+				OBJ_517 /* DisjunctiveFacetingIntegrationTests.swift */,
+				OBJ_518 /* HierarchicalIntegrationTests.swift */,
+				OBJ_519 /* OnlineTestCase.swift */,
+				OBJ_520 /* TestCredentials.swift */,
+			);
+			path = Integration;
+			sourceTree = "<group>";
+		};
+		OBJ_521 /* Misc */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_522 /* Data+FileAccess.swift */,
+			);
+			path = Misc;
+			sourceTree = "<group>";
+		};
+		OBJ_523 /* Unit */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_524 /* AttributedStringWithTaggedStringTests.swift */,
+				OBJ_525 /* Connectors */,
+				OBJ_529 /* CurrentFilters */,
+				OBJ_533 /* DecodingErrorPrettyPrinterTests.swift */,
+				OBJ_534 /* DisjunctiveFacetingsTests.swift */,
+				OBJ_535 /* DynamicFacets */,
+				OBJ_537 /* FacetList */,
+				OBJ_546 /* FilterState */,
+				OBJ_552 /* Helpers.swift */,
+				OBJ_553 /* Hits */,
+				OBJ_561 /* InfiniteScrollingControllerTests.swift */,
+				OBJ_562 /* ItemInteractorTests.swift */,
+				OBJ_563 /* LoggingTests.swift */,
+				OBJ_564 /* MultiIndexHits */,
+				OBJ_567 /* MultiIndexHitsInteractorTests.swift */,
+				OBJ_568 /* MultiSourceHitsReloaderTests.swift */,
+				OBJ_569 /* Number */,
+				OBJ_572 /* PageMapTests.swift */,
+				OBJ_573 /* PaginatorTests.swift */,
+				OBJ_574 /* QueryBuilderTests.swift */,
+				OBJ_575 /* QueryInput */,
+				OBJ_581 /* QueryRuleCustomData */,
+				OBJ_583 /* RelevantSort */,
+				OBJ_588 /* Searcher */,
+				OBJ_592 /* SelectableInteractorConnectorsTests.swift */,
+				OBJ_593 /* SelectableInteractorTests.swift */,
+				OBJ_594 /* SelectableListInteractorFilterConnectorsTests.swift */,
+				OBJ_595 /* SelectableListInteractorTests.swift */,
+				OBJ_596 /* SelectableSegment */,
+				OBJ_600 /* SequencerTest.swift */,
+				OBJ_601 /* StatsInteractorConnectorsTests.swift */,
+				OBJ_602 /* TelemetryTests.swift */,
+				OBJ_603 /* Tracker */,
+			);
+			path = Unit;
+			sourceTree = "<group>";
+		};
+		OBJ_525 /* Connectors */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_526 /* MultiIndexSearchConnectorTests.swift */,
+				OBJ_527 /* SearchConnectorTests.swift */,
+				OBJ_528 /* SortByConnectorTests.swift */,
+			);
+			path = Connectors;
+			sourceTree = "<group>";
+		};
+		OBJ_529 /* CurrentFilters */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_530 /* CurrentFiltersControllerConnectionTests.swift */,
+				OBJ_531 /* CurrentFiltersFilterStateConnectionTests.swift */,
+				OBJ_532 /* TestCurrentFiltersController.swift */,
+			);
+			path = CurrentFilters;
+			sourceTree = "<group>";
+		};
+		OBJ_53 /* TableView */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_54 /* MultiIndexHitsTableController.swift */,
+				OBJ_55 /* MultiIndexHitsTableViewDataSource.swift */,
+				OBJ_56 /* MultiIndexHitsTableViewDelegate.swift */,
+			);
+			path = TableView;
+			sourceTree = "<group>";
+		};
+		OBJ_535 /* DynamicFacets */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_536 /* FacetsOrdererTests.swift */,
+			);
+			path = DynamicFacets;
+			sourceTree = "<group>";
+		};
+		OBJ_537 /* FacetList */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_538 /* Array+Facet.swift */,
+				OBJ_539 /* FacetListControllerConnectionTests.swift */,
+				OBJ_540 /* FacetListFacetSearcherConnectionTests.swift */,
+				OBJ_541 /* FacetListFilterStateConnectionTests.swift */,
+				OBJ_542 /* FacetListHitsSearcherConnectionTests.swift */,
+				OBJ_543 /* FacetListInteractorTests.swift */,
+				OBJ_544 /* FacetListPresenterTests.swift */,
+				OBJ_545 /* TestFacetListController.swift */,
+			);
+			path = FacetList;
+			sourceTree = "<group>";
+		};
+		OBJ_546 /* FilterState */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_547 /* FilterGroupCollectionsTests.swift */,
+				OBJ_548 /* FilterGroupTests.swift */,
+				OBJ_549 /* FilterStateGroupTests.swift */,
+				OBJ_550 /* FilterStateTests.swift */,
+				OBJ_551 /* FilterTests.swift */,
+			);
+			path = FilterState;
+			sourceTree = "<group>";
+		};
+		OBJ_553 /* Hits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_554 /* HitsInteractorControllerConnectionTests.swift */,
+				OBJ_555 /* HitsInteractorFilterStateConnectionTests.swift */,
+				OBJ_556 /* HitsInteractorRelatedItemsTests.swift */,
+				OBJ_557 /* HitsInteractorSearcherConnectionTests.swift */,
+				OBJ_558 /* HitsInteractorTests.swift */,
+				OBJ_559 /* TestHitsController.swift */,
+				OBJ_560 /* TestInfiniteScrollingController.swift */,
+			);
+			path = Hits;
+			sourceTree = "<group>";
+		};
+		OBJ_564 /* MultiIndexHits */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_565 /* MultiIndexHitsInteractorControllerConnectionTests.swift */,
+				OBJ_566 /* MultiIndexHitsInteractorSearcherConnectionTests.swift */,
+			);
+			path = MultiIndexHits;
+			sourceTree = "<group>";
+		};
+		OBJ_569 /* Number */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_570 /* NumberInteractorTests.swift */,
+				OBJ_571 /* NumberRangeInteractorTests.swift */,
+			);
+			path = Number;
+			sourceTree = "<group>";
+		};
+		OBJ_57 /* Numeric */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_58 /* NumericRatingController.swift */,
+				OBJ_59 /* NumericRatingRangeController.swift */,
+				OBJ_60 /* NumericStepperController.swift */,
+				OBJ_61 /* NumericTextFieldController.swift */,
+				OBJ_62 /* RatingControl.swift */,
+			);
+			path = Numeric;
+			sourceTree = "<group>";
+		};
+		OBJ_575 /* QueryInput */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_576 /* SearchBoxControllerConnectionTests.swift */,
+				OBJ_577 /* SearchBoxInteractorTests.swift */,
+				OBJ_578 /* SearchBoxSearcherConnectionTests.swift */,
+				OBJ_579 /* TestSearchBoxController.swift */,
+				OBJ_580 /* TestSearcher.swift */,
+			);
+			path = QueryInput;
+			sourceTree = "<group>";
+		};
+		OBJ_581 /* QueryRuleCustomData */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_582 /* QueryRuleCustomDataSearcherConnectionTests.swift */,
+			);
+			path = QueryRuleCustomData;
+			sourceTree = "<group>";
+		};
+		OBJ_583 /* RelevantSort */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_584 /* RelevantSortControllerConnectionTests.swift */,
+				OBJ_585 /* RelevantSortHitsSearcherConnectionTests.swift */,
+				OBJ_586 /* RelevantSortInteractorTests.swift */,
+				OBJ_587 /* RelevantSortMultiIndexSearcherConnectionTests.swift */,
+			);
+			path = RelevantSort;
+			sourceTree = "<group>";
+		};
+		OBJ_588 /* Searcher */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_589 /* AnswersSearcherTests.swift */,
+				OBJ_590 /* HitsSearcherTests.swift */,
+				OBJ_591 /* MultiIndexSearcherTests.swift */,
+			);
+			path = Searcher;
+			sourceTree = "<group>";
+		};
+		OBJ_596 /* SelectableSegment */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_597 /* SelectableSegmentInteractorConnectorsTests.swift */,
+				OBJ_598 /* SelectableSegmentInteractorTests.swift */,
+				OBJ_599 /* TestSelectableSegmentController.swift */,
+			);
+			path = SelectableSegment;
+			sourceTree = "<group>";
+		};
+		OBJ_603 /* Tracker */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_604 /* FilterTrackerTests.swift */,
+				OBJ_605 /* HitsTrackerTests.swift */,
+				OBJ_606 /* TestFiltersTracker.swift */,
+				OBJ_607 /* TestHitsTracker.swift */,
+			);
+			path = Tracker;
+			sourceTree = "<group>";
+		};
+		OBJ_609 /* InstantSearchInsightsTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_610 /* Helpers */,
+				OBJ_618 /* Unit */,
+			);
+			name = InstantSearchInsightsTests;
+			path = Tests/InstantSearchInsightsTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_610 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_611 /* MockEventService.swift */,
+				OBJ_612 /* String+Random.swift */,
+				OBJ_613 /* TestEvent.swift */,
+				OBJ_614 /* TestEventProcessor.swift */,
+				OBJ_615 /* TestEventTracker.swift */,
+				OBJ_616 /* TestPackageStorage.swift */,
+				OBJ_617 /* XCTest+Codable.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_618 /* Unit */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_619 /* EventTrackerTests.swift */,
+				OBJ_620 /* EventsProcessorTests.swift */,
+				OBJ_621 /* InsightsTests.swift */,
+				OBJ_622 /* JSONFilePackageStorageTests.swift */,
+				OBJ_623 /* LoggingTests.swift */,
+				OBJ_624 /* PackageTests.swift */,
+				OBJ_625 /* PackagerTests.swift */,
+				OBJ_626 /* TimerControllerTests.swift */,
+			);
+			path = Unit;
+			sourceTree = "<group>";
+		};
+		OBJ_627 /* InstantSearchSwiftUITests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_628 /* ObservableControllerTests.swift */,
+			);
+			name = InstantSearchSwiftUITests;
+			path = Tests/InstantSearchSwiftUITests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_629 /* InstantSearchTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_630 /* Helpers */,
+				OBJ_632 /* InstantSearchTests.swift */,
+				OBJ_633 /* LoggingTests.swift */,
+				OBJ_634 /* Snippets */,
+				OBJ_653 /* TestHitsSource.swift */,
+				OBJ_654 /* TestMultiHitsDataSource.swift */,
+				OBJ_655 /* XCTestManifests.swift */,
+			);
+			name = InstantSearchTests;
+			path = Tests/InstantSearchTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_63 /* QuerySuggestions */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_64 /* QuerySuggestionsViewController.swift */,
+			);
+			path = QuerySuggestions;
+			sourceTree = "<group>";
+		};
+		OBJ_630 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_631 /* String+Random.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_634 /* Snippets */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_635 /* BannerGuideSnippets.swift */,
+				OBJ_636 /* CurrentRefinementsSnippets.swift */,
+				OBJ_637 /* FacetFilterListSnippets.swift */,
+				OBJ_638 /* FacetListConnectorSnippets.swift */,
+				OBJ_639 /* FilterClearSnippets.swift */,
+				OBJ_640 /* HierarchicalSnippets.swift */,
+				OBJ_641 /* HitsSnippets.swift */,
+				OBJ_642 /* LoadingSnippets.swift */,
+				OBJ_643 /* MultiIndexHitsSnippets.swift */,
+				OBJ_644 /* NumberRangeSnippets.swift */,
+				OBJ_645 /* NumericFilterListSnippets.swift */,
+				OBJ_646 /* QueryRuleCustomDataSnippets.swift */,
+				OBJ_647 /* RedirectGuideSnippets.swift */,
+				OBJ_648 /* SearchBoxSnippets.swift */,
+				OBJ_649 /* SortBySnippets.swift */,
+				OBJ_650 /* StatsSnippets.swift */,
+				OBJ_651 /* TagFilterListSnippets.swift */,
+				OBJ_652 /* ToggleFilterSnippets.swift */,
+			);
+			path = Snippets;
+			sourceTree = "<group>";
+		};
+		OBJ_65 /* RelevantSort */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_66 /* ButtonRelevantSortController.swift */,
+			);
+			path = RelevantSort;
+			sourceTree = "<group>";
+		};
+		OBJ_656 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_657 /* InstantSearchTelemetry */,
+				OBJ_665 /* SwiftProtobuf 1.19.0 */,
+				OBJ_754 /* AlgoliaSearchClient 8.14.0 */,
+				OBJ_1138 /* swift-log 1.4.2 */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		OBJ_657 /* InstantSearchTelemetry */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_658 /* InstantSearchTelemetry */,
+				OBJ_664 /* Package.swift */,
+			);
+			name = InstantSearchTelemetry;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_658 /* InstantSearchTelemetry */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_659 /* CRC32.swift */,
+				OBJ_660 /* Data+Gzip.swift */,
+				OBJ_661 /* Gzip.swift */,
+				OBJ_662 /* Telemetry.swift */,
+				OBJ_663 /* telemetry.pb.swift */,
+			);
+			name = InstantSearchTelemetry;
+			path = ".build/checkouts/instantsearch-telemetry-native/Sources/InstantSearchTelemetry";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_665 /* SwiftProtobuf 1.19.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_666 /* SwiftProtobuf */,
+				OBJ_751 /* SwiftProtobufPluginLibrary */,
+				OBJ_752 /* protoc-gen-swift */,
+				OBJ_753 /* Package.swift */,
+			);
+			name = "SwiftProtobuf 1.19.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_666 /* SwiftProtobuf */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_667 /* AnyMessageStorage.swift */,
+				OBJ_668 /* AnyUnpackError.swift */,
+				OBJ_669 /* BinaryDecoder.swift */,
+				OBJ_670 /* BinaryDecodingError.swift */,
+				OBJ_671 /* BinaryDecodingOptions.swift */,
+				OBJ_672 /* BinaryDelimited.swift */,
+				OBJ_673 /* BinaryEncoder.swift */,
+				OBJ_674 /* BinaryEncodingError.swift */,
+				OBJ_675 /* BinaryEncodingSizeVisitor.swift */,
+				OBJ_676 /* BinaryEncodingVisitor.swift */,
+				OBJ_677 /* CustomJSONCodable.swift */,
+				OBJ_678 /* Data+Extensions.swift */,
+				OBJ_679 /* Decoder.swift */,
+				OBJ_680 /* DoubleParser.swift */,
+				OBJ_681 /* Enum.swift */,
+				OBJ_682 /* ExtensibleMessage.swift */,
+				OBJ_683 /* ExtensionFieldValueSet.swift */,
+				OBJ_684 /* ExtensionFields.swift */,
+				OBJ_685 /* ExtensionMap.swift */,
+				OBJ_686 /* FieldTag.swift */,
+				OBJ_687 /* FieldTypes.swift */,
+				OBJ_688 /* Google_Protobuf_Any+Extensions.swift */,
+				OBJ_689 /* Google_Protobuf_Any+Registry.swift */,
+				OBJ_690 /* Google_Protobuf_Duration+Extensions.swift */,
+				OBJ_691 /* Google_Protobuf_FieldMask+Extensions.swift */,
+				OBJ_692 /* Google_Protobuf_ListValue+Extensions.swift */,
+				OBJ_693 /* Google_Protobuf_NullValue+Extensions.swift */,
+				OBJ_694 /* Google_Protobuf_Struct+Extensions.swift */,
+				OBJ_695 /* Google_Protobuf_Timestamp+Extensions.swift */,
+				OBJ_696 /* Google_Protobuf_Value+Extensions.swift */,
+				OBJ_697 /* Google_Protobuf_Wrappers+Extensions.swift */,
+				OBJ_698 /* HashVisitor.swift */,
+				OBJ_699 /* Internal.swift */,
+				OBJ_700 /* JSONDecoder.swift */,
+				OBJ_701 /* JSONDecodingError.swift */,
+				OBJ_702 /* JSONDecodingOptions.swift */,
+				OBJ_703 /* JSONEncoder.swift */,
+				OBJ_704 /* JSONEncodingError.swift */,
+				OBJ_705 /* JSONEncodingOptions.swift */,
+				OBJ_706 /* JSONEncodingVisitor.swift */,
+				OBJ_707 /* JSONMapEncodingVisitor.swift */,
+				OBJ_708 /* JSONScanner.swift */,
+				OBJ_709 /* MathUtils.swift */,
+				OBJ_710 /* Message+AnyAdditions.swift */,
+				OBJ_711 /* Message+BinaryAdditions.swift */,
+				OBJ_712 /* Message+JSONAdditions.swift */,
+				OBJ_713 /* Message+JSONArrayAdditions.swift */,
+				OBJ_714 /* Message+TextFormatAdditions.swift */,
+				OBJ_715 /* Message.swift */,
+				OBJ_716 /* MessageExtension.swift */,
+				OBJ_717 /* NameMap.swift */,
+				OBJ_718 /* ProtoNameProviding.swift */,
+				OBJ_719 /* ProtobufAPIVersionCheck.swift */,
+				OBJ_720 /* ProtobufMap.swift */,
+				OBJ_721 /* SelectiveVisitor.swift */,
+				OBJ_722 /* SimpleExtensionMap.swift */,
+				OBJ_723 /* StringUtils.swift */,
+				OBJ_724 /* TextFormatDecoder.swift */,
+				OBJ_725 /* TextFormatDecodingError.swift */,
+				OBJ_726 /* TextFormatDecodingOptions.swift */,
+				OBJ_727 /* TextFormatEncoder.swift */,
+				OBJ_728 /* TextFormatEncodingOptions.swift */,
+				OBJ_729 /* TextFormatEncodingVisitor.swift */,
+				OBJ_730 /* TextFormatScanner.swift */,
+				OBJ_731 /* TimeUtils.swift */,
+				OBJ_732 /* UnknownStorage.swift */,
+				OBJ_733 /* UnsafeBufferPointer+Shims.swift */,
+				OBJ_734 /* UnsafeRawPointer+Shims.swift */,
+				OBJ_735 /* Varint.swift */,
+				OBJ_736 /* Version.swift */,
+				OBJ_737 /* Visitor.swift */,
+				OBJ_738 /* WireFormat.swift */,
+				OBJ_739 /* ZigZag.swift */,
+				OBJ_740 /* any.pb.swift */,
+				OBJ_741 /* api.pb.swift */,
+				OBJ_742 /* descriptor.pb.swift */,
+				OBJ_743 /* duration.pb.swift */,
+				OBJ_744 /* empty.pb.swift */,
+				OBJ_745 /* field_mask.pb.swift */,
+				OBJ_746 /* source_context.pb.swift */,
+				OBJ_747 /* struct.pb.swift */,
+				OBJ_748 /* timestamp.pb.swift */,
+				OBJ_749 /* type.pb.swift */,
+				OBJ_750 /* wrappers.pb.swift */,
+			);
+			name = SwiftProtobuf;
+			path = ".build/checkouts/swift-protobuf/Sources/SwiftProtobuf";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_67 /* SearchBox */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_68 /* SearchBarController.swift */,
+				OBJ_69 /* TextFieldController.swift */,
+			);
+			path = SearchBox;
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* InstantSearch */,
+				OBJ_80 /* InstantSearchCore */,
+				OBJ_444 /* InstantSearchInsights */,
+				OBJ_481 /* InstantSearchSwiftUI */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_70 /* Segmented */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_71 /* SegmentedController.swift */,
+			);
+			path = Segmented;
+			sourceTree = "<group>";
+		};
+		OBJ_72 /* Selectable */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_73 /* FilterSwitchController.swift */,
+				OBJ_74 /* SelectableFilterButtonController.swift */,
+			);
+			path = Selectable;
+			sourceTree = "<group>";
+		};
+		OBJ_75 /* Sort By */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_76 /* SelectIndexController.swift */,
+				OBJ_77 /* SwitchIndexAlertControllerBuilder.swift */,
+			);
+			path = "Sort By";
+			sourceTree = "<group>";
+		};
+		OBJ_751 /* SwiftProtobufPluginLibrary */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = SwiftProtobufPluginLibrary;
+			path = ".build/checkouts/swift-protobuf/Sources/SwiftProtobufPluginLibrary";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_752 /* protoc-gen-swift */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "protoc-gen-swift";
+			path = ".build/checkouts/swift-protobuf/Sources/protoc-gen-swift";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_754 /* AlgoliaSearchClient 8.14.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_755 /* AlgoliaSearchClient */,
+				OBJ_1137 /* Package.swift */,
+			);
+			name = "AlgoliaSearchClient 8.14.0";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_755 /* AlgoliaSearchClient */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_756 /* Async */,
+				OBJ_759 /* Client */,
+				OBJ_776 /* Command */,
+				OBJ_797 /* Helpers */,
+				OBJ_844 /* Index */,
+				OBJ_856 /* Models */,
+				OBJ_1115 /* Transport */,
+			);
+			name = AlgoliaSearchClient;
+			path = ".build/checkouts/algoliasearch-client-swift/Sources/AlgoliaSearchClient";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_756 /* Async */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_757 /* AsyncOperation.swift */,
+				OBJ_758 /* WaitTask.swift */,
+			);
+			path = Async;
+			sourceTree = "<group>";
+		};
+		OBJ_759 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_760 /* AccountClient.swift */,
+				OBJ_761 /* AnalyticsClient.swift */,
+				OBJ_762 /* InsightsClient.swift */,
+				OBJ_763 /* PersonalizationClient.swift */,
+				OBJ_764 /* PlacesClient.swift */,
+				OBJ_765 /* RecommendClient.swift */,
+				OBJ_766 /* Search */,
+			);
+			path = Client;
+			sourceTree = "<group>";
+		};
+		OBJ_766 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_767 /* SearchClient+APIKey.swift */,
+				OBJ_768 /* SearchClient+Dictionaries.swift */,
+				OBJ_769 /* SearchClient+Logs.swift */,
+				OBJ_770 /* SearchClient+Management.swift */,
+				OBJ_771 /* SearchClient+MultiCluster.swift */,
+				OBJ_772 /* SearchClient+MultiIndex.swift */,
+				OBJ_773 /* SearchClient+SecuredAPIKey.swift */,
+				OBJ_774 /* SearchClient+Wait.swift */,
+				OBJ_775 /* SearchClient.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		OBJ_776 /* Command */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_777 /* AlgoliaCommand.swift */,
+				OBJ_778 /* Command+ABTest.swift */,
+				OBJ_779 /* Command+APIKeys.swift */,
+				OBJ_780 /* Command+Advanced.swift */,
+				OBJ_781 /* Command+Answers.swift */,
+				OBJ_782 /* Command+Custom.swift */,
+				OBJ_783 /* Command+Dictionaries.swift */,
+				OBJ_784 /* Command+Index.swift */,
+				OBJ_785 /* Command+Indexing.swift */,
+				OBJ_786 /* Command+Insights.swift */,
+				OBJ_787 /* Command+MultiCluster.swift */,
+				OBJ_788 /* Command+MultipleIndex.swift */,
+				OBJ_789 /* Command+Personalization.swift */,
+				OBJ_790 /* Command+Places.swift */,
+				OBJ_791 /* Command+Recommend.swift */,
+				OBJ_792 /* Command+Rule.swift */,
+				OBJ_793 /* Command+Search.swift */,
+				OBJ_794 /* Command+Settings.swift */,
+				OBJ_795 /* Command+Synonym.swift */,
+				OBJ_796 /* Command.swift */,
+			);
+			path = Command;
+			sourceTree = "<group>";
+		};
+		OBJ_78 /* Stats */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_79 /* LabelStatsController.swift */,
+			);
+			path = Stats;
+			sourceTree = "<group>";
+		};
+		OBJ_797 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_798 /* AssertionTestHelper.swift */,
+				OBJ_799 /* Coding */,
+				OBJ_813 /* Crypto */,
+				OBJ_816 /* FoundationConvenience */,
+				OBJ_822 /* Logging.swift */,
+				OBJ_823 /* ObjectIDChecker.swift */,
+				OBJ_824 /* Protocols */,
+				OBJ_829 /* ResultCallback.swift */,
+				OBJ_830 /* String */,
+				OBJ_834 /* UserAgent */,
+				OBJ_837 /* Version+Current.swift */,
+				OBJ_838 /* Version.swift */,
+				OBJ_839 /* Wait */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		OBJ_799 /* Coding */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_800 /* CustomParametersCoder.swift */,
+				OBJ_801 /* Date */,
+				OBJ_805 /* DecodingErrorPrettyPrinter.swift */,
+				OBJ_806 /* DynamicKey.swift */,
+				OBJ_807 /* Encodiable+HTTPBody.swift */,
+				OBJ_808 /* KeyedDecodingContainer+Convenience.swift */,
+				OBJ_809 /* Wrappers */,
+			);
+			path = Coding;
+			sourceTree = "<group>";
+		};
+		OBJ_8 /* InstantSearch */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* AdvancedConnectors */,
+				OBJ_12 /* ClearRefinements */,
+				OBJ_14 /* CurrentFilters */,
+				OBJ_17 /* DynamicFacets */,
+				OBJ_19 /* FacetList */,
+				OBJ_21 /* FilterList */,
+				OBJ_23 /* Helpers */,
+				OBJ_26 /* Hierarchical */,
+				OBJ_28 /* Hits */,
+				OBJ_44 /* LoadingIndicator */,
+				OBJ_46 /* Logging */,
+				OBJ_48 /* MultiIndexHits */,
+				OBJ_57 /* Numeric */,
+				OBJ_63 /* QuerySuggestions */,
+				OBJ_65 /* RelevantSort */,
+				OBJ_67 /* SearchBox */,
+				OBJ_70 /* Segmented */,
+				OBJ_72 /* Selectable */,
+				OBJ_75 /* Sort By */,
+				OBJ_78 /* Stats */,
+			);
+			name = InstantSearch;
+			path = Sources/InstantSearch;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_80 /* InstantSearchCore */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_81 /* AdvancedConnectors */,
+				OBJ_84 /* Common */,
+				OBJ_118 /* CurrentFilters */,
+				OBJ_128 /* DynamicFacets */,
+				OBJ_139 /* Extensions */,
+				OBJ_145 /* FacetList */,
+				OBJ_159 /* FilterClear */,
+				OBJ_167 /* FilterList */,
+				OBJ_182 /* FilterMap */,
+				OBJ_190 /* FilterState */,
+				OBJ_227 /* Helper */,
+				OBJ_231 /* Hierarchical */,
+				OBJ_240 /* Highlighting */,
+				OBJ_242 /* Hits */,
+				OBJ_263 /* InfiniteScrolling */,
+				OBJ_266 /* Loading */,
+				OBJ_274 /* Logging */,
+				OBJ_277 /* MultiIndexHits */,
+				OBJ_289 /* Number */,
+				OBJ_300 /* NumberRange */,
+				OBJ_308 /* Observations */,
+				OBJ_314 /* Pagination */,
+				OBJ_320 /* Presenters */,
+				OBJ_329 /* QueryBuilder */,
+				OBJ_333 /* QueryRuleCustomData */,
+				OBJ_341 /* RelevantSort */,
+				OBJ_350 /* SearchBox */,
+				OBJ_360 /* Searcher */,
+				OBJ_398 /* Sequencer */,
+				OBJ_400 /* Signal.swift */,
+				OBJ_401 /* SortBy */,
+				OBJ_414 /* Stats */,
+				OBJ_425 /* SwitchIndex */,
+				OBJ_429 /* Telemetry */,
+				OBJ_431 /* Toggle */,
+				OBJ_437 /* Tracker */,
+			);
+			name = InstantSearchCore;
+			path = Sources/InstantSearchCore;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_801 /* Date */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_802 /* ClientDateCodingStrategy.swift */,
+				OBJ_803 /* KeyedDecodingContainer+DateFormat.swift */,
+				OBJ_804 /* KeyedEncodingContainer+DateFormat.swift */,
+			);
+			path = Date;
+			sourceTree = "<group>";
+		};
+		OBJ_809 /* Wrappers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_810 /* BoolContainer.swift */,
+				OBJ_811 /* CustomKey.swift */,
+				OBJ_812 /* StringNumberContainer.swift */,
+			);
+			path = Wrappers;
+			sourceTree = "<group>";
+		};
+		OBJ_81 /* AdvancedConnectors */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_82 /* MultiIndexSearchConnector.swift */,
+				OBJ_83 /* SearchConnector.swift */,
+			);
+			path = AdvancedConnectors;
+			sourceTree = "<group>";
+		};
+		OBJ_813 /* Crypto */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_814 /* HMAC.swift */,
+				OBJ_815 /* String+HMAC.swift */,
+			);
+			path = Crypto;
+			sourceTree = "<group>";
+		};
+		OBJ_816 /* FoundationConvenience */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_817 /* Array+Chunks.swift */,
+				OBJ_818 /* Data+JSONString.swift */,
+				OBJ_819 /* Dictionary+Merging.swift */,
+				OBJ_820 /* Optional+Convenience.swift */,
+				OBJ_821 /* TimeInterval+Minutes.swift */,
+			);
+			path = FoundationConvenience;
+			sourceTree = "<group>";
+		};
+		OBJ_824 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_825 /* Builder.swift */,
+				OBJ_826 /* Cancellable.swift */,
+				OBJ_827 /* ResultContainer.swift */,
+				OBJ_828 /* URLEncodable.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		OBJ_830 /* String */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_831 /* String+Base64.swift */,
+				OBJ_832 /* String+Environment.swift */,
+				OBJ_833 /* String+Wrapping.swift */,
+			);
+			path = String;
+			sourceTree = "<group>";
+		};
+		OBJ_834 /* UserAgent */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_835 /* UserAgent.swift */,
+				OBJ_836 /* UserAgentController.swift */,
+			);
+			path = UserAgent;
+			sourceTree = "<group>";
+		};
+		OBJ_839 /* Wait */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_840 /* AnyWaitable.swift */,
+				OBJ_841 /* TaskWaitable.swift */,
+				OBJ_842 /* Waitable.swift */,
+				OBJ_843 /* WaitableWrapper.swift */,
+			);
+			path = Wait;
+			sourceTree = "<group>";
+		};
+		OBJ_84 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_85 /* AsyncOperation.swift */,
+				OBJ_86 /* Attribute.swift */,
+				OBJ_87 /* Connection.swift */,
+				OBJ_88 /* Constants.swift */,
+				OBJ_89 /* Event */,
+				OBJ_91 /* GeoLocation.swift */,
+				OBJ_92 /* Geolocated.swift */,
+				OBJ_93 /* Hit+Place.swift */,
+				OBJ_94 /* IndexNameSettable.swift */,
+				OBJ_95 /* IndexQueryState.swift */,
+				OBJ_96 /* Item */,
+				OBJ_100 /* Number */,
+				OBJ_103 /* Point+CoreLocation.swift */,
+				OBJ_104 /* Presenter */,
+				OBJ_106 /* QuerySuggestion.swift */,
+				OBJ_107 /* Reloadable.swift */,
+				OBJ_108 /* ResultUpdatable.swift */,
+				OBJ_109 /* Selectable */,
+				OBJ_112 /* SelectableList */,
+				OBJ_115 /* SelectableSegment */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		OBJ_844 /* Index */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_845 /* Index+Advanced.swift */,
+				OBJ_846 /* Index+Answers.swift */,
+				OBJ_847 /* Index+Export.swift */,
+				OBJ_848 /* Index+Index.swift */,
+				OBJ_849 /* Index+Indexing.swift */,
+				OBJ_850 /* Index+Logs.swift */,
+				OBJ_851 /* Index+Rule.swift */,
+				OBJ_852 /* Index+Search.swift */,
+				OBJ_853 /* Index+Settings.swift */,
+				OBJ_854 /* Index+Synonym.swift */,
+				OBJ_855 /* Index.swift */,
+			);
+			path = Index;
+			sourceTree = "<group>";
+		};
+		OBJ_856 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_857 /* APIKey */,
+				OBJ_868 /* Analytics */,
+				OBJ_884 /* Answers */,
+				OBJ_887 /* Common */,
+				OBJ_903 /* Data structures */,
+				OBJ_909 /* Dictionaries */,
+				OBJ_921 /* Insights */,
+				OBJ_932 /* Internal */,
+				OBJ_942 /* Logs */,
+				OBJ_946 /* MultiCluster */,
+				OBJ_960 /* Personalization */,
+				OBJ_966 /* Places */,
+				OBJ_975 /* Recommend */,
+				OBJ_978 /* Rule */,
+				OBJ_992 /* Search */,
+				OBJ_1068 /* Settings */,
+				OBJ_1092 /* Synonym */,
+				OBJ_1099 /* Task */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		OBJ_857 /* APIKey */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_858 /* ACL.swift */,
+				OBJ_859 /* APIKey.swift */,
+				OBJ_860 /* APIKeyCreation.swift */,
+				OBJ_861 /* APIKeyDeletion.swift */,
+				OBJ_862 /* APIKeyParameters.swift */,
+				OBJ_863 /* APIKeyResponse.swift */,
+				OBJ_864 /* APIKeyRevision.swift */,
+				OBJ_865 /* ListAPIKeysResponse.swift */,
+				OBJ_866 /* Secured */,
+			);
+			path = APIKey;
+			sourceTree = "<group>";
+		};
+		OBJ_866 /* Secured */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_867 /* SecuredAPIKeyRestriction.swift */,
+			);
+			path = Secured;
+			sourceTree = "<group>";
+		};
+		OBJ_868 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_869 /* ABTest */,
+				OBJ_883 /* AnalyticsConfiguration.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		OBJ_869 /* ABTest */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_870 /* ABTest+Variant.swift */,
+				OBJ_871 /* ABTest.swift */,
+				OBJ_872 /* ABTestID.swift */,
+				OBJ_873 /* ABTestStatus.swift */,
+				OBJ_874 /* Response */,
+				OBJ_879 /* Task */,
+			);
+			path = ABTest;
+			sourceTree = "<group>";
+		};
+		OBJ_874 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_875 /* ABTestResponse+Variant.swift */,
+				OBJ_876 /* ABTestResponse.swift */,
+				OBJ_877 /* ABTestShortResponse.swift */,
+				OBJ_878 /* ABTestsResponse.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		OBJ_879 /* Task */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_880 /* ABTestCreation.swift */,
+				OBJ_881 /* ABTestDeletion.swift */,
+				OBJ_882 /* ABTestRevision.swift */,
+			);
+			path = Task;
+			sourceTree = "<group>";
+		};
+		OBJ_884 /* Answers */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_885 /* AnswersQuery+Language.swift */,
+				OBJ_886 /* AnswersQuery.swift */,
+			);
+			path = Answers;
+			sourceTree = "<group>";
+		};
+		OBJ_887 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_888 /* AppRevision.swift */,
+				OBJ_889 /* Attribute.swift */,
+				OBJ_890 /* CommonParameters.swift */,
+				OBJ_891 /* Credentials */,
+				OBJ_894 /* ObjectID.swift */,
+				OBJ_895 /* Region.swift */,
+				OBJ_896 /* RequestOptions.swift */,
+				OBJ_897 /* ResponseField.swift */,
+				OBJ_898 /* Revision.swift */,
+				OBJ_899 /* StringOption.swift */,
+				OBJ_900 /* StringWrapper.swift */,
+				OBJ_901 /* TimeRange.swift */,
+				OBJ_902 /* UserToken.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		OBJ_89 /* Event */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_90 /* EventInteractor.swift */,
+			);
+			path = Event;
+			sourceTree = "<group>";
+		};
+		OBJ_891 /* Credentials */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_892 /* AlgoliaCredentials.swift */,
+				OBJ_893 /* Credentials.swift */,
+			);
+			path = Credentials;
+			sourceTree = "<group>";
+		};
+		OBJ_9 /* AdvancedConnectors */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* MultiIndexSearchConnector+UIKit.swift */,
+				OBJ_11 /* SearchConnector+UIKit.swift */,
+			);
+			path = AdvancedConnectors;
+			sourceTree = "<group>";
+		};
+		OBJ_903 /* Data structures */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_904 /* FieldWrapper.swift */,
+				OBJ_905 /* JSON.swift */,
+				OBJ_906 /* PrefixedString.swift */,
+				OBJ_907 /* SingleOrList.swift */,
+				OBJ_908 /* TreeModel.swift */,
+			);
+			path = "Data structures";
+			sourceTree = "<group>";
+		};
+		OBJ_909 /* Dictionaries */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_910 /* CompoundsDictionary.swift */,
+				OBJ_911 /* CustomDictionary.swift */,
+				OBJ_912 /* DictionaryEntry.swift */,
+				OBJ_913 /* DictionaryName.swift */,
+				OBJ_914 /* DictionaryQuery.swift */,
+				OBJ_915 /* DictionaryRequest.swift */,
+				OBJ_916 /* DictionaryRevision.swift */,
+				OBJ_917 /* DictionarySearchResponse.swift */,
+				OBJ_918 /* DictionarySettings.swift */,
+				OBJ_919 /* PluralsDictionary.swift */,
+				OBJ_920 /* StopwordsDictionary.swift */,
+			);
+			path = Dictionaries;
+			sourceTree = "<group>";
+		};
+		OBJ_921 /* Insights */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_922 /* Event */,
+				OBJ_929 /* EventConstructionError.swift */,
+				OBJ_930 /* InsightsConfiguration.swift */,
+				OBJ_931 /* InsightsEvent+Resources.swift */,
+			);
+			path = Insights;
+			sourceTree = "<group>";
+		};
+		OBJ_922 /* Event */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_923 /* EventName.swift */,
+				OBJ_924 /* EventType.swift */,
+				OBJ_925 /* InsightsEvent+Click.swift */,
+				OBJ_926 /* InsightsEvent+Conversion.swift */,
+				OBJ_927 /* InsightsEvent+View.swift */,
+				OBJ_928 /* InsightsEvent.swift */,
+			);
+			path = Event;
+			sourceTree = "<group>";
+		};
+		OBJ_932 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_933 /* CallType.swift */,
+				OBJ_934 /* Configuration.swift */,
+				OBJ_935 /* Empty.swift */,
+				OBJ_936 /* HTTP */,
+				OBJ_940 /* Hosts.swift */,
+				OBJ_941 /* URL+Convenience.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		OBJ_936 /* HTTP */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_937 /* HTTPError.swift */,
+				OBJ_938 /* HTTPMethod.swift */,
+				OBJ_939 /* HTTPStatusCode.swift */,
+			);
+			path = HTTP;
+			sourceTree = "<group>";
+		};
+		OBJ_942 /* Logs */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_943 /* Log.swift */,
+				OBJ_944 /* LogType.swift */,
+				OBJ_945 /* LogsResponse.swift */,
+			);
+			path = Logs;
+			sourceTree = "<group>";
+		};
+		OBJ_946 /* MultiCluster */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_947 /* Cluster.swift */,
+				OBJ_948 /* ClusterName.swift */,
+				OBJ_949 /* ClustersListResponse.swift */,
+				OBJ_950 /* HasPendingMappingResponse.swift */,
+				OBJ_951 /* Task */,
+				OBJ_954 /* TopUserIDResponse.swift */,
+				OBJ_955 /* UserID.swift */,
+				OBJ_956 /* UserIDListResponse.swift */,
+				OBJ_957 /* UserIDQuery.swift */,
+				OBJ_958 /* UserIDResponse.swift */,
+				OBJ_959 /* UserIDSearchResponse.swift */,
+			);
+			path = MultiCluster;
+			sourceTree = "<group>";
+		};
+		OBJ_951 /* Task */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_952 /* Creation.swift */,
+				OBJ_953 /* Deletion.swift */,
+			);
+			path = Task;
+			sourceTree = "<group>";
+		};
+		OBJ_96 /* Item */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_97 /* ItemController.swift */,
+				OBJ_98 /* ItemInteractor+Controller.swift */,
+				OBJ_99 /* ItemInteractor.swift */,
+			);
+			path = Item;
+			sourceTree = "<group>";
+		};
+		OBJ_960 /* Personalization */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_961 /* EventScoring.swift */,
+				OBJ_962 /* FacetScoring.swift */,
+				OBJ_963 /* PersonalizationConfiguration.swift */,
+				OBJ_964 /* PersonalizationStrategy.swift */,
+				OBJ_965 /* SetStrategyResponse.swift */,
+			);
+			path = Personalization;
+			sourceTree = "<group>";
+		};
+		OBJ_966 /* Places */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_967 /* Country.swift */,
+				OBJ_968 /* MultiLanguagePlace.swift */,
+				OBJ_969 /* Place.swift */,
+				OBJ_970 /* PlaceCodingKeys.swift */,
+				OBJ_971 /* PlaceType.swift */,
+				OBJ_972 /* PlacesConfiguration.swift */,
+				OBJ_973 /* PlacesQuery.swift */,
+				OBJ_974 /* PlacesResponse.swift */,
+			);
+			path = Places;
+			sourceTree = "<group>";
+		};
+		OBJ_975 /* Recommend */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_976 /* RecommendationModel.swift */,
+				OBJ_977 /* RecommendationsOptions.swift */,
+			);
+			path = Recommend;
+			sourceTree = "<group>";
+		};
+		OBJ_978 /* Rule */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_979 /* RenderingContent.swift */,
+				OBJ_980 /* Rule+Alternatives.swift */,
+				OBJ_981 /* Rule+Anchoring.swift */,
+				OBJ_982 /* Rule+AutomaticFacetFilters.swift */,
+				OBJ_983 /* Rule+Condition.swift */,
+				OBJ_984 /* Rule+Consequence.swift */,
+				OBJ_985 /* Rule+Edit.swift */,
+				OBJ_986 /* Rule+Pattern.swift */,
+				OBJ_987 /* Rule+Promotion.swift */,
+				OBJ_988 /* Rule.swift */,
+				OBJ_989 /* RuleQuery.swift */,
+				OBJ_990 /* RuleSearchResponse+Hit.swift */,
+				OBJ_991 /* RuleSearchResponse.swift */,
+			);
+			path = Rule;
+			sourceTree = "<group>";
+		};
+		OBJ_992 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_993 /* ApplicationID.swift */,
+				OBJ_994 /* Hit */,
+				OBJ_1001 /* IndexName.swift */,
+				OBJ_1002 /* Indexing */,
+				OBJ_1014 /* MultipleIndex */,
+				OBJ_1023 /* Query */,
+				OBJ_1037 /* Response */,
+				OBJ_1065 /* SearchConfiguration.swift */,
+				OBJ_1066 /* SearchParameters.swift */,
+				OBJ_1067 /* SearchParametersStorage.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		OBJ_994 /* Hit */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_995 /* Answer.swift */,
+				OBJ_996 /* HighlightResult.swift */,
+				OBJ_997 /* Hit.swift */,
+				OBJ_998 /* MatchLevel.swift */,
+				OBJ_999 /* RankingInfo.swift */,
+				OBJ_1000 /* SnippetResult.swift */,
+			);
+			path = Hit;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1171 /* Build configuration list for PBXNativeTarget "AlgoliaSearchClient" */;
+			buildPhases = (
+				OBJ_1174 /* Sources */,
+				OBJ_1490 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1492 /* PBXTargetDependency */,
+			);
+			name = AlgoliaSearchClient;
+			productName = AlgoliaSearchClient;
+			productReference = "algoliasearch-client-swift::AlgoliaSearchClient::Product" /* AlgoliaSearchClient.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"algoliasearch-client-swift::SwiftPMPackageDescription" /* AlgoliaSearchClientPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1495 /* Build configuration list for PBXNativeTarget "AlgoliaSearchClientPackageDescription" */;
+			buildPhases = (
+				OBJ_1498 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AlgoliaSearchClientPackageDescription;
+			productName = AlgoliaSearchClientPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-ios::InstantSearch" /* InstantSearch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1501 /* Build configuration list for PBXNativeTarget "InstantSearch" */;
+			buildPhases = (
+				OBJ_1504 /* Sources */,
+				OBJ_1552 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1559 /* PBXTargetDependency */,
+				OBJ_1561 /* PBXTargetDependency */,
+				OBJ_1563 /* PBXTargetDependency */,
+				OBJ_1565 /* PBXTargetDependency */,
+				OBJ_1567 /* PBXTargetDependency */,
+				OBJ_1568 /* PBXTargetDependency */,
+			);
+			name = InstantSearch;
+			productName = InstantSearch;
+			productReference = "instantsearch-ios::InstantSearch::Product" /* InstantSearch.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-ios::InstantSearchCore" /* InstantSearchCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1569 /* Build configuration list for PBXNativeTarget "InstantSearchCore" */;
+			buildPhases = (
+				OBJ_1572 /* Sources */,
+				OBJ_1863 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1869 /* PBXTargetDependency */,
+				OBJ_1870 /* PBXTargetDependency */,
+				OBJ_1871 /* PBXTargetDependency */,
+				OBJ_1872 /* PBXTargetDependency */,
+				OBJ_1873 /* PBXTargetDependency */,
+			);
+			name = InstantSearchCore;
+			productName = InstantSearchCore;
+			productReference = "instantsearch-ios::InstantSearchCore::Product" /* InstantSearchCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-ios::InstantSearchCoreTests" /* InstantSearchCoreTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1875 /* Build configuration list for PBXNativeTarget "InstantSearchCoreTests" */;
+			buildPhases = (
+				OBJ_1878 /* Sources */,
+				OBJ_1959 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_1966 /* PBXTargetDependency */,
+				OBJ_1967 /* PBXTargetDependency */,
+				OBJ_1968 /* PBXTargetDependency */,
+				OBJ_1969 /* PBXTargetDependency */,
+				OBJ_1970 /* PBXTargetDependency */,
+				OBJ_1971 /* PBXTargetDependency */,
+			);
+			name = InstantSearchCoreTests;
+			productName = InstantSearchCoreTests;
+			productReference = "instantsearch-ios::InstantSearchCoreTests::Product" /* InstantSearchCoreTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_1972 /* Build configuration list for PBXNativeTarget "InstantSearchInsights" */;
+			buildPhases = (
+				OBJ_1975 /* Sources */,
+				OBJ_2005 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_2008 /* PBXTargetDependency */,
+				OBJ_2009 /* PBXTargetDependency */,
+			);
+			name = InstantSearchInsights;
+			productName = InstantSearchInsights;
+			productReference = "instantsearch-ios::InstantSearchInsights::Product" /* InstantSearchInsights.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-ios::InstantSearchInsightsTests" /* InstantSearchInsightsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2011 /* Build configuration list for PBXNativeTarget "InstantSearchInsightsTests" */;
+			buildPhases = (
+				OBJ_2014 /* Sources */,
+				OBJ_2030 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_2034 /* PBXTargetDependency */,
+				OBJ_2035 /* PBXTargetDependency */,
+				OBJ_2036 /* PBXTargetDependency */,
+			);
+			name = InstantSearchInsightsTests;
+			productName = InstantSearchInsightsTests;
+			productReference = "instantsearch-ios::InstantSearchInsightsTests::Product" /* InstantSearchInsightsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"instantsearch-ios::InstantSearchSwiftUI" /* InstantSearchSwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2054 /* Build configuration list for PBXNativeTarget "InstantSearchSwiftUI" */;
+			buildPhases = (
+				OBJ_2057 /* Sources */,
+				OBJ_2083 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_2090 /* PBXTargetDependency */,
+				OBJ_2091 /* PBXTargetDependency */,
+				OBJ_2092 /* PBXTargetDependency */,
+				OBJ_2093 /* PBXTargetDependency */,
+				OBJ_2094 /* PBXTargetDependency */,
+				OBJ_2095 /* PBXTargetDependency */,
+			);
+			name = InstantSearchSwiftUI;
+			productName = InstantSearchSwiftUI;
+			productReference = "instantsearch-ios::InstantSearchSwiftUI::Product" /* InstantSearchSwiftUI.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-ios::InstantSearchSwiftUITests" /* InstantSearchSwiftUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2096 /* Build configuration list for PBXNativeTarget "InstantSearchSwiftUITests" */;
+			buildPhases = (
+				OBJ_2099 /* Sources */,
+				OBJ_2101 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_2109 /* PBXTargetDependency */,
+				OBJ_2110 /* PBXTargetDependency */,
+				OBJ_2111 /* PBXTargetDependency */,
+				OBJ_2112 /* PBXTargetDependency */,
+				OBJ_2113 /* PBXTargetDependency */,
+				OBJ_2114 /* PBXTargetDependency */,
+				OBJ_2115 /* PBXTargetDependency */,
+			);
+			name = InstantSearchSwiftUITests;
+			productName = InstantSearchSwiftUITests;
+			productReference = "instantsearch-ios::InstantSearchSwiftUITests::Product" /* InstantSearchSwiftUITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"instantsearch-ios::InstantSearchTests" /* InstantSearchTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2134 /* Build configuration list for PBXNativeTarget "InstantSearchTests" */;
+			buildPhases = (
+				OBJ_2137 /* Sources */,
+				OBJ_2162 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_2170 /* PBXTargetDependency */,
+				OBJ_2171 /* PBXTargetDependency */,
+				OBJ_2172 /* PBXTargetDependency */,
+				OBJ_2173 /* PBXTargetDependency */,
+				OBJ_2174 /* PBXTargetDependency */,
+				OBJ_2175 /* PBXTargetDependency */,
+				OBJ_2176 /* PBXTargetDependency */,
+			);
+			name = InstantSearchTests;
+			productName = InstantSearchTests;
+			productReference = "instantsearch-ios::InstantSearchTests::Product" /* InstantSearchTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"instantsearch-ios::SwiftPMPackageDescription" /* InstantSearchPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2038 /* Build configuration list for PBXNativeTarget "InstantSearchPackageDescription" */;
+			buildPhases = (
+				OBJ_2041 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InstantSearchPackageDescription;
+			productName = InstantSearchPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2116 /* Build configuration list for PBXNativeTarget "InstantSearchTelemetry" */;
+			buildPhases = (
+				OBJ_2119 /* Sources */,
+				OBJ_2125 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_2127 /* PBXTargetDependency */,
+			);
+			name = InstantSearchTelemetry;
+			productName = InstantSearchTelemetry;
+			productReference = "instantsearch-telemetry-native::InstantSearchTelemetry::Product" /* InstantSearchTelemetry.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"instantsearch-telemetry-native::SwiftPMPackageDescription" /* InstantSearchTelemetryPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2129 /* Build configuration list for PBXNativeTarget "InstantSearchTelemetryPackageDescription" */;
+			buildPhases = (
+				OBJ_2132 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InstantSearchTelemetryPackageDescription;
+			productName = InstantSearchTelemetryPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"swift-log::Logging" /* Logging */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2177 /* Build configuration list for PBXNativeTarget "Logging" */;
+			buildPhases = (
+				OBJ_2180 /* Sources */,
+				OBJ_2184 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Logging;
+			productName = Logging;
+			productReference = "swift-log::Logging::Product" /* Logging.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"swift-log::SwiftPMPackageDescription" /* swift-logPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2281 /* Build configuration list for PBXNativeTarget "swift-logPackageDescription" */;
+			buildPhases = (
+				OBJ_2284 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "swift-logPackageDescription";
+			productName = "swift-logPackageDescription";
+			productType = "com.apple.product-type.framework";
+		};
+		"swift-protobuf::SwiftPMPackageDescription" /* SwiftProtobufPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2275 /* Build configuration list for PBXNativeTarget "SwiftProtobufPackageDescription" */;
+			buildPhases = (
+				OBJ_2278 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobufPackageDescription;
+			productName = SwiftProtobufPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_2185 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */;
+			buildPhases = (
+				OBJ_2188 /* Sources */,
+				OBJ_2273 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobuf;
+			productName = SwiftProtobuf;
+			productReference = "swift-protobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftMigration = 9999;
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "InstantSearch" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_1144 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */,
+				"algoliasearch-client-swift::SwiftPMPackageDescription" /* AlgoliaSearchClientPackageDescription */,
+				"instantsearch-ios::InstantSearch" /* InstantSearch */,
+				"instantsearch-ios::InstantSearchCore" /* InstantSearchCore */,
+				"instantsearch-ios::InstantSearchCoreTests" /* InstantSearchCoreTests */,
+				"instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */,
+				"instantsearch-ios::InstantSearchInsightsTests" /* InstantSearchInsightsTests */,
+				"instantsearch-ios::SwiftPMPackageDescription" /* InstantSearchPackageDescription */,
+				"instantsearch-ios::InstantSearchPackageTests::ProductTarget" /* InstantSearchPackageTests */,
+				"instantsearch-ios::InstantSearchSwiftUI" /* InstantSearchSwiftUI */,
+				"instantsearch-ios::InstantSearchSwiftUITests" /* InstantSearchSwiftUITests */,
+				"instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */,
+				"instantsearch-telemetry-native::SwiftPMPackageDescription" /* InstantSearchTelemetryPackageDescription */,
+				"instantsearch-ios::InstantSearchTests" /* InstantSearchTests */,
+				"swift-log::Logging" /* Logging */,
+				"swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */,
+				"swift-protobuf::SwiftPMPackageDescription" /* SwiftProtobufPackageDescription */,
+				"swift-log::SwiftPMPackageDescription" /* swift-logPackageDescription */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_1174 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1175 /* AsyncOperation.swift in Sources */,
+				OBJ_1176 /* WaitTask.swift in Sources */,
+				OBJ_1177 /* AccountClient.swift in Sources */,
+				OBJ_1178 /* AnalyticsClient.swift in Sources */,
+				OBJ_1179 /* InsightsClient.swift in Sources */,
+				OBJ_1180 /* PersonalizationClient.swift in Sources */,
+				OBJ_1181 /* PlacesClient.swift in Sources */,
+				OBJ_1182 /* RecommendClient.swift in Sources */,
+				OBJ_1183 /* SearchClient+APIKey.swift in Sources */,
+				OBJ_1184 /* SearchClient+Dictionaries.swift in Sources */,
+				OBJ_1185 /* SearchClient+Logs.swift in Sources */,
+				OBJ_1186 /* SearchClient+Management.swift in Sources */,
+				OBJ_1187 /* SearchClient+MultiCluster.swift in Sources */,
+				OBJ_1188 /* SearchClient+MultiIndex.swift in Sources */,
+				OBJ_1189 /* SearchClient+SecuredAPIKey.swift in Sources */,
+				OBJ_1190 /* SearchClient+Wait.swift in Sources */,
+				OBJ_1191 /* SearchClient.swift in Sources */,
+				OBJ_1192 /* AlgoliaCommand.swift in Sources */,
+				OBJ_1193 /* Command+ABTest.swift in Sources */,
+				OBJ_1194 /* Command+APIKeys.swift in Sources */,
+				OBJ_1195 /* Command+Advanced.swift in Sources */,
+				OBJ_1196 /* Command+Answers.swift in Sources */,
+				OBJ_1197 /* Command+Custom.swift in Sources */,
+				OBJ_1198 /* Command+Dictionaries.swift in Sources */,
+				OBJ_1199 /* Command+Index.swift in Sources */,
+				OBJ_1200 /* Command+Indexing.swift in Sources */,
+				OBJ_1201 /* Command+Insights.swift in Sources */,
+				OBJ_1202 /* Command+MultiCluster.swift in Sources */,
+				OBJ_1203 /* Command+MultipleIndex.swift in Sources */,
+				OBJ_1204 /* Command+Personalization.swift in Sources */,
+				OBJ_1205 /* Command+Places.swift in Sources */,
+				OBJ_1206 /* Command+Recommend.swift in Sources */,
+				OBJ_1207 /* Command+Rule.swift in Sources */,
+				OBJ_1208 /* Command+Search.swift in Sources */,
+				OBJ_1209 /* Command+Settings.swift in Sources */,
+				OBJ_1210 /* Command+Synonym.swift in Sources */,
+				OBJ_1211 /* Command.swift in Sources */,
+				OBJ_1212 /* AssertionTestHelper.swift in Sources */,
+				OBJ_1213 /* CustomParametersCoder.swift in Sources */,
+				OBJ_1214 /* ClientDateCodingStrategy.swift in Sources */,
+				OBJ_1215 /* KeyedDecodingContainer+DateFormat.swift in Sources */,
+				OBJ_1216 /* KeyedEncodingContainer+DateFormat.swift in Sources */,
+				OBJ_1217 /* DecodingErrorPrettyPrinter.swift in Sources */,
+				OBJ_1218 /* DynamicKey.swift in Sources */,
+				OBJ_1219 /* Encodiable+HTTPBody.swift in Sources */,
+				OBJ_1220 /* KeyedDecodingContainer+Convenience.swift in Sources */,
+				OBJ_1221 /* BoolContainer.swift in Sources */,
+				OBJ_1222 /* CustomKey.swift in Sources */,
+				OBJ_1223 /* StringNumberContainer.swift in Sources */,
+				OBJ_1224 /* HMAC.swift in Sources */,
+				OBJ_1225 /* String+HMAC.swift in Sources */,
+				OBJ_1226 /* Array+Chunks.swift in Sources */,
+				OBJ_1227 /* Data+JSONString.swift in Sources */,
+				OBJ_1228 /* Dictionary+Merging.swift in Sources */,
+				OBJ_1229 /* Optional+Convenience.swift in Sources */,
+				OBJ_1230 /* TimeInterval+Minutes.swift in Sources */,
+				OBJ_1231 /* Logging.swift in Sources */,
+				OBJ_1232 /* ObjectIDChecker.swift in Sources */,
+				OBJ_1233 /* Builder.swift in Sources */,
+				OBJ_1234 /* Cancellable.swift in Sources */,
+				OBJ_1235 /* ResultContainer.swift in Sources */,
+				OBJ_1236 /* URLEncodable.swift in Sources */,
+				OBJ_1237 /* ResultCallback.swift in Sources */,
+				OBJ_1238 /* String+Base64.swift in Sources */,
+				OBJ_1239 /* String+Environment.swift in Sources */,
+				OBJ_1240 /* String+Wrapping.swift in Sources */,
+				OBJ_1241 /* UserAgent.swift in Sources */,
+				OBJ_1242 /* UserAgentController.swift in Sources */,
+				OBJ_1243 /* Version+Current.swift in Sources */,
+				OBJ_1244 /* Version.swift in Sources */,
+				OBJ_1245 /* AnyWaitable.swift in Sources */,
+				OBJ_1246 /* TaskWaitable.swift in Sources */,
+				OBJ_1247 /* Waitable.swift in Sources */,
+				OBJ_1248 /* WaitableWrapper.swift in Sources */,
+				OBJ_1249 /* Index+Advanced.swift in Sources */,
+				OBJ_1250 /* Index+Answers.swift in Sources */,
+				OBJ_1251 /* Index+Export.swift in Sources */,
+				OBJ_1252 /* Index+Index.swift in Sources */,
+				OBJ_1253 /* Index+Indexing.swift in Sources */,
+				OBJ_1254 /* Index+Logs.swift in Sources */,
+				OBJ_1255 /* Index+Rule.swift in Sources */,
+				OBJ_1256 /* Index+Search.swift in Sources */,
+				OBJ_1257 /* Index+Settings.swift in Sources */,
+				OBJ_1258 /* Index+Synonym.swift in Sources */,
+				OBJ_1259 /* Index.swift in Sources */,
+				OBJ_1260 /* ACL.swift in Sources */,
+				OBJ_1261 /* APIKey.swift in Sources */,
+				OBJ_1262 /* APIKeyCreation.swift in Sources */,
+				OBJ_1263 /* APIKeyDeletion.swift in Sources */,
+				OBJ_1264 /* APIKeyParameters.swift in Sources */,
+				OBJ_1265 /* APIKeyResponse.swift in Sources */,
+				OBJ_1266 /* APIKeyRevision.swift in Sources */,
+				OBJ_1267 /* ListAPIKeysResponse.swift in Sources */,
+				OBJ_1268 /* SecuredAPIKeyRestriction.swift in Sources */,
+				OBJ_1269 /* ABTest+Variant.swift in Sources */,
+				OBJ_1270 /* ABTest.swift in Sources */,
+				OBJ_1271 /* ABTestID.swift in Sources */,
+				OBJ_1272 /* ABTestStatus.swift in Sources */,
+				OBJ_1273 /* ABTestResponse+Variant.swift in Sources */,
+				OBJ_1274 /* ABTestResponse.swift in Sources */,
+				OBJ_1275 /* ABTestShortResponse.swift in Sources */,
+				OBJ_1276 /* ABTestsResponse.swift in Sources */,
+				OBJ_1277 /* ABTestCreation.swift in Sources */,
+				OBJ_1278 /* ABTestDeletion.swift in Sources */,
+				OBJ_1279 /* ABTestRevision.swift in Sources */,
+				OBJ_1280 /* AnalyticsConfiguration.swift in Sources */,
+				OBJ_1281 /* AnswersQuery+Language.swift in Sources */,
+				OBJ_1282 /* AnswersQuery.swift in Sources */,
+				OBJ_1283 /* AppRevision.swift in Sources */,
+				OBJ_1284 /* Attribute.swift in Sources */,
+				OBJ_1285 /* CommonParameters.swift in Sources */,
+				OBJ_1286 /* AlgoliaCredentials.swift in Sources */,
+				OBJ_1287 /* Credentials.swift in Sources */,
+				OBJ_1288 /* ObjectID.swift in Sources */,
+				OBJ_1289 /* Region.swift in Sources */,
+				OBJ_1290 /* RequestOptions.swift in Sources */,
+				OBJ_1291 /* ResponseField.swift in Sources */,
+				OBJ_1292 /* Revision.swift in Sources */,
+				OBJ_1293 /* StringOption.swift in Sources */,
+				OBJ_1294 /* StringWrapper.swift in Sources */,
+				OBJ_1295 /* TimeRange.swift in Sources */,
+				OBJ_1296 /* UserToken.swift in Sources */,
+				OBJ_1297 /* FieldWrapper.swift in Sources */,
+				OBJ_1298 /* JSON.swift in Sources */,
+				OBJ_1299 /* PrefixedString.swift in Sources */,
+				OBJ_1300 /* SingleOrList.swift in Sources */,
+				OBJ_1301 /* TreeModel.swift in Sources */,
+				OBJ_1302 /* CompoundsDictionary.swift in Sources */,
+				OBJ_1303 /* CustomDictionary.swift in Sources */,
+				OBJ_1304 /* DictionaryEntry.swift in Sources */,
+				OBJ_1305 /* DictionaryName.swift in Sources */,
+				OBJ_1306 /* DictionaryQuery.swift in Sources */,
+				OBJ_1307 /* DictionaryRequest.swift in Sources */,
+				OBJ_1308 /* DictionaryRevision.swift in Sources */,
+				OBJ_1309 /* DictionarySearchResponse.swift in Sources */,
+				OBJ_1310 /* DictionarySettings.swift in Sources */,
+				OBJ_1311 /* PluralsDictionary.swift in Sources */,
+				OBJ_1312 /* StopwordsDictionary.swift in Sources */,
+				OBJ_1313 /* EventName.swift in Sources */,
+				OBJ_1314 /* EventType.swift in Sources */,
+				OBJ_1315 /* InsightsEvent+Click.swift in Sources */,
+				OBJ_1316 /* InsightsEvent+Conversion.swift in Sources */,
+				OBJ_1317 /* InsightsEvent+View.swift in Sources */,
+				OBJ_1318 /* InsightsEvent.swift in Sources */,
+				OBJ_1319 /* EventConstructionError.swift in Sources */,
+				OBJ_1320 /* InsightsConfiguration.swift in Sources */,
+				OBJ_1321 /* InsightsEvent+Resources.swift in Sources */,
+				OBJ_1322 /* CallType.swift in Sources */,
+				OBJ_1323 /* Configuration.swift in Sources */,
+				OBJ_1324 /* Empty.swift in Sources */,
+				OBJ_1325 /* HTTPError.swift in Sources */,
+				OBJ_1326 /* HTTPMethod.swift in Sources */,
+				OBJ_1327 /* HTTPStatusCode.swift in Sources */,
+				OBJ_1328 /* Hosts.swift in Sources */,
+				OBJ_1329 /* URL+Convenience.swift in Sources */,
+				OBJ_1330 /* Log.swift in Sources */,
+				OBJ_1331 /* LogType.swift in Sources */,
+				OBJ_1332 /* LogsResponse.swift in Sources */,
+				OBJ_1333 /* Cluster.swift in Sources */,
+				OBJ_1334 /* ClusterName.swift in Sources */,
+				OBJ_1335 /* ClustersListResponse.swift in Sources */,
+				OBJ_1336 /* HasPendingMappingResponse.swift in Sources */,
+				OBJ_1337 /* Creation.swift in Sources */,
+				OBJ_1338 /* Deletion.swift in Sources */,
+				OBJ_1339 /* TopUserIDResponse.swift in Sources */,
+				OBJ_1340 /* UserID.swift in Sources */,
+				OBJ_1341 /* UserIDListResponse.swift in Sources */,
+				OBJ_1342 /* UserIDQuery.swift in Sources */,
+				OBJ_1343 /* UserIDResponse.swift in Sources */,
+				OBJ_1344 /* UserIDSearchResponse.swift in Sources */,
+				OBJ_1345 /* EventScoring.swift in Sources */,
+				OBJ_1346 /* FacetScoring.swift in Sources */,
+				OBJ_1347 /* PersonalizationConfiguration.swift in Sources */,
+				OBJ_1348 /* PersonalizationStrategy.swift in Sources */,
+				OBJ_1349 /* SetStrategyResponse.swift in Sources */,
+				OBJ_1350 /* Country.swift in Sources */,
+				OBJ_1351 /* MultiLanguagePlace.swift in Sources */,
+				OBJ_1352 /* Place.swift in Sources */,
+				OBJ_1353 /* PlaceCodingKeys.swift in Sources */,
+				OBJ_1354 /* PlaceType.swift in Sources */,
+				OBJ_1355 /* PlacesConfiguration.swift in Sources */,
+				OBJ_1356 /* PlacesQuery.swift in Sources */,
+				OBJ_1357 /* PlacesResponse.swift in Sources */,
+				OBJ_1358 /* RecommendationModel.swift in Sources */,
+				OBJ_1359 /* RecommendationsOptions.swift in Sources */,
+				OBJ_1360 /* RenderingContent.swift in Sources */,
+				OBJ_1361 /* Rule+Alternatives.swift in Sources */,
+				OBJ_1362 /* Rule+Anchoring.swift in Sources */,
+				OBJ_1363 /* Rule+AutomaticFacetFilters.swift in Sources */,
+				OBJ_1364 /* Rule+Condition.swift in Sources */,
+				OBJ_1365 /* Rule+Consequence.swift in Sources */,
+				OBJ_1366 /* Rule+Edit.swift in Sources */,
+				OBJ_1367 /* Rule+Pattern.swift in Sources */,
+				OBJ_1368 /* Rule+Promotion.swift in Sources */,
+				OBJ_1369 /* Rule.swift in Sources */,
+				OBJ_1370 /* RuleQuery.swift in Sources */,
+				OBJ_1371 /* RuleSearchResponse+Hit.swift in Sources */,
+				OBJ_1372 /* RuleSearchResponse.swift in Sources */,
+				OBJ_1373 /* ApplicationID.swift in Sources */,
+				OBJ_1374 /* Answer.swift in Sources */,
+				OBJ_1375 /* HighlightResult.swift in Sources */,
+				OBJ_1376 /* Hit.swift in Sources */,
+				OBJ_1377 /* MatchLevel.swift in Sources */,
+				OBJ_1378 /* RankingInfo.swift in Sources */,
+				OBJ_1379 /* SnippetResult.swift in Sources */,
+				OBJ_1380 /* IndexName.swift in Sources */,
+				OBJ_1381 /* BatchOperation.swift in Sources */,
+				OBJ_1382 /* BatchResponse.swift in Sources */,
+				OBJ_1383 /* IndexBatchOperation.swift in Sources */,
+				OBJ_1384 /* Cursor.swift in Sources */,
+				OBJ_1385 /* IndexOperation.swift in Sources */,
+				OBJ_1386 /* ObjectRequest.swift in Sources */,
+				OBJ_1387 /* ObjectWrapper.swift in Sources */,
+				OBJ_1388 /* PartialUpdate.swift in Sources */,
+				OBJ_1389 /* PartialUpdateAction.swift in Sources */,
+				OBJ_1390 /* Scope.swift in Sources */,
+				OBJ_1391 /* BatchesResponse.swift in Sources */,
+				OBJ_1392 /* IndexedFacetQuery.swift in Sources */,
+				OBJ_1393 /* IndexedQuery.swift in Sources */,
+				OBJ_1394 /* IndicesListResponse.swift in Sources */,
+				OBJ_1395 /* MultiSearchQuery.swift in Sources */,
+				OBJ_1396 /* MultipleQueriesRequest.swift in Sources */,
+				OBJ_1397 /* MultipleQueriesStrategy.swift in Sources */,
+				OBJ_1398 /* SearchesResponse.swift in Sources */,
+				OBJ_1399 /* AroundPrecision.swift in Sources */,
+				OBJ_1400 /* AroundRadius.swift in Sources */,
+				OBJ_1401 /* BoundingBox.swift in Sources */,
+				OBJ_1402 /* ExplainModule.swift in Sources */,
+				OBJ_1403 /* FiltersStorage.swift in Sources */,
+				OBJ_1404 /* Point.swift in Sources */,
+				OBJ_1405 /* Polygon.swift in Sources */,
+				OBJ_1406 /* DeleteByQuery.swift in Sources */,
+				OBJ_1407 /* Query+Codable.swift in Sources */,
+				OBJ_1408 /* Query+URLEncodable.swift in Sources */,
+				OBJ_1409 /* Query.swift in Sources */,
+				OBJ_1410 /* QueryID.swift in Sources */,
+				OBJ_1411 /* FacetSearchResponse.swift in Sources */,
+				OBJ_1412 /* HitWithPosition.swift in Sources */,
+				OBJ_1413 /* MultiSearchResponse.swift in Sources */,
+				OBJ_1414 /* ObjectsResponse.swift in Sources */,
+				OBJ_1415 /* Alternative.swift in Sources */,
+				OBJ_1416 /* AlternativeType.swift in Sources */,
+				OBJ_1417 /* Explain.swift in Sources */,
+				OBJ_1418 /* QueryMatch.swift in Sources */,
+				OBJ_1419 /* Facet.swift in Sources */,
+				OBJ_1420 /* FacetsStorage.swift in Sources */,
+				OBJ_1421 /* FacetStats.swift in Sources */,
+				OBJ_1422 /* FacetStatsStorage.swift in Sources */,
+				OBJ_1423 /* HighlightedString.swift in Sources */,
+				OBJ_1424 /* TaggedString.swift in Sources */,
+				OBJ_1425 /* FacetOrdering.swift in Sources */,
+				OBJ_1426 /* FacetValuesOrder.swift in Sources */,
+				OBJ_1427 /* FacetsOrder.swift in Sources */,
+				OBJ_1428 /* SearchResponse+Codable.swift in Sources */,
+				OBJ_1429 /* SearchResponse.swift in Sources */,
+				OBJ_1430 /* SearchConfiguration.swift in Sources */,
+				OBJ_1431 /* SearchParameters.swift in Sources */,
+				OBJ_1432 /* SearchParametersStorage.swift in Sources */,
+				OBJ_1433 /* AdvancedSyntaxFeatures.swift in Sources */,
+				OBJ_1434 /* AlternativesAsExact.swift in Sources */,
+				OBJ_1435 /* AttributeForFaceting.swift in Sources */,
+				OBJ_1436 /* CustomRankingCriterion.swift in Sources */,
+				OBJ_1437 /* DecompoundedAttributes.swift in Sources */,
+				OBJ_1438 /* Distinct.swift in Sources */,
+				OBJ_1439 /* ExactOnSingleWordQuery.swift in Sources */,
+				OBJ_1440 /* Language.swift in Sources */,
+				OBJ_1441 /* LanguageFeature.swift in Sources */,
+				OBJ_1442 /* NumericAttributeFilter.swift in Sources */,
+				OBJ_1443 /* QueryType.swift in Sources */,
+				OBJ_1444 /* RankingCriterion.swift in Sources */,
+				OBJ_1445 /* RemoveWordIfNoResults.swift in Sources */,
+				OBJ_1446 /* SearchableAttribute.swift in Sources */,
+				OBJ_1447 /* Snippet.swift in Sources */,
+				OBJ_1448 /* SortFacetsBy.swift in Sources */,
+				OBJ_1449 /* TypoTolerance.swift in Sources */,
+				OBJ_1450 /* Settings+CustomStringConvertible.swift in Sources */,
+				OBJ_1451 /* Settings.swift in Sources */,
+				OBJ_1452 /* SettingsParameters.swift in Sources */,
+				OBJ_1453 /* SettingsParametersCodingKeys.swift in Sources */,
+				OBJ_1454 /* SettingsParametersStorage.swift in Sources */,
+				OBJ_1455 /* Synonym.swift in Sources */,
+				OBJ_1456 /* SynonymQuery.swift in Sources */,
+				OBJ_1457 /* SynonymRevision.swift in Sources */,
+				OBJ_1458 /* SynonymSearchResponse+Hit.swift in Sources */,
+				OBJ_1459 /* SynonymSearchResponse.swift in Sources */,
+				OBJ_1460 /* SynonymType.swift in Sources */,
+				OBJ_1461 /* AppTaskID.swift in Sources */,
+				OBJ_1462 /* AppTask.swift in Sources */,
+				OBJ_1463 /* IndexTask.swift in Sources */,
+				OBJ_1464 /* TaskInfo.swift in Sources */,
+				OBJ_1465 /* TaskStatus.swift in Sources */,
+				OBJ_1466 /* IndexDeletion.swift in Sources */,
+				OBJ_1467 /* IndexRevision.swift in Sources */,
+				OBJ_1468 /* IndexedTask.swift in Sources */,
+				OBJ_1469 /* ObjectCreation.swift in Sources */,
+				OBJ_1470 /* ObjectDeletion.swift in Sources */,
+				OBJ_1471 /* ObjectRevision.swift in Sources */,
+				OBJ_1472 /* TaskID.swift in Sources */,
+				OBJ_1473 /* Transport+CustomRequest.swift in Sources */,
+				OBJ_1474 /* Transport.swift in Sources */,
+				OBJ_1475 /* TransportContainer.swift in Sources */,
+				OBJ_1476 /* HTTPRequest.swift in Sources */,
+				OBJ_1477 /* HTTPRequestBuilder.swift in Sources */,
+				OBJ_1478 /* HTTPRequester.swift in Sources */,
+				OBJ_1479 /* HTTPTransport+Error.swift in Sources */,
+				OBJ_1480 /* HTTPTransport+Result.swift in Sources */,
+				OBJ_1481 /* HTTPTransport.swift in Sources */,
+				OBJ_1482 /* OperationLauncher.swift in Sources */,
+				OBJ_1483 /* AlgoliaRetryStrategy.swift in Sources */,
+				OBJ_1484 /* HostIterator.swift in Sources */,
+				OBJ_1485 /* HostSwitcher.swift in Sources */,
+				OBJ_1486 /* RetryStrategy.swift in Sources */,
+				OBJ_1487 /* RetryableHost.swift in Sources */,
+				OBJ_1488 /* URLRequest+Convenience.swift in Sources */,
+				OBJ_1489 /* URLSession+HTTPRequester.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1498 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1499 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1504 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1505 /* MultiIndexSearchConnector+UIKit.swift in Sources */,
+				OBJ_1506 /* SearchConnector+UIKit.swift in Sources */,
+				OBJ_1507 /* ClearRefinementsButtonController.swift in Sources */,
+				OBJ_1508 /* CurrentFiltersSearchTextFieldController.swift in Sources */,
+				OBJ_1509 /* CurrentFiltersTableViewController.swift in Sources */,
+				OBJ_1510 /* DynamicFacetListTableViewController.swift in Sources */,
+				OBJ_1511 /* FacetListTableController.swift in Sources */,
+				OBJ_1512 /* FilterListTableController.swift in Sources */,
+				OBJ_1513 /* UICollectionView+Convenience.swift in Sources */,
+				OBJ_1514 /* UITableView+Convenience.swift in Sources */,
+				OBJ_1515 /* HierarchicalTableViewController.swift in Sources */,
+				OBJ_1516 /* CellConfigurable.swift in Sources */,
+				OBJ_1517 /* HitsCollectionController.swift in Sources */,
+				OBJ_1518 /* HitsCollectionViewContainer.swift in Sources */,
+				OBJ_1519 /* HitsCollectionViewController.swift in Sources */,
+				OBJ_1520 /* HitsCollectionViewDataSource.swift in Sources */,
+				OBJ_1521 /* HitsCollectionViewDelegate.swift in Sources */,
+				OBJ_1522 /* UICollectionViewController+HitsCollectionViewContainer.swift in Sources */,
+				OBJ_1523 /* HitsTableController.swift in Sources */,
+				OBJ_1524 /* HitsTableViewContainer.swift in Sources */,
+				OBJ_1525 /* HitsTableViewController.swift in Sources */,
+				OBJ_1526 /* HitsTableViewDataSource.swift in Sources */,
+				OBJ_1527 /* HitsTableViewDelegate.swift in Sources */,
+				OBJ_1528 /* UITableViewController+HitsTableViewContainer.swift in Sources */,
+				OBJ_1529 /* ActivityIndicatorController.swift in Sources */,
+				OBJ_1530 /* Logger+InstantSearch.swift in Sources */,
+				OBJ_1531 /* MultiIndexHitsCollectionController.swift in Sources */,
+				OBJ_1532 /* MultiIndexHitsCollectionViewDataSource.swift in Sources */,
+				OBJ_1533 /* MultiIndexHitsCollectionViewDelegate.swift in Sources */,
+				OBJ_1534 /* MultiIndexHitsTableController.swift in Sources */,
+				OBJ_1535 /* MultiIndexHitsTableViewDataSource.swift in Sources */,
+				OBJ_1536 /* MultiIndexHitsTableViewDelegate.swift in Sources */,
+				OBJ_1537 /* NumericRatingController.swift in Sources */,
+				OBJ_1538 /* NumericRatingRangeController.swift in Sources */,
+				OBJ_1539 /* NumericStepperController.swift in Sources */,
+				OBJ_1540 /* NumericTextFieldController.swift in Sources */,
+				OBJ_1541 /* RatingControl.swift in Sources */,
+				OBJ_1542 /* QuerySuggestionsViewController.swift in Sources */,
+				OBJ_1543 /* ButtonRelevantSortController.swift in Sources */,
+				OBJ_1544 /* SearchBarController.swift in Sources */,
+				OBJ_1545 /* TextFieldController.swift in Sources */,
+				OBJ_1546 /* SegmentedController.swift in Sources */,
+				OBJ_1547 /* FilterSwitchController.swift in Sources */,
+				OBJ_1548 /* SelectableFilterButtonController.swift in Sources */,
+				OBJ_1549 /* SelectIndexController.swift in Sources */,
+				OBJ_1550 /* SwitchIndexAlertControllerBuilder.swift in Sources */,
+				OBJ_1551 /* LabelStatsController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1572 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1573 /* MultiIndexSearchConnector.swift in Sources */,
+				OBJ_1574 /* SearchConnector.swift in Sources */,
+				OBJ_1575 /* AsyncOperation.swift in Sources */,
+				OBJ_1576 /* Attribute.swift in Sources */,
+				OBJ_1577 /* Connection.swift in Sources */,
+				OBJ_1578 /* Constants.swift in Sources */,
+				OBJ_1579 /* EventInteractor.swift in Sources */,
+				OBJ_1580 /* GeoLocation.swift in Sources */,
+				OBJ_1581 /* Geolocated.swift in Sources */,
+				OBJ_1582 /* Hit+Place.swift in Sources */,
+				OBJ_1583 /* IndexNameSettable.swift in Sources */,
+				OBJ_1584 /* IndexQueryState.swift in Sources */,
+				OBJ_1585 /* ItemController.swift in Sources */,
+				OBJ_1586 /* ItemInteractor+Controller.swift in Sources */,
+				OBJ_1587 /* ItemInteractor.swift in Sources */,
+				OBJ_1588 /* Boundable.swift in Sources */,
+				OBJ_1589 /* DoubleRepresentable.swift in Sources */,
+				OBJ_1590 /* Point+CoreLocation.swift in Sources */,
+				OBJ_1591 /* Presenter.swift in Sources */,
+				OBJ_1592 /* QuerySuggestion.swift in Sources */,
+				OBJ_1593 /* Reloadable.swift in Sources */,
+				OBJ_1594 /* ResultUpdatable.swift in Sources */,
+				OBJ_1595 /* SelectableController.swift in Sources */,
+				OBJ_1596 /* SelectableInteractor.swift in Sources */,
+				OBJ_1597 /* SelectableListController.swift in Sources */,
+				OBJ_1598 /* SelectableListInteractor.swift in Sources */,
+				OBJ_1599 /* SelectableSegmentController.swift in Sources */,
+				OBJ_1600 /* SelectableSegmentInteractor.swift in Sources */,
+				OBJ_1601 /* CurrentFiltersConnector+Controller.swift in Sources */,
+				OBJ_1602 /* CurrentFiltersConnector.swift in Sources */,
+				OBJ_1603 /* CurrentFiltersInteractor+FilterState.swift in Sources */,
+				OBJ_1604 /* CurrentFiltersInteractor.swift in Sources */,
+				OBJ_1605 /* CurrentFiltersListController.swift in Sources */,
+				OBJ_1606 /* ItemListController.swift in Sources */,
+				OBJ_1607 /* ItemListInteractor+Controller.swift in Sources */,
+				OBJ_1608 /* ItemsListInteractor.swift in Sources */,
+				OBJ_1609 /* AttributedFacets.swift in Sources */,
+				OBJ_1610 /* DynamicFacetListConnector+Controller.swift in Sources */,
+				OBJ_1611 /* DynamicFacetListConnector.swift in Sources */,
+				OBJ_1612 /* DynamicFacetListController.swift in Sources */,
+				OBJ_1613 /* DynamicFacetListInteractor+Controller.swift in Sources */,
+				OBJ_1614 /* DynamicFacetListInteractor+FilterState.swift in Sources */,
+				OBJ_1615 /* DynamicFacetListInteractor+Searcher.swift in Sources */,
+				OBJ_1616 /* DynamicFacetListInteractor.swift in Sources */,
+				OBJ_1617 /* FacetsOrderer.swift in Sources */,
+				OBJ_1618 /* Optional+Collection.swift in Sources */,
+				OBJ_1619 /* Optional+String.swift in Sources */,
+				OBJ_1620 /* Query+Facets.swift in Sources */,
+				OBJ_1621 /* Result+ConvenientInit.swift in Sources */,
+				OBJ_1622 /* Sequence+Convenience.swift in Sources */,
+				OBJ_1623 /* FacetListConnector+Controller.swift in Sources */,
+				OBJ_1624 /* FacetListConnector+FacetSearcher.swift in Sources */,
+				OBJ_1625 /* FacetListConnector+HitsSearcher.swift in Sources */,
+				OBJ_1626 /* FacetListConnector.swift in Sources */,
+				OBJ_1627 /* FacetListController.swift in Sources */,
+				OBJ_1628 /* FacetListInteractor+Controller.swift in Sources */,
+				OBJ_1629 /* FacetListInteractor+FacetSearcher.swift in Sources */,
+				OBJ_1630 /* FacetListInteractor+FilterState.swift in Sources */,
+				OBJ_1631 /* FacetListInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1632 /* FacetListInteractor+MultiIndexSearcher.swift in Sources */,
+				OBJ_1633 /* FacetListInteractor.swift in Sources */,
+				OBJ_1634 /* FacetListPresenter.swift in Sources */,
+				OBJ_1635 /* FilterClearConnector+Controller.swift in Sources */,
+				OBJ_1636 /* FilterClearConnector.swift in Sources */,
+				OBJ_1637 /* FilterClearController.swift in Sources */,
+				OBJ_1638 /* FilterClearInteractor+FilterClearController.swift in Sources */,
+				OBJ_1639 /* FilterClearInteractor+FilterState.swift in Sources */,
+				OBJ_1640 /* FilterClearInteractor.swift in Sources */,
+				OBJ_1641 /* FacetFilterListConnector.swift in Sources */,
+				OBJ_1642 /* FilterListConnector+Controller.swift in Sources */,
+				OBJ_1643 /* FilterListConnector.swift in Sources */,
+				OBJ_1644 /* FilterTypeAliases.swift in Sources */,
+				OBJ_1645 /* NumericFilterListConnector.swift in Sources */,
+				OBJ_1646 /* TagFilterListConnector.swift in Sources */,
+				OBJ_1647 /* FilterListController.swift in Sources */,
+				OBJ_1648 /* FilterListInteractor+Controller.swift in Sources */,
+				OBJ_1649 /* FilterListInteractor+Facet.swift in Sources */,
+				OBJ_1650 /* FilterListInteractor+FilterState.swift in Sources */,
+				OBJ_1651 /* FilterListInteractor+Numeric.swift in Sources */,
+				OBJ_1652 /* FilterListInteractor+Tag.swift in Sources */,
+				OBJ_1653 /* FilterListInteractor.swift in Sources */,
+				OBJ_1654 /* FilterMapConnector+Controller.swift in Sources */,
+				OBJ_1655 /* FilterMapConnector.swift in Sources */,
+				OBJ_1656 /* FilterMapInteractor+Controller.swift in Sources */,
+				OBJ_1657 /* FilterMapInteractor+FilterState.swift in Sources */,
+				OBJ_1658 /* FilterMapInteractor+Searcher.swift in Sources */,
+				OBJ_1659 /* FilterMapInteractor.swift in Sources */,
+				OBJ_1660 /* AndGroupAccessor.swift in Sources */,
+				OBJ_1661 /* GroupAccessor.swift in Sources */,
+				OBJ_1662 /* HierarchicalGroupAccessor.swift in Sources */,
+				OBJ_1663 /* OrGroupAccessor.swift in Sources */,
+				OBJ_1664 /* SpecializedAndGroupAccessor.swift in Sources */,
+				OBJ_1665 /* FilterConverter.swift in Sources */,
+				OBJ_1666 /* FilterGroupConverter.swift in Sources */,
+				OBJ_1667 /* LegacySyntax.swift in Sources */,
+				OBJ_1668 /* SQLSyntax.swift in Sources */,
+				OBJ_1669 /* FacetFilter.swift in Sources */,
+				OBJ_1670 /* Filter.swift in Sources */,
+				OBJ_1671 /* AndFilterGroup.swift in Sources */,
+				OBJ_1672 /* FilterGroupType.swift in Sources */,
+				OBJ_1673 /* HierarchicalFilterGroup.swift in Sources */,
+				OBJ_1674 /* OrFilterGroup.swift in Sources */,
+				OBJ_1675 /* NumericFilter.swift in Sources */,
+				OBJ_1676 /* TagFilter.swift in Sources */,
+				OBJ_1677 /* FilterGroupID.swift in Sources */,
+				OBJ_1678 /* FilterGroupsConvertible.swift in Sources */,
+				OBJ_1679 /* FilterState+Commands.swift in Sources */,
+				OBJ_1680 /* FilterState+DisjunctiveFaceting.swift in Sources */,
+				OBJ_1681 /* FilterState+FiltersReadable.swift in Sources */,
+				OBJ_1682 /* FilterState+FiltersWritable.swift in Sources */,
+				OBJ_1683 /* FilterState+HierarchicalFaceting.swift in Sources */,
+				OBJ_1684 /* FilterState+Searcher.swift in Sources */,
+				OBJ_1685 /* FilterState.swift in Sources */,
+				OBJ_1686 /* FilterStateDSL.swift in Sources */,
+				OBJ_1687 /* FiltersReadable.swift in Sources */,
+				OBJ_1688 /* FiltersSettable.swift in Sources */,
+				OBJ_1689 /* FiltersWritable.swift in Sources */,
+				OBJ_1690 /* GroupStorage.swift in Sources */,
+				OBJ_1691 /* HierarchicalManageable.swift in Sources */,
+				OBJ_1692 /* Decodable+JSON.swift in Sources */,
+				OBJ_1693 /* UserAgentSetter.swift in Sources */,
+				OBJ_1694 /* Version+Current.swift in Sources */,
+				OBJ_1695 /* HierarchicalConnector+Controller.swift in Sources */,
+				OBJ_1696 /* HierarchicalConnector.swift in Sources */,
+				OBJ_1697 /* HierarchicalController.swift in Sources */,
+				OBJ_1698 /* HierarchicalInteractor+Controller.swift in Sources */,
+				OBJ_1699 /* HierarchicalInteractor+FilterState.swift in Sources */,
+				OBJ_1700 /* HierarchicalInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1701 /* HierarchicalInteractor.swift in Sources */,
+				OBJ_1702 /* NSAttributedString+TaggedString.swift in Sources */,
+				OBJ_1703 /* AnyHitsInteractor.swift in Sources */,
+				OBJ_1704 /* HitsConnector+Controller.swift in Sources */,
+				OBJ_1705 /* HitsConnector+GeoSearch.swift in Sources */,
+				OBJ_1706 /* HitsConnector.swift in Sources */,
+				OBJ_1707 /* GeoHitsController.swift in Sources */,
+				OBJ_1708 /* HitsController.swift in Sources */,
+				OBJ_1709 /* HitsExtractable.swift in Sources */,
+				OBJ_1710 /* HitsInteractor+Controller.swift in Sources */,
+				OBJ_1711 /* HitsInteractor+FilterState.swift in Sources */,
+				OBJ_1712 /* HitsInteractor+GeoHitsController.swift in Sources */,
+				OBJ_1713 /* HitsInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1714 /* HitsInteractor+PlacesSearcher.swift in Sources */,
+				OBJ_1715 /* HitsInteractor+Searcher.swift in Sources */,
+				OBJ_1716 /* HitsInteractor.swift in Sources */,
+				OBJ_1717 /* HitsSource.swift in Sources */,
+				OBJ_1718 /* MultiSourceReloadNotifier.swift in Sources */,
+				OBJ_1719 /* MatchingPattern.swift in Sources */,
+				OBJ_1720 /* RelatedItemsInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1721 /* InfiniteScrollable.swift in Sources */,
+				OBJ_1722 /* InfiniteScrollingController.swift in Sources */,
+				OBJ_1723 /* LoadingConnector+Controller.swift in Sources */,
+				OBJ_1724 /* LoadingConnector.swift in Sources */,
+				OBJ_1725 /* LoadingController.swift in Sources */,
+				OBJ_1726 /* LoadingInteractor+Controller.swift in Sources */,
+				OBJ_1727 /* LoadingInteractor+Searcher.swift in Sources */,
+				OBJ_1728 /* LoadingInteractor.swift in Sources */,
+				OBJ_1729 /* DecodingErrorPrettyPrinter.swift in Sources */,
+				OBJ_1730 /* Logger+InstantSearchCore.swift in Sources */,
+				OBJ_1731 /* MultiIndexHitsConnector+Controller.swift in Sources */,
+				OBJ_1732 /* MultiIndexHitsConnector+IndexModule.swift in Sources */,
+				OBJ_1733 /* MultiIndexHitsConnector+Suggestions.swift in Sources */,
+				OBJ_1734 /* MultiIndexHitsConnector.swift in Sources */,
+				OBJ_1735 /* MultiIndexHitsController.swift in Sources */,
+				OBJ_1736 /* MultiIndexHitsInteractor+Controller.swift in Sources */,
+				OBJ_1737 /* MultiIndexHitsInteractor+FilterState.swift in Sources */,
+				OBJ_1738 /* MultiIndexHitsInteractor+Searcher.swift in Sources */,
+				OBJ_1739 /* MultiIndexHitsInteractor.swift in Sources */,
+				OBJ_1740 /* MultiIndexHitsSource.swift in Sources */,
+				OBJ_1741 /* Boundable+SearchResultProvider.swift in Sources */,
+				OBJ_1742 /* Computation.swift in Sources */,
+				OBJ_1743 /* FilterComparisonConnector+Controller.swift in Sources */,
+				OBJ_1744 /* FilterComparisonConnector.swift in Sources */,
+				OBJ_1745 /* FilterComparison+Controller.swift in Sources */,
+				OBJ_1746 /* FilterComparison+FilterState.swift in Sources */,
+				OBJ_1747 /* FilterComparisonComputeBounds.swift in Sources */,
+				OBJ_1748 /* NumberController.swift in Sources */,
+				OBJ_1749 /* NumberInteractor.swift in Sources */,
+				OBJ_1750 /* NumberRangeConnector+Controller.swift in Sources */,
+				OBJ_1751 /* NumberRangeConnector.swift in Sources */,
+				OBJ_1752 /* NumberRangeController.swift in Sources */,
+				OBJ_1753 /* NumberRangeInteractor+Controller.swift in Sources */,
+				OBJ_1754 /* NumberRangeInteractor+FilterState.swift in Sources */,
+				OBJ_1755 /* NumberRangeInteractor.swift in Sources */,
+				OBJ_1756 /* Observable.swift in Sources */,
+				OBJ_1757 /* Observation.swift in Sources */,
+				OBJ_1758 /* Observer.swift in Sources */,
+				OBJ_1759 /* Signals+Observable.swift in Sources */,
+				OBJ_1760 /* Subscription.swift in Sources */,
+				OBJ_1761 /* PageLoadable.swift in Sources */,
+				OBJ_1762 /* PageMap.swift in Sources */,
+				OBJ_1763 /* Paginator.swift in Sources */,
+				OBJ_1764 /* SearchResults+PageMap.swift in Sources */,
+				OBJ_1765 /* SynchronizedSet.swift in Sources */,
+				OBJ_1766 /* DefaultPresenter.swift in Sources */,
+				OBJ_1767 /* FacetPresenter.swift in Sources */,
+				OBJ_1768 /* FilterPresenter.swift in Sources */,
+				OBJ_1769 /* HierarchicalPresenter.swift in Sources */,
+				OBJ_1770 /* IndexNamePresenter.swift in Sources */,
+				OBJ_1771 /* IndexPresenter.swift in Sources */,
+				OBJ_1772 /* RelevantSortPresenter.swift in Sources */,
+				OBJ_1773 /* StatsPresenter.swift in Sources */,
+				OBJ_1774 /* QueryBuilder+DisjunctiveFaceting.swift in Sources */,
+				OBJ_1775 /* QueryBuilder+HierarchicalFaceting.swift in Sources */,
+				OBJ_1776 /* QueryBuilder.swift in Sources */,
+				OBJ_1777 /* QueryRuleCustomDataConnector+Controller.swift in Sources */,
+				OBJ_1778 /* QueryRuleCustomDataConnector.swift in Sources */,
+				OBJ_1779 /* QueryRuleCustomData+Searcher.swift in Sources */,
+				OBJ_1780 /* QueryRuleCustomDataInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1781 /* QueryRuleCustomDataInteractor+MultiIndexSearcher.swift in Sources */,
+				OBJ_1782 /* QueryRuleCustomDataInteractor.swift in Sources */,
+				OBJ_1783 /* RelevantSortConnector+Controller.swift in Sources */,
+				OBJ_1784 /* RelevantSortConnector.swift in Sources */,
+				OBJ_1785 /* RelevantSortInteractor+Controller.swift in Sources */,
+				OBJ_1786 /* RelevantSortInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1787 /* RelevantSortInteractor+MultiIndexSearcher.swift in Sources */,
+				OBJ_1788 /* RelevantSortInteractor.swift in Sources */,
+				OBJ_1789 /* RelevantSortPriority.swift in Sources */,
+				OBJ_1790 /* SearchBoxConnector+Controller.swift in Sources */,
+				OBJ_1791 /* SearchBoxConnector.swift in Sources */,
+				OBJ_1792 /* QuerySettable.swift in Sources */,
+				OBJ_1793 /* SearchBoxController.swift in Sources */,
+				OBJ_1794 /* SearchBoxInteractor+Controller.swift in Sources */,
+				OBJ_1795 /* SearchBoxInteractor+Searcher.swift in Sources */,
+				OBJ_1796 /* SearchBoxInteractor.swift in Sources */,
+				OBJ_1797 /* SearchTriggeringMode.swift in Sources */,
+				OBJ_1798 /* AbstractSearcher+TextualQueryProvider.swift in Sources */,
+				OBJ_1799 /* AbstractSearcher.swift in Sources */,
+				OBJ_1800 /* AnswersSearcher+FilterState.swift in Sources */,
+				OBJ_1801 /* AnswersSearcher.swift in Sources */,
+				OBJ_1802 /* DisjunctiveFacetingDelegate.swift in Sources */,
+				OBJ_1803 /* FacetSearcher+FilterState.swift in Sources */,
+				OBJ_1804 /* FacetSearcher.swift in Sources */,
+				OBJ_1805 /* HierarchicalFacetingDelegate.swift in Sources */,
+				OBJ_1806 /* HitsSearcher+FilterState.swift in Sources */,
+				OBJ_1807 /* HitsSearcher.swift in Sources */,
+				OBJ_1808 /* IndexNameProvider.swift in Sources */,
+				OBJ_1809 /* IndexSearcher.swift in Sources */,
+				OBJ_1810 /* AbstractMultiSearcher.swift in Sources */,
+				OBJ_1811 /* MultiRequest.swift in Sources */,
+				OBJ_1812 /* MultiResult.swift in Sources */,
+				OBJ_1813 /* MultiSearchComponent.swift in Sources */,
+				OBJ_1814 /* MultiSearchService.swift in Sources */,
+				OBJ_1815 /* MultiSearcher.swift in Sources */,
+				OBJ_1816 /* MultiIndexSearcher+FilterState.swift in Sources */,
+				OBJ_1817 /* MultiIndexSearcher.swift in Sources */,
+				OBJ_1818 /* PlacesSearcher.swift in Sources */,
+				OBJ_1819 /* AlgoliaAnswersSearchService.swift in Sources */,
+				OBJ_1820 /* AlgoliaMultiSearchService.swift in Sources */,
+				OBJ_1821 /* AlgoliaPlacesSearchService.swift in Sources */,
+				OBJ_1822 /* AlgoliaRequest.swift in Sources */,
+				OBJ_1823 /* AlgoliaSearchService.swift in Sources */,
+				OBJ_1824 /* FacetSearchService.swift in Sources */,
+				OBJ_1825 /* SearchService.swift in Sources */,
+				OBJ_1826 /* Searcher.swift in Sources */,
+				OBJ_1827 /* TextualQueryProvider.swift in Sources */,
+				OBJ_1828 /* Sequencer.swift in Sources */,
+				OBJ_1829 /* Signal.swift in Sources */,
+				OBJ_1830 /* SortByConnector+Controller.swift in Sources */,
+				OBJ_1831 /* SortByConnector.swift in Sources */,
+				OBJ_1832 /* IndexSegmentInteractor+AnswersSearcher.swift in Sources */,
+				OBJ_1833 /* IndexSegmentInteractor+Controller.swift in Sources */,
+				OBJ_1834 /* IndexSegmentInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1835 /* IndexSegmentInteractor+MultiIndexSearcher.swift in Sources */,
+				OBJ_1836 /* IndexSegmentInteractor.swift in Sources */,
+				OBJ_1837 /* SortByInteractor+Controller.swift in Sources */,
+				OBJ_1838 /* SortByInteractor+Searcher.swift in Sources */,
+				OBJ_1839 /* SortByInteractor.swift in Sources */,
+				OBJ_1840 /* StatsConnector+Controller.swift in Sources */,
+				OBJ_1841 /* StatsConnector.swift in Sources */,
+				OBJ_1842 /* SearchStats.swift in Sources */,
+				OBJ_1843 /* SearchStatsConvertible.swift in Sources */,
+				OBJ_1844 /* StatsController.swift in Sources */,
+				OBJ_1845 /* StatsInteractor+Controller.swift in Sources */,
+				OBJ_1846 /* StatsInteractor+HitsSearcher.swift in Sources */,
+				OBJ_1847 /* StatsInteractor+Searcher.swift in Sources */,
+				OBJ_1848 /* StatsInteractor.swift in Sources */,
+				OBJ_1849 /* SwitchIndexInteractor+Controller.swift in Sources */,
+				OBJ_1850 /* SwitchIndexInteractor+Searcher.swift in Sources */,
+				OBJ_1851 /* SwitchIndexInteractor.swift.swift in Sources */,
+				OBJ_1852 /* Telemetry.swift in Sources */,
+				OBJ_1853 /* FilterToggleConnector+Controller.swift in Sources */,
+				OBJ_1854 /* FilterToggleConnector.swift in Sources */,
+				OBJ_1855 /* FilgerToggle+Controller.swift in Sources */,
+				OBJ_1856 /* FilterToggle+FilterState.swift in Sources */,
+				OBJ_1857 /* FilterTrackable.swift in Sources */,
+				OBJ_1858 /* FilterTracker.swift in Sources */,
+				OBJ_1859 /* HitsAfterSearchTrackable.swift in Sources */,
+				OBJ_1860 /* HitsTracker.swift in Sources */,
+				OBJ_1861 /* InsightsTracker.swift in Sources */,
+				OBJ_1862 /* TrackableSearcher.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1878 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1879 /* JSONDecoder+Resource.swift in Sources */,
+				OBJ_1880 /* String+Random.swift in Sources */,
+				OBJ_1881 /* InstantSearchCoreTests.swift in Sources */,
+				OBJ_1882 /* DisjuncitveAndHierarchicalIntegrationTests.swift in Sources */,
+				OBJ_1883 /* DisjunctiveFacetingIntegrationTests.swift in Sources */,
+				OBJ_1884 /* HierarchicalIntegrationTests.swift in Sources */,
+				OBJ_1885 /* OnlineTestCase.swift in Sources */,
+				OBJ_1886 /* TestCredentials.swift in Sources */,
+				OBJ_1887 /* Data+FileAccess.swift in Sources */,
+				OBJ_1888 /* AttributedStringWithTaggedStringTests.swift in Sources */,
+				OBJ_1889 /* MultiIndexSearchConnectorTests.swift in Sources */,
+				OBJ_1890 /* SearchConnectorTests.swift in Sources */,
+				OBJ_1891 /* SortByConnectorTests.swift in Sources */,
+				OBJ_1892 /* CurrentFiltersControllerConnectionTests.swift in Sources */,
+				OBJ_1893 /* CurrentFiltersFilterStateConnectionTests.swift in Sources */,
+				OBJ_1894 /* TestCurrentFiltersController.swift in Sources */,
+				OBJ_1895 /* DecodingErrorPrettyPrinterTests.swift in Sources */,
+				OBJ_1896 /* DisjunctiveFacetingsTests.swift in Sources */,
+				OBJ_1897 /* FacetsOrdererTests.swift in Sources */,
+				OBJ_1898 /* Array+Facet.swift in Sources */,
+				OBJ_1899 /* FacetListControllerConnectionTests.swift in Sources */,
+				OBJ_1900 /* FacetListFacetSearcherConnectionTests.swift in Sources */,
+				OBJ_1901 /* FacetListFilterStateConnectionTests.swift in Sources */,
+				OBJ_1902 /* FacetListHitsSearcherConnectionTests.swift in Sources */,
+				OBJ_1903 /* FacetListInteractorTests.swift in Sources */,
+				OBJ_1904 /* FacetListPresenterTests.swift in Sources */,
+				OBJ_1905 /* TestFacetListController.swift in Sources */,
+				OBJ_1906 /* FilterGroupCollectionsTests.swift in Sources */,
+				OBJ_1907 /* FilterGroupTests.swift in Sources */,
+				OBJ_1908 /* FilterStateGroupTests.swift in Sources */,
+				OBJ_1909 /* FilterStateTests.swift in Sources */,
+				OBJ_1910 /* FilterTests.swift in Sources */,
+				OBJ_1911 /* Helpers.swift in Sources */,
+				OBJ_1912 /* HitsInteractorControllerConnectionTests.swift in Sources */,
+				OBJ_1913 /* HitsInteractorFilterStateConnectionTests.swift in Sources */,
+				OBJ_1914 /* HitsInteractorRelatedItemsTests.swift in Sources */,
+				OBJ_1915 /* HitsInteractorSearcherConnectionTests.swift in Sources */,
+				OBJ_1916 /* HitsInteractorTests.swift in Sources */,
+				OBJ_1917 /* TestHitsController.swift in Sources */,
+				OBJ_1918 /* TestInfiniteScrollingController.swift in Sources */,
+				OBJ_1919 /* InfiniteScrollingControllerTests.swift in Sources */,
+				OBJ_1920 /* ItemInteractorTests.swift in Sources */,
+				OBJ_1921 /* LoggingTests.swift in Sources */,
+				OBJ_1922 /* MultiIndexHitsInteractorControllerConnectionTests.swift in Sources */,
+				OBJ_1923 /* MultiIndexHitsInteractorSearcherConnectionTests.swift in Sources */,
+				OBJ_1924 /* MultiIndexHitsInteractorTests.swift in Sources */,
+				OBJ_1925 /* MultiSourceHitsReloaderTests.swift in Sources */,
+				OBJ_1926 /* NumberInteractorTests.swift in Sources */,
+				OBJ_1927 /* NumberRangeInteractorTests.swift in Sources */,
+				OBJ_1928 /* PageMapTests.swift in Sources */,
+				OBJ_1929 /* PaginatorTests.swift in Sources */,
+				OBJ_1930 /* QueryBuilderTests.swift in Sources */,
+				OBJ_1931 /* SearchBoxControllerConnectionTests.swift in Sources */,
+				OBJ_1932 /* SearchBoxInteractorTests.swift in Sources */,
+				OBJ_1933 /* SearchBoxSearcherConnectionTests.swift in Sources */,
+				OBJ_1934 /* TestSearchBoxController.swift in Sources */,
+				OBJ_1935 /* TestSearcher.swift in Sources */,
+				OBJ_1936 /* QueryRuleCustomDataSearcherConnectionTests.swift in Sources */,
+				OBJ_1937 /* RelevantSortControllerConnectionTests.swift in Sources */,
+				OBJ_1938 /* RelevantSortHitsSearcherConnectionTests.swift in Sources */,
+				OBJ_1939 /* RelevantSortInteractorTests.swift in Sources */,
+				OBJ_1940 /* RelevantSortMultiIndexSearcherConnectionTests.swift in Sources */,
+				OBJ_1941 /* AnswersSearcherTests.swift in Sources */,
+				OBJ_1942 /* HitsSearcherTests.swift in Sources */,
+				OBJ_1943 /* MultiIndexSearcherTests.swift in Sources */,
+				OBJ_1944 /* SelectableInteractorConnectorsTests.swift in Sources */,
+				OBJ_1945 /* SelectableInteractorTests.swift in Sources */,
+				OBJ_1946 /* SelectableListInteractorFilterConnectorsTests.swift in Sources */,
+				OBJ_1947 /* SelectableListInteractorTests.swift in Sources */,
+				OBJ_1948 /* SelectableSegmentInteractorConnectorsTests.swift in Sources */,
+				OBJ_1949 /* SelectableSegmentInteractorTests.swift in Sources */,
+				OBJ_1950 /* TestSelectableSegmentController.swift in Sources */,
+				OBJ_1951 /* SequencerTest.swift in Sources */,
+				OBJ_1952 /* StatsInteractorConnectorsTests.swift in Sources */,
+				OBJ_1953 /* TelemetryTests.swift in Sources */,
+				OBJ_1954 /* FilterTrackerTests.swift in Sources */,
+				OBJ_1955 /* HitsTrackerTests.swift in Sources */,
+				OBJ_1956 /* TestFiltersTracker.swift in Sources */,
+				OBJ_1957 /* TestHitsTracker.swift in Sources */,
+				OBJ_1958 /* XCTestManifests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_1975 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1976 /* Date+Milliseconds.swift in Sources */,
+				OBJ_1977 /* Encodable.swift in Sources */,
+				OBJ_1978 /* JSONFilePackageStorage.swift in Sources */,
+				OBJ_1979 /* TimerController.swift in Sources */,
+				OBJ_1980 /* LogCollector.swift in Sources */,
+				OBJ_1981 /* LogLevel.swift in Sources */,
+				OBJ_1982 /* LogService.swift in Sources */,
+				OBJ_1983 /* Logger+InstantSearchInsights.swift in Sources */,
+				OBJ_1984 /* PrefixedLogger.swift in Sources */,
+				OBJ_1985 /* SwiftLog+LogService.swift in Sources */,
+				OBJ_1986 /* EventProcessor+AlgoliaClient.swift in Sources */,
+				OBJ_1987 /* EventProcessor.swift in Sources */,
+				OBJ_1988 /* EventTracker.swift in Sources */,
+				OBJ_1989 /* Insights+EventTracking.swift in Sources */,
+				OBJ_1990 /* Insights+SearchEventTracking.swift in Sources */,
+				OBJ_1991 /* Insights.swift in Sources */,
+				OBJ_1992 /* InsightsClient+EventService.swift in Sources */,
+				OBJ_1993 /* Config.swift in Sources */,
+				OBJ_1994 /* Package+InsightsEvent.swift in Sources */,
+				OBJ_1995 /* Package.swift in Sources */,
+				OBJ_1996 /* Packager+InsightsEvent.swift in Sources */,
+				OBJ_1997 /* Packager.swift in Sources */,
+				OBJ_1998 /* EventProcessable.swift in Sources */,
+				OBJ_1999 /* EventTrackable.swift in Sources */,
+				OBJ_2000 /* EventsService.swift in Sources */,
+				OBJ_2001 /* Flushable.swift in Sources */,
+				OBJ_2002 /* PackageManageable.swift in Sources */,
+				OBJ_2003 /* Packaging.swift in Sources */,
+				OBJ_2004 /* Storage.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2014 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2015 /* MockEventService.swift in Sources */,
+				OBJ_2016 /* String+Random.swift in Sources */,
+				OBJ_2017 /* TestEvent.swift in Sources */,
+				OBJ_2018 /* TestEventProcessor.swift in Sources */,
+				OBJ_2019 /* TestEventTracker.swift in Sources */,
+				OBJ_2020 /* TestPackageStorage.swift in Sources */,
+				OBJ_2021 /* XCTest+Codable.swift in Sources */,
+				OBJ_2022 /* EventTrackerTests.swift in Sources */,
+				OBJ_2023 /* EventsProcessorTests.swift in Sources */,
+				OBJ_2024 /* InsightsTests.swift in Sources */,
+				OBJ_2025 /* JSONFilePackageStorageTests.swift in Sources */,
+				OBJ_2026 /* LoggingTests.swift in Sources */,
+				OBJ_2027 /* PackageTests.swift in Sources */,
+				OBJ_2028 /* PackagerTests.swift in Sources */,
+				OBJ_2029 /* TimerControllerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2041 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2042 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2057 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2058 /* CurrentFiltersObservableController.swift in Sources */,
+				OBJ_2059 /* DynamicFacetListObservableController.swift in Sources */,
+				OBJ_2060 /* FacetListObservableController.swift in Sources */,
+				OBJ_2061 /* FilterClearObservableController.swift in Sources */,
+				OBJ_2062 /* FilterListObservableController.swift in Sources */,
+				OBJ_2063 /* FilterToggleObservableController.swift in Sources */,
+				OBJ_2064 /* HierarchicalObservableController.swift in Sources */,
+				OBJ_2065 /* HitsObservableController.swift in Sources */,
+				OBJ_2066 /* LoadingObservableController.swift in Sources */,
+				OBJ_2067 /* NumberRangeObservableController.swift in Sources */,
+				OBJ_2068 /* RelevantSortObservableController.swift in Sources */,
+				OBJ_2069 /* SearchBoxObservableController.swift in Sources */,
+				OBJ_2070 /* SelectableSegmentObservableController.swift in Sources */,
+				OBJ_2071 /* StatsObservableController.swift in Sources */,
+				OBJ_2072 /* StatsTextObservableController.swift in Sources */,
+				OBJ_2073 /* SwitchIndexObservableController.swift in Sources */,
+				OBJ_2074 /* FacetList.swift in Sources */,
+				OBJ_2075 /* FacetRow.swift in Sources */,
+				OBJ_2076 /* FilterList.swift in Sources */,
+				OBJ_2077 /* HierarchicalFacetRow.swift in Sources */,
+				OBJ_2078 /* HierarchicalList.swift in Sources */,
+				OBJ_2079 /* HitsList.swift in Sources */,
+				OBJ_2080 /* SearchBar.swift in Sources */,
+				OBJ_2081 /* SuggestionRow.swift in Sources */,
+				OBJ_2082 /* Text+Highlighting.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2099 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2100 /* ObservableControllerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2119 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2120 /* CRC32.swift in Sources */,
+				OBJ_2121 /* Data+Gzip.swift in Sources */,
+				OBJ_2122 /* Gzip.swift in Sources */,
+				OBJ_2123 /* Telemetry.swift in Sources */,
+				OBJ_2124 /* telemetry.pb.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2132 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2133 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2137 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2138 /* String+Random.swift in Sources */,
+				OBJ_2139 /* InstantSearchTests.swift in Sources */,
+				OBJ_2140 /* LoggingTests.swift in Sources */,
+				OBJ_2141 /* BannerGuideSnippets.swift in Sources */,
+				OBJ_2142 /* CurrentRefinementsSnippets.swift in Sources */,
+				OBJ_2143 /* FacetFilterListSnippets.swift in Sources */,
+				OBJ_2144 /* FacetListConnectorSnippets.swift in Sources */,
+				OBJ_2145 /* FilterClearSnippets.swift in Sources */,
+				OBJ_2146 /* HierarchicalSnippets.swift in Sources */,
+				OBJ_2147 /* HitsSnippets.swift in Sources */,
+				OBJ_2148 /* LoadingSnippets.swift in Sources */,
+				OBJ_2149 /* MultiIndexHitsSnippets.swift in Sources */,
+				OBJ_2150 /* NumberRangeSnippets.swift in Sources */,
+				OBJ_2151 /* NumericFilterListSnippets.swift in Sources */,
+				OBJ_2152 /* QueryRuleCustomDataSnippets.swift in Sources */,
+				OBJ_2153 /* RedirectGuideSnippets.swift in Sources */,
+				OBJ_2154 /* SearchBoxSnippets.swift in Sources */,
+				OBJ_2155 /* SortBySnippets.swift in Sources */,
+				OBJ_2156 /* StatsSnippets.swift in Sources */,
+				OBJ_2157 /* TagFilterListSnippets.swift in Sources */,
+				OBJ_2158 /* ToggleFilterSnippets.swift in Sources */,
+				OBJ_2159 /* TestHitsSource.swift in Sources */,
+				OBJ_2160 /* TestMultiHitsDataSource.swift in Sources */,
+				OBJ_2161 /* XCTestManifests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2180 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2181 /* Locks.swift in Sources */,
+				OBJ_2182 /* LogHandler.swift in Sources */,
+				OBJ_2183 /* Logging.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2188 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2189 /* AnyMessageStorage.swift in Sources */,
+				OBJ_2190 /* AnyUnpackError.swift in Sources */,
+				OBJ_2191 /* BinaryDecoder.swift in Sources */,
+				OBJ_2192 /* BinaryDecodingError.swift in Sources */,
+				OBJ_2193 /* BinaryDecodingOptions.swift in Sources */,
+				OBJ_2194 /* BinaryDelimited.swift in Sources */,
+				OBJ_2195 /* BinaryEncoder.swift in Sources */,
+				OBJ_2196 /* BinaryEncodingError.swift in Sources */,
+				OBJ_2197 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				OBJ_2198 /* BinaryEncodingVisitor.swift in Sources */,
+				OBJ_2199 /* CustomJSONCodable.swift in Sources */,
+				OBJ_2200 /* Data+Extensions.swift in Sources */,
+				OBJ_2201 /* Decoder.swift in Sources */,
+				OBJ_2202 /* DoubleParser.swift in Sources */,
+				OBJ_2203 /* Enum.swift in Sources */,
+				OBJ_2204 /* ExtensibleMessage.swift in Sources */,
+				OBJ_2205 /* ExtensionFieldValueSet.swift in Sources */,
+				OBJ_2206 /* ExtensionFields.swift in Sources */,
+				OBJ_2207 /* ExtensionMap.swift in Sources */,
+				OBJ_2208 /* FieldTag.swift in Sources */,
+				OBJ_2209 /* FieldTypes.swift in Sources */,
+				OBJ_2210 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				OBJ_2211 /* Google_Protobuf_Any+Registry.swift in Sources */,
+				OBJ_2212 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
+				OBJ_2213 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
+				OBJ_2214 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
+				OBJ_2215 /* Google_Protobuf_NullValue+Extensions.swift in Sources */,
+				OBJ_2216 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
+				OBJ_2217 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
+				OBJ_2218 /* Google_Protobuf_Value+Extensions.swift in Sources */,
+				OBJ_2219 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				OBJ_2220 /* HashVisitor.swift in Sources */,
+				OBJ_2221 /* Internal.swift in Sources */,
+				OBJ_2222 /* JSONDecoder.swift in Sources */,
+				OBJ_2223 /* JSONDecodingError.swift in Sources */,
+				OBJ_2224 /* JSONDecodingOptions.swift in Sources */,
+				OBJ_2225 /* JSONEncoder.swift in Sources */,
+				OBJ_2226 /* JSONEncodingError.swift in Sources */,
+				OBJ_2227 /* JSONEncodingOptions.swift in Sources */,
+				OBJ_2228 /* JSONEncodingVisitor.swift in Sources */,
+				OBJ_2229 /* JSONMapEncodingVisitor.swift in Sources */,
+				OBJ_2230 /* JSONScanner.swift in Sources */,
+				OBJ_2231 /* MathUtils.swift in Sources */,
+				OBJ_2232 /* Message+AnyAdditions.swift in Sources */,
+				OBJ_2233 /* Message+BinaryAdditions.swift in Sources */,
+				OBJ_2234 /* Message+JSONAdditions.swift in Sources */,
+				OBJ_2235 /* Message+JSONArrayAdditions.swift in Sources */,
+				OBJ_2236 /* Message+TextFormatAdditions.swift in Sources */,
+				OBJ_2237 /* Message.swift in Sources */,
+				OBJ_2238 /* MessageExtension.swift in Sources */,
+				OBJ_2239 /* NameMap.swift in Sources */,
+				OBJ_2240 /* ProtoNameProviding.swift in Sources */,
+				OBJ_2241 /* ProtobufAPIVersionCheck.swift in Sources */,
+				OBJ_2242 /* ProtobufMap.swift in Sources */,
+				OBJ_2243 /* SelectiveVisitor.swift in Sources */,
+				OBJ_2244 /* SimpleExtensionMap.swift in Sources */,
+				OBJ_2245 /* StringUtils.swift in Sources */,
+				OBJ_2246 /* TextFormatDecoder.swift in Sources */,
+				OBJ_2247 /* TextFormatDecodingError.swift in Sources */,
+				OBJ_2248 /* TextFormatDecodingOptions.swift in Sources */,
+				OBJ_2249 /* TextFormatEncoder.swift in Sources */,
+				OBJ_2250 /* TextFormatEncodingOptions.swift in Sources */,
+				OBJ_2251 /* TextFormatEncodingVisitor.swift in Sources */,
+				OBJ_2252 /* TextFormatScanner.swift in Sources */,
+				OBJ_2253 /* TimeUtils.swift in Sources */,
+				OBJ_2254 /* UnknownStorage.swift in Sources */,
+				OBJ_2255 /* UnsafeBufferPointer+Shims.swift in Sources */,
+				OBJ_2256 /* UnsafeRawPointer+Shims.swift in Sources */,
+				OBJ_2257 /* Varint.swift in Sources */,
+				OBJ_2258 /* Version.swift in Sources */,
+				OBJ_2259 /* Visitor.swift in Sources */,
+				OBJ_2260 /* WireFormat.swift in Sources */,
+				OBJ_2261 /* ZigZag.swift in Sources */,
+				OBJ_2262 /* any.pb.swift in Sources */,
+				OBJ_2263 /* api.pb.swift in Sources */,
+				OBJ_2264 /* descriptor.pb.swift in Sources */,
+				OBJ_2265 /* duration.pb.swift in Sources */,
+				OBJ_2266 /* empty.pb.swift in Sources */,
+				OBJ_2267 /* field_mask.pb.swift in Sources */,
+				OBJ_2268 /* source_context.pb.swift in Sources */,
+				OBJ_2269 /* struct.pb.swift in Sources */,
+				OBJ_2270 /* timestamp.pb.swift in Sources */,
+				OBJ_2271 /* type.pb.swift in Sources */,
+				OBJ_2272 /* wrappers.pb.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2278 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2279 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_2284 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_2285 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_1492 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 403811FA284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1559 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchCore" /* InstantSearchCore */;
+			targetProxy = 403811F4284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1561 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */;
+			targetProxy = 403811FE284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1563 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 403811FF284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1565 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 40381200284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1567 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 40381201284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1568 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 40381202284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1869 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */;
+			targetProxy = 403811F5284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1870 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 403811F7284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1871 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 403811F8284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1872 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 403811FC284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1873 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 403811FD284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1966 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchCore" /* InstantSearchCore */;
+			targetProxy = 40381209284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1967 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */;
+			targetProxy = 4038120A284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1968 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 4038120B284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1969 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 4038120C284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1970 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 4038120D284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_1971 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 4038120E284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2008 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 403811F9284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2009 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 403811FB284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2034 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 4038120F284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2035 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 40381210284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2036 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 40381211284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2047 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchTests" /* InstantSearchTests */;
+			targetProxy = 40381220284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2049 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchSwiftUITests" /* InstantSearchSwiftUITests */;
+			targetProxy = 40381221284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2051 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsightsTests" /* InstantSearchInsightsTests */;
+			targetProxy = 40381222284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2052 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchCoreTests" /* InstantSearchCoreTests */;
+			targetProxy = 40381223284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2090 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchCore" /* InstantSearchCore */;
+			targetProxy = 40381203284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2091 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */;
+			targetProxy = 40381204284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2092 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 40381205284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2093 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 40381206284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2094 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 40381207284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2095 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 40381208284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2109 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchSwiftUI" /* InstantSearchSwiftUI */;
+			targetProxy = 40381212284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2110 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchCore" /* InstantSearchCore */;
+			targetProxy = 40381213284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2111 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */;
+			targetProxy = 40381214284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2112 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 40381215284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2113 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 40381216284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2114 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 40381217284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2115 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 40381218284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2127 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 403811F6284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2170 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearch" /* InstantSearch */;
+			targetProxy = 40381219284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2171 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchCore" /* InstantSearchCore */;
+			targetProxy = 4038121A284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2172 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-telemetry-native::InstantSearchTelemetry" /* InstantSearchTelemetry */;
+			targetProxy = 4038121B284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2173 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-protobuf::SwiftProtobuf" /* SwiftProtobuf */;
+			targetProxy = 4038121C284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2174 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "instantsearch-ios::InstantSearchInsights" /* InstantSearchInsights */;
+			targetProxy = 4038121D284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2175 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "algoliasearch-client-swift::AlgoliaSearchClient" /* AlgoliaSearchClient */;
+			targetProxy = 4038121E284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+		OBJ_2176 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "swift-log::Logging" /* Logging */;
+			targetProxy = 4038121F284007E60060B8D9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_1172 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/AlgoliaSearchClient_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = AlgoliaSearchClient;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = AlgoliaSearchClient;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1173 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/AlgoliaSearchClient_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = AlgoliaSearchClient;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = AlgoliaSearchClient;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_1496 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.1.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_1497 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.1.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_1502 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearch_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearch;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearch;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1503 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearch_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearch;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearch;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_1570 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchCore_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchCore;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchCore;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1571 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchCore_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchCore;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchCore;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_1876 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchCoreTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchCoreTests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		OBJ_1877 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchCoreTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchCoreTests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
+		OBJ_1973 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchInsights_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchInsights;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchInsights;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_1974 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchInsights_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchInsights;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchInsights;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_2012 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchInsightsTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchInsightsTests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		OBJ_2013 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchInsightsTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchInsightsTests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
+		OBJ_2039 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.5.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_2040 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.5.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_2045 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_2046 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_2055 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchSwiftUI_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchSwiftUI;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchSwiftUI;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_2056 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchSwiftUI_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchSwiftUI;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchSwiftUI;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_2097 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchSwiftUITests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchSwiftUITests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		OBJ_2098 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchSwiftUITests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchSwiftUITests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
+		OBJ_2117 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchTelemetry_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchTelemetry;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchTelemetry;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_2118 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchTelemetry_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = InstantSearchTelemetry;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchTelemetry;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_2130 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.5.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_2131 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.5.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_2135 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchTests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		OBJ_2136 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/InstantSearchTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = InstantSearchTests;
+				TVOS_DEPLOYMENT_TARGET = 14.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
+		OBJ_2178 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/Logging_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Logging;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Logging;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_2179 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/Logging_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Logging;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Logging;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_2186 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/SwiftProtobuf_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftProtobuf;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftProtobuf;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_2187 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = InstantSearch.xcodeproj/SwiftProtobuf_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftProtobuf;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftProtobuf;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_2276 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 4.2.0";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		OBJ_2277 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 4.2.0";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
+		OBJ_2282 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.0.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_2283 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/ManifestAPI -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -package-description-version 5.0.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+					"DEBUG=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_1171 /* Build configuration list for PBXNativeTarget "AlgoliaSearchClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1172 /* Debug */,
+				OBJ_1173 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1495 /* Build configuration list for PBXNativeTarget "AlgoliaSearchClientPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1496 /* Debug */,
+				OBJ_1497 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1501 /* Build configuration list for PBXNativeTarget "InstantSearch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1502 /* Debug */,
+				OBJ_1503 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1569 /* Build configuration list for PBXNativeTarget "InstantSearchCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1570 /* Debug */,
+				OBJ_1571 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1875 /* Build configuration list for PBXNativeTarget "InstantSearchCoreTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1876 /* Debug */,
+				OBJ_1877 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_1972 /* Build configuration list for PBXNativeTarget "InstantSearchInsights" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_1973 /* Debug */,
+				OBJ_1974 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "InstantSearch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2011 /* Build configuration list for PBXNativeTarget "InstantSearchInsightsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2012 /* Debug */,
+				OBJ_2013 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2038 /* Build configuration list for PBXNativeTarget "InstantSearchPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2039 /* Debug */,
+				OBJ_2040 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2044 /* Build configuration list for PBXAggregateTarget "InstantSearchPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2045 /* Debug */,
+				OBJ_2046 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2054 /* Build configuration list for PBXNativeTarget "InstantSearchSwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2055 /* Debug */,
+				OBJ_2056 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2096 /* Build configuration list for PBXNativeTarget "InstantSearchSwiftUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2097 /* Debug */,
+				OBJ_2098 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2116 /* Build configuration list for PBXNativeTarget "InstantSearchTelemetry" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2117 /* Debug */,
+				OBJ_2118 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2129 /* Build configuration list for PBXNativeTarget "InstantSearchTelemetryPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2130 /* Debug */,
+				OBJ_2131 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2134 /* Build configuration list for PBXNativeTarget "InstantSearchTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2135 /* Debug */,
+				OBJ_2136 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2177 /* Build configuration list for PBXNativeTarget "Logging" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2178 /* Debug */,
+				OBJ_2179 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2185 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2186 /* Debug */,
+				OBJ_2187 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2275 /* Build configuration list for PBXNativeTarget "SwiftProtobufPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2276 /* Debug */,
+				OBJ_2277 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2281 /* Build configuration list for PBXNativeTarget "swift-logPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_2282 /* Debug */,
+				OBJ_2283 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
+}

--- a/InstantSearch.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/InstantSearch.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/InstantSearch.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/InstantSearch.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/InstantSearch.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+    <false/>
+</dict>
+</plist>

--- a/InstantSearch.xcodeproj/xcshareddata/xcschemes/InstantSearch-Package.xcscheme
+++ b/InstantSearch.xcodeproj/xcshareddata/xcschemes/InstantSearch-Package.xcscheme
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearch"
+               BuildableName = "InstantSearch.framework"
+               BlueprintName = "InstantSearch"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchCore"
+               BuildableName = "InstantSearchCore.framework"
+               BlueprintName = "InstantSearchCore"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchInsights"
+               BuildableName = "InstantSearchInsights.framework"
+               BlueprintName = "InstantSearchInsights"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchSwiftUI"
+               BuildableName = "InstantSearchSwiftUI.framework"
+               BlueprintName = "InstantSearchSwiftUI"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchCoreTests"
+               BuildableName = "InstantSearchCoreTests.xctest"
+               BlueprintName = "InstantSearchCoreTests"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchInsightsTests"
+               BuildableName = "InstantSearchInsightsTests.xctest"
+               BlueprintName = "InstantSearchInsightsTests"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchSwiftUITests"
+               BuildableName = "InstantSearchSwiftUITests.xctest"
+               BlueprintName = "InstantSearchSwiftUITests"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "instantsearch-ios::InstantSearchTests"
+               BuildableName = "InstantSearchTests.xctest"
+               BlueprintName = "InstantSearchTests"
+               ReferencedContainer = "container:InstantSearch.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
              from: "8.13.0"),
     .package(name: "InstantSearchTelemetry",
              url: "https://github.com/algolia/instantsearch-telemetry-native",
-             .branch("fix/carthage-build"))
+             from: "0.1.1")
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
              from: "8.13.0"),
     .package(name: "InstantSearchTelemetry",
              url: "https://github.com/algolia/instantsearch-telemetry-native",
-             from: "0.1.1")
+             from: "0.1.2")
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
              from: "8.13.0"),
     .package(name: "InstantSearchTelemetry",
              url: "https://github.com/algolia/instantsearch-telemetry-native",
-             from: "0.1.0-beta1")
+             .branch("fix/carthage-build"))
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   name: "InstantSearch",
   platforms: [
     .iOS(.v9),
-    .macOS(.v10_10),
+    .macOS(.v10_11),
     .watchOS(.v2),
     .tvOS(.v9)
   ],

--- a/carthage-prebuild
+++ b/carthage-prebuild
@@ -1,19 +1,27 @@
-packages=(
+# packages requiring xcodeproj file generation for Carthage
+PACKAGES_TO_GEN_XCODEPROJ=(
   algoliasearch-client-swift
   swift-log
 )
 
 cd Carthage/Checkouts/
-for package in "${packages[@]}"; do
-  cd ./$package
+for PACKAGE in "${PACKAGES_TO_GEN_XCODEPROJ[@]}"; do
+  cd ./$PACKAGE
   swift package generate-xcodeproj
   cd ..
 done
-cd instantsearch-telemetry-native
-swift package resolve
-cd ..
-cd instantsearch-ios
-swift package resolve
-cd ..
+
+# packages requiring manual SPM resolve for Carthage
+PACKAGES_TO_RESOLVE=(
+  instantsearch-telemetry-native
+  instantsearch-ios
+)
+
+for PACKAGE in "${PACKAGES_TO_RESOLVE[@]}"; do
+  cd ./$PACKAGE
+  swift package resolve
+  cd ..
+done
+
 cd ../../..
 

--- a/carthage-prebuild
+++ b/carthage-prebuild
@@ -1,7 +1,6 @@
 packages=(
   algoliasearch-client-swift
   swift-log
-  instantsearch-telemetry-native
 )
 
 cd Carthage/Checkouts/

--- a/carthage-prebuild
+++ b/carthage-prebuild
@@ -1,7 +1,6 @@
 packages=(
   algoliasearch-client-swift
   swift-log
-  instantsearch-ios
 )
 
 cd Carthage/Checkouts/
@@ -11,6 +10,9 @@ for package in "${packages[@]}"; do
   cd ..
 done
 cd instantsearch-telemetry-native
+swift package resolve
+cd ..
+cd instantsearch-ios
 swift package resolve
 cd ..
 cd ../../..

--- a/carthage-prebuild
+++ b/carthage-prebuild
@@ -1,6 +1,7 @@
 packages=(
   algoliasearch-client-swift
   swift-log
+  instantsearch-ios
 )
 
 cd Carthage/Checkouts/

--- a/carthage-prebuild
+++ b/carthage-prebuild
@@ -9,8 +9,8 @@ for package in "${packages[@]}"; do
   swift package generate-xcodeproj
   cd ..
 done
+cd instantsearch-telemetry-native
+swift package resolve
+cd ..
 cd ../../..
 
-cd Carthage/Checkouts/instantsearch-telemetry-native
-swift package resolve
-cd ../../..

--- a/carthage-prebuild
+++ b/carthage-prebuild
@@ -10,3 +10,7 @@ for package in "${packages[@]}"; do
   cd ..
 done
 cd ../../..
+
+cd Carthage/Checkouts/instantsearch-telemetry-native
+swift package resolve
+cd ../../..


### PR DESCRIPTION
**Summary**

Starting from version 7.16.0 and due to change in the Swift Package Manager project generation behaviour, it's impossible to build InstantSearch using Carthage dependency manager.

Fix #218 

**Result**

Latest InstantSearch version builds successfully with Carthage. 
