### PR TITLE
chore: update fastlane action and make it verbose

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,8 @@ jobs:
           ruby-version: '2.7.2'
           bundler-cache: true
       - uses: actions/checkout@v2
-      - uses: maierj/fastlane-action@v2.0.1
+      - uses: maierj/fastlane-action@v2.2.1
         with:
           lane: 'deploy'
+          verbose: 'true'
           options: '{ "type": "${{ env.RELEASE_TYPE }}" }'


### PR DESCRIPTION
**Summary**

- Update fastlane action version to 2.2.1 supporting verbose output
- Make the fastlane step output verbose