### PR TITLE
fix: SwiftUI infinite scrolling issue

### DIFF
--- a/Sources/InstantSearchCore/Hits/HitsInteractor.swift
+++ b/Sources/InstantSearchCore/Hits/HitsInteractor.swift
@@ -101,7 +101,7 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
       return hitsPageMap.count
     }
   }
-  
+
   /// Map hits pages into the list of hits. The hits contained by pages unloaded from memory are represented as nil values.
   public var hits: [Record?] {
     guard let pageMap = paginator.pageMap else { return [] }

--- a/Sources/InstantSearchCore/Hits/HitsInteractor.swift
+++ b/Sources/InstantSearchCore/Hits/HitsInteractor.swift
@@ -101,6 +101,12 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
       return hitsPageMap.count
     }
   }
+  
+  /// Map hits pages into the list of hits. The hits contained by pages unloaded from memory are represented as nil values.
+  public var hits: [Record?] {
+    guard let pageMap = paginator.pageMap else { return [] }
+    return Array(pageMap)
+  }
 
   public func hit(atIndex index: Int) -> Record? {
     guard let hitsPageMap = paginator.pageMap else { return nil }

--- a/Sources/InstantSearchSwiftUI/DataModel/HitsObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/HitsObservableController.swift
@@ -29,7 +29,7 @@ public class HitsObservableController<Hit: Codable>: ObservableObject, HitsContr
   }
 
   public func reload() {
-    self.hits = hitsSource?.getCurrentHits() ?? []
+    self.hits = hitsSource?.hits ?? []
   }
 
   /// Function to call on hit appearance  to ensure the infinite scrolling functionality

--- a/Tests/InstantSearchCoreTests/Unit/PageMapTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/PageMapTests.swift
@@ -101,6 +101,35 @@ class PageMapTests: XCTestCase {
     XCTAssertEqual(updatedPageMap.count, 6)
 
   }
+  
+  func testArrayTransformationEmptyMiddlePage() {
+    let p0 = ["i4", "i5", "i6"]
+    let p1 = ["i7", "i8", "i9"]
+    let p2 = ["i10", "i11", "i12"]
+
+    var pageMap = PageMap(p0)!
+    pageMap.insert(p1, withIndex: 1)
+    pageMap.insert(p2, withIndex: 2)
+    pageMap.removePage(atIndex: 1)
+    
+    let array = Array(pageMap)
+    XCTAssertEqual(array, ["i4", "i5", "i6", nil, nil, nil, "i10", "i11", "i12"])
+  }
+  
+  func testArrayTransformationEmptyFirstPage() {
+    let p0 = ["i4", "i5", "i6"]
+    let p1 = ["i7", "i8", "i9"]
+    let p2 = ["i10", "i11", "i12"]
+
+    var pageMap = PageMap(p0)!
+    pageMap.insert(p1, withIndex: 1)
+    pageMap.insert(p2, withIndex: 2)
+    pageMap.removePage(atIndex: 0)
+    
+    let array = Array(pageMap)
+    XCTAssertEqual(array, [nil, nil, nil, "i7", "i8", "i9", "i10", "i11", "i12"])
+  }
+
 
   func testInsertionKeepingMissingPage() {
 

--- a/Tests/InstantSearchCoreTests/Unit/PageMapTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/PageMapTests.swift
@@ -101,7 +101,7 @@ class PageMapTests: XCTestCase {
     XCTAssertEqual(updatedPageMap.count, 6)
 
   }
-  
+
   func testInsertionKeepingMissingPage() {
 
     let p0 = ["i4", "i5", "i6"]

--- a/Tests/InstantSearchCoreTests/Unit/PageMapTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/PageMapTests.swift
@@ -102,35 +102,6 @@ class PageMapTests: XCTestCase {
 
   }
   
-  func testArrayTransformationEmptyMiddlePage() {
-    let p0 = ["i4", "i5", "i6"]
-    let p1 = ["i7", "i8", "i9"]
-    let p2 = ["i10", "i11", "i12"]
-
-    var pageMap = PageMap(p0)!
-    pageMap.insert(p1, withIndex: 1)
-    pageMap.insert(p2, withIndex: 2)
-    pageMap.removePage(atIndex: 1)
-    
-    let array = Array(pageMap)
-    XCTAssertEqual(array, ["i4", "i5", "i6", nil, nil, nil, "i10", "i11", "i12"])
-  }
-  
-  func testArrayTransformationEmptyFirstPage() {
-    let p0 = ["i4", "i5", "i6"]
-    let p1 = ["i7", "i8", "i9"]
-    let p2 = ["i10", "i11", "i12"]
-
-    var pageMap = PageMap(p0)!
-    pageMap.insert(p1, withIndex: 1)
-    pageMap.insert(p2, withIndex: 2)
-    pageMap.removePage(atIndex: 0)
-    
-    let array = Array(pageMap)
-    XCTAssertEqual(array, [nil, nil, nil, "i7", "i8", "i9", "i10", "i11", "i12"])
-  }
-
-
   func testInsertionKeepingMissingPage() {
 
     let p0 = ["i4", "i5", "i6"]


### PR DESCRIPTION
**Summary**

The existing implementation of `HitsObservableController` uses `getCurrentHits` function  of `HitsInteractor` to build an observable list of hits. That's why the infinite scrolling didn't work correctly due optimization which keeps only 4 most recents pages of hits in memory. 
This PR adds `hits` computed property in `HitsInteractor` which ensures the correct hits pages to hits list by presenting the hits of unloaded pages as `nil` values.  


**Result**

Inifinite scrolling works correctly with `HitsObservableController`. 