### PR TITLE
chore: deprecate Boundable <-> Search Result Provider connection

### DIFF
--- a/Examples/Showcase/Filter/FilterNumericRange/FilterNumericRangeDemoController.swift
+++ b/Examples/Showcase/Filter/FilterNumericRange/FilterNumericRangeDemoController.swift
@@ -15,7 +15,9 @@ class FilterNumericRangeDemoController {
   let filterState: FilterState
   let filterClearConnector: FilterClearConnector
 
+  let searchBoxConnector: SearchBoxConnector
   let rangeConnector: NumberRangeConnector<Double>
+  let statsConnector: StatsConnector
 
   init() {
     self.searcher = HitsSearcher(client: .instantSearch,
@@ -25,9 +27,10 @@ class FilterNumericRangeDemoController {
     rangeConnector = .init(searcher: searcher,
                            filterState: filterState,
                            attribute: "price")
+    statsConnector = .init(searcher: searcher)
+    searchBoxConnector = .init(searcher: searcher)
     searcher.connectFilterState(filterState)
     searcher.search()
-
   }
 
 }

--- a/Examples/Showcase/Filter/FilterNumericRange/FilterNumericRangeDemoViewController.swift
+++ b/Examples/Showcase/Filter/FilterNumericRange/FilterNumericRangeDemoViewController.swift
@@ -12,14 +12,20 @@ import InstantSearch
 
 class FilterNumericRangeDemoViewController: UIViewController {
 
+  let searchController: UISearchController
   let demoController: FilterNumericRangeDemoController
+  let statsController: LabelStatsController
   let numericRangeController: NumericRangeController
   let filterDebugViewController: FilterDebugViewController
+  let searchBoxController: TextFieldController
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    searchController = UISearchController()
     demoController = .init()
     numericRangeController = NumericRangeController(rangeSlider: .init())
     filterDebugViewController = FilterDebugViewController(filterState: demoController.filterState)
+    statsController = LabelStatsController()
+    searchBoxController = TextFieldController(searchBar: searchController.searchBar)
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }
 
@@ -38,9 +44,13 @@ class FilterNumericRangeDemoViewController: UIViewController {
 private extension FilterNumericRangeDemoViewController {
 
   func setup() {
+    navigationItem.searchController = searchController
     addChild(filterDebugViewController)
     filterDebugViewController.didMove(toParent: self)
+    demoController.searchBoxConnector.connectController(searchBoxController)
+    demoController.statsConnector.connectController(statsController)
     demoController.rangeConnector.connectController(numericRangeController)
+    demoController.rangeConnector.interactor.connectSearcher(demoController.searcher, attribute: "price")
     demoController.filterClearConnector.connectController(filterDebugViewController.clearFilterController)
   }
 
@@ -57,6 +67,7 @@ private extension FilterNumericRangeDemoViewController {
     searchDebugView.translatesAutoresizingMaskIntoConstraints = false
     searchDebugView.heightAnchor.constraint(equalToConstant: 150).isActive = true
     mainStackView.addArrangedSubview(searchDebugView)
+    mainStackView.addArrangedSubview(statsController.label)
     mainStackView.addArrangedSubview(numericRangeController.view)
     mainStackView.addArrangedSubview(.spacer)
     view.addSubview(mainStackView)

--- a/InstantSearch.xcodeproj/project.pbxproj
+++ b/InstantSearch.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		40B737ED287F923000323B26 /* Boundable+HitsSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B737EC287F923000323B26 /* Boundable+HitsSearcher.swift */; };
 		OBJ_1175 /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_757 /* AsyncOperation.swift */; };
 		OBJ_1176 /* WaitTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_758 /* WaitTask.swift */; };
 		OBJ_1177 /* AccountClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_760 /* AccountClient.swift */; };
@@ -568,7 +569,6 @@
 		OBJ_1744 /* FilterComparisonConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* FilterComparisonConnector.swift */; };
 		OBJ_1745 /* FilterComparison+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* FilterComparison+Controller.swift */; };
 		OBJ_1746 /* FilterComparison+FilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* FilterComparison+FilterState.swift */; };
-		OBJ_1747 /* FilterComparisonComputeBounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* FilterComparisonComputeBounds.swift */; };
 		OBJ_1748 /* NumberController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_298 /* NumberController.swift */; };
 		OBJ_1749 /* NumberInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* NumberInteractor.swift */; };
 		OBJ_1750 /* NumberRangeConnector+Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_302 /* NumberRangeConnector+Controller.swift */; };
@@ -1333,6 +1333,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		40B737EC287F923000323B26 /* Boundable+HitsSearcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Boundable+HitsSearcher.swift"; sourceTree = "<group>"; };
 		OBJ_10 /* MultiIndexSearchConnector+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexSearchConnector+UIKit.swift"; sourceTree = "<group>"; };
 		OBJ_1000 /* SnippetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetResult.swift; sourceTree = "<group>"; };
 		OBJ_1001 /* IndexName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexName.swift; sourceTree = "<group>"; };
@@ -1633,7 +1634,6 @@
 		OBJ_294 /* FilterComparisonConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterComparisonConnector.swift; sourceTree = "<group>"; };
 		OBJ_295 /* FilterComparison+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterComparison+Controller.swift"; sourceTree = "<group>"; };
 		OBJ_296 /* FilterComparison+FilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterComparison+FilterState.swift"; sourceTree = "<group>"; };
-		OBJ_297 /* FilterComparisonComputeBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterComparisonComputeBounds.swift; sourceTree = "<group>"; };
 		OBJ_298 /* NumberController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberController.swift; sourceTree = "<group>"; };
 		OBJ_299 /* NumberInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberInteractor.swift; sourceTree = "<group>"; };
 		OBJ_302 /* NumberRangeConnector+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberRangeConnector+Controller.swift"; sourceTree = "<group>"; };
@@ -3248,12 +3248,12 @@
 		OBJ_289 /* Number */ = {
 			isa = PBXGroup;
 			children = (
+				40B737EC287F923000323B26 /* Boundable+HitsSearcher.swift */,
 				OBJ_290 /* Boundable+SearchResultProvider.swift */,
 				OBJ_291 /* Computation.swift */,
 				OBJ_292 /* Connector */,
 				OBJ_295 /* FilterComparison+Controller.swift */,
 				OBJ_296 /* FilterComparison+FilterState.swift */,
-				OBJ_297 /* FilterComparisonComputeBounds.swift */,
 				OBJ_298 /* NumberController.swift */,
 				OBJ_299 /* NumberInteractor.swift */,
 			);
@@ -3809,7 +3809,7 @@
 			path = View;
 			sourceTree = "<group>";
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -3831,7 +3831,6 @@
 				OBJ_1168 /* Gemfile.lock */,
 				OBJ_1169 /* generate_version */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_509 /* Tests */ = {
@@ -5431,7 +5430,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_1144 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -5888,6 +5887,7 @@
 				OBJ_1611 /* DynamicFacetListConnector.swift in Sources */,
 				OBJ_1612 /* DynamicFacetListController.swift in Sources */,
 				OBJ_1613 /* DynamicFacetListInteractor+Controller.swift in Sources */,
+				40B737ED287F923000323B26 /* Boundable+HitsSearcher.swift in Sources */,
 				OBJ_1614 /* DynamicFacetListInteractor+FilterState.swift in Sources */,
 				OBJ_1615 /* DynamicFacetListInteractor+Searcher.swift in Sources */,
 				OBJ_1616 /* DynamicFacetListInteractor.swift in Sources */,
@@ -6021,7 +6021,6 @@
 				OBJ_1744 /* FilterComparisonConnector.swift in Sources */,
 				OBJ_1745 /* FilterComparison+Controller.swift in Sources */,
 				OBJ_1746 /* FilterComparison+FilterState.swift in Sources */,
-				OBJ_1747 /* FilterComparisonComputeBounds.swift in Sources */,
 				OBJ_1748 /* NumberController.swift in Sources */,
 				OBJ_1749 /* NumberInteractor.swift in Sources */,
 				OBJ_1750 /* NumberRangeConnector+Controller.swift in Sources */,

--- a/Sources/InstantSearchCore/Number/Boundable+HitsSearcher.swift
+++ b/Sources/InstantSearchCore/Number/Boundable+HitsSearcher.swift
@@ -1,5 +1,5 @@
 //
-//  FilterComparisonComputeBounds.swift
+//  Boundable+HitsSearcher.swift
 //  InstantSearchCore
 //
 //  Created by Guy Daher on 04/06/2019.

--- a/Sources/InstantSearchCore/Number/Boundable+SearchResultProvider.swift
+++ b/Sources/InstantSearchCore/Number/Boundable+SearchResultProvider.swift
@@ -15,6 +15,7 @@ public protocol FacetStatsProvider {
 
 extension SearchResponse: FacetStatsProvider {}
 
+@available(*, deprecated, message: "use BoundableHitsSearcherConnection")
 public struct BoundableSearchResultProvderConnection<B: Boundable, SearchResponseProvider: SearchResultObservable>: Connection where SearchResponseProvider.SearchResult: FacetStatsProvider {
 
   public let boundable: B
@@ -23,7 +24,7 @@ public struct BoundableSearchResultProvderConnection<B: Boundable, SearchRespons
 
   public func connect() {
     let attribute = self.attribute
-    searchResultProvider.onResults.subscribePast(with: boundable) { boundable, searchResult in
+    searchResultProvider.onResults.subscribePastOnce(with: boundable) { boundable, searchResult in
       boundable.computeBoundsFromFacetStats(attribute: attribute, facetStats: searchResult.facetStats)
     }
   }
@@ -36,6 +37,7 @@ public struct BoundableSearchResultProvderConnection<B: Boundable, SearchRespons
 
 extension Boundable {
 
+  @available(*, deprecated, message: "use connectSearcher(_ searcher: HitsSearcher, attribute: Attribute)")
   @discardableResult public func connect<SearchResponseProvider>(_ searchResultProvider: SearchResponseProvider, attribute: Attribute) -> BoundableSearchResultProvderConnection<Self, SearchResponseProvider> {
     let connection = BoundableSearchResultProvderConnection(boundable: self, searchResultProvider: searchResultProvider, attribute: attribute)
     connection.connect()


### PR DESCRIPTION
**Summary**

- Deprecate the unused  `BoundableSearchResultProvderConnection` to remove the ambiguity with `BoundableHitsSearcherConnection `.
-  Make the Number Range Demo more interactive by adding the search bar and stats