### PR TITLE
Expose text field background color to enable dark mode support

### DIFF
--- a/Sources/InstantSearchSwiftUI/View/SearchBar.swift
+++ b/Sources/InstantSearchSwiftUI/View/SearchBar.swift
@@ -21,6 +21,10 @@ public struct SearchBar: View {
 
   /// Whether the search bar is in the editing state
   @Binding public var isEditing: Bool
+    
+  /// Customizable background color for the main text field
+  @State public var searchBarBackgroundColor =
+    Color(.sRGB, red: 239/255, green: 239/255, blue: 240/255, opacity: 1)
 
   private let placeholder: String
   private var onSubmit: () -> Void
@@ -66,15 +70,15 @@ public struct SearchBar: View {
       .onTapGesture {
         isEditing = true
       }
-      .background(Color(.sRGB, red: 239/255, green: 239/255, blue: 240/255, opacity: 1))
+      .background(searchBarBackgroundColor)
       .cornerRadius(10)
       if isEditing {
-        Button(action: {
-                isEditing = false
-               },
-               label: {
-                Text("Cancel")
-               })
+          
+        Button<Text> {
+          isEditing = false
+        } label: {
+          Text("Cancel")
+        }
         .padding(.trailing, 10)
         .transition(.move(edge: .trailing))
         .animation(.default)


### PR DESCRIPTION
**Summary**

The text field background color for the main search bar component is not dark mode aware, so this PR exposes that color for 3rd party developers to override and customize.

**Result**

The Xcode project in this repository seems to require special local configuration in order to build from the project file, so I opened the `Package.swift` file and made sure the changes built using the package declarations (which it did).

Also I made a minor update to specify the generic type of the button label in order to satisfy Swift's compiler in Xcode 13.4.1  which could not figure out the Button's label type. If you find this unnecessary I'm happy to remove it.

