### PR TITLE
fix(hierarchical): Hierarchical facets clearing

### DIFF
--- a/Sources/InstantSearchCore/FilterState/GroupStorage.swift
+++ b/Sources/InstantSearchCore/FilterState/GroupStorage.swift
@@ -147,7 +147,9 @@ extension GroupsStorage: FiltersWritable {
     for groupID in groupIDs {
       switch groupID {
       case .hierarchical:
-        filterGroups[groupID] = filterGroups[groupID]?.withFilters([])
+        var cleanHierarchicalGroup = filterGroups[groupID]?.withFilters([]) as! FilterGroup.Hierarchical
+        cleanHierarchicalGroup.hierarchicalFilters.removeAll()
+        filterGroups[groupID] = cleanHierarchicalGroup
       default:
         filterGroups.removeValue(forKey: groupID)
       }
@@ -182,7 +184,7 @@ extension GroupsStorage: FiltersWritable {
   }
 
   mutating func removeAll() {
-    filterGroups.removeAll()
+    removeAll(fromGroupWithIDs: Array(getGroupIDs()))
   }
 
 }

--- a/Sources/InstantSearchCore/FilterState/GroupStorage.swift
+++ b/Sources/InstantSearchCore/FilterState/GroupStorage.swift
@@ -147,9 +147,10 @@ extension GroupsStorage: FiltersWritable {
     for groupID in groupIDs {
       switch groupID {
       case .hierarchical:
-        var cleanHierarchicalGroup = filterGroups[groupID]?.withFilters([]) as! FilterGroup.Hierarchical
-        cleanHierarchicalGroup.hierarchicalFilters.removeAll()
-        filterGroups[groupID] = cleanHierarchicalGroup
+        if var cleanHierarchicalGroup = filterGroups[groupID]?.withFilters([]) as? FilterGroup.Hierarchical {
+          cleanHierarchicalGroup.hierarchicalFilters.removeAll()
+          filterGroups[groupID] = cleanHierarchicalGroup
+        }
       default:
         filterGroups.removeValue(forKey: groupID)
       }

--- a/Sources/InstantSearchCore/Hierarchical/HierarchicalInteractor+FilterState.swift
+++ b/Sources/InstantSearchCore/Hierarchical/HierarchicalInteractor+FilterState.swift
@@ -39,8 +39,10 @@ public extension HierarchicalInteractor {
 
       }
 
-      filterState.onChange.subscribePast(with: interactor) { _, _ in
-        // TODO
+      filterState.onChange.subscribePast(with: interactor) { interactor, filterState in
+        if filterState[hierarchical: groupName].isEmpty {
+          interactor.selections = []
+        }
       }
 
     }


### PR DESCRIPTION
**Summary**

Clearing of `FilterState` using Clear Filters widget doesn't correctly reset the hierarchical group, causing the incorrect state for future searches and crashes. 
This PR fixes the clearing logic.

Fix #251 