### PR TITLE
feat(HitsInteractor): ability to set a custom json decoder to hits interactor

### DIFF
--- a/Sources/InstantSearchCore/Hits/HitsExtractable.swift
+++ b/Sources/InstantSearchCore/Hits/HitsExtractable.swift
@@ -10,26 +10,33 @@ import Foundation
 
 public protocol HitsExtractable {
 
-  func extractHits<T: Decodable>() throws -> [T]
+  func extractHits<T: Decodable>(jsonDecoder: JSONDecoder) throws -> [T]
 
 }
 
-extension SearchResponse: HitsExtractable {}
+extension SearchResponse: HitsExtractable {
+  
+  public func extractHits<T>(jsonDecoder: JSONDecoder) throws -> [T] where T: Decodable {
+    let hitsData = try JSONEncoder().encode(hits)
+    return try jsonDecoder.decode([T].self, from: hitsData)
+  }
+  
+}
 
 extension PlacesResponse: HitsExtractable {
 
-  public func extractHits<T>() throws -> [T] where T: Decodable {
+  public func extractHits<T>(jsonDecoder: JSONDecoder) throws -> [T] where T: Decodable {
     let hitsData = try JSONEncoder().encode(hits)
-    return try JSONDecoder().decode([T].self, from: hitsData)
+    return try jsonDecoder.decode([T].self, from: hitsData)
   }
 
 }
 
 extension FacetSearchResponse: HitsExtractable {
 
-  public func extractHits<T>() throws -> [T] where T: Decodable {
+  public func extractHits<T>(jsonDecoder: JSONDecoder) throws -> [T] where T: Decodable {
     let hitsData = try JSONEncoder().encode(facetHits)
-    return try JSONDecoder().decode([T].self, from: hitsData)
+    return try jsonDecoder.decode([T].self, from: hitsData)
   }
 
 }

--- a/Sources/InstantSearchCore/Hits/HitsExtractable.swift
+++ b/Sources/InstantSearchCore/Hits/HitsExtractable.swift
@@ -15,12 +15,12 @@ public protocol HitsExtractable {
 }
 
 extension SearchResponse: HitsExtractable {
-  
+
   public func extractHits<T>(jsonDecoder: JSONDecoder) throws -> [T] where T: Decodable {
     let hitsData = try JSONEncoder().encode(hits)
     return try jsonDecoder.decode([T].self, from: hitsData)
   }
-  
+
 }
 
 extension PlacesResponse: HitsExtractable {

--- a/Sources/InstantSearchCore/Hits/HitsInteractor.swift
+++ b/Sources/InstantSearchCore/Hits/HitsInteractor.swift
@@ -56,7 +56,7 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
       paginator.pageCleanUpOffset = newValue
     }
   }
-  
+
   /// JSONDecoder used for hits decoding from the search response
   public var jsonDecoder: JSONDecoder
 

--- a/Sources/InstantSearchCore/Pagination/SearchResults+PageMap.swift
+++ b/Sources/InstantSearchCore/Pagination/SearchResults+PageMap.swift
@@ -27,9 +27,9 @@ struct HitsPage<Item: Codable>: Pageable {
 
 extension HitsPage {
 
-  init(searchResults: HitsExtractable & SearchStatsConvertible) throws {
+  init(searchResults: HitsExtractable & SearchStatsConvertible, jsonDecoder: JSONDecoder) throws {
     self.index = searchResults.searchStats.page
-    self.items = try searchResults.extractHits()
+    self.items = try searchResults.extractHits(jsonDecoder: jsonDecoder)
   }
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorControllerConnectionTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorControllerConnectionTests.swift
@@ -15,7 +15,7 @@ class HitsInteractorControllerConnectionTests: XCTestCase {
   var interactor: HitsInteractor<JSON> {
     return HitsInteractor<JSON>(settings: .init(infiniteScrolling: .on(withOffset: 10), showItemsOnEmptyQuery: true),
           paginationController: .init(),
-    infiniteScrollingController: TestInfiniteScrollingController())
+    infiniteScrollingController: TestInfiniteScrollingController(), jsonDecoder: JSONDecoder())
   }
   
   weak var disposableController: TestHitsController<JSON>?


### PR DESCRIPTION
**Summary**

Currently `HitsInteractor` supports only the camel case case since it uses the default `JSONDecoder` constructor, so the client might add `CodingKeys` per model to support snake case.

**Result**

`HitsInteractor` provides `jsonDecoder` property which can be set in the initialiser or as property, so it's possible to set a custom decoder for hits. 

Fix #247 