### PR TITLE
fix(Searcher): set open access level  for AbstractSearcher and IndexSearcher 

### DIFF
--- a/Sources/InstantSearchCore/Searcher/AbstractSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/AbstractSearcher.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Abstract search business logic
-public class AbstractSearcher<Service: SearchService>: Searcher, SequencerDelegate, SearchResultObservable, ErrorObservable where Service.Process == Operation {
+open class AbstractSearcher<Service: SearchService>: Searcher, SequencerDelegate, SearchResultObservable, ErrorObservable where Service.Process == Operation {
 
   public typealias Request = Service.Request
   public typealias Result = Service.Result

--- a/Sources/InstantSearchCore/Searcher/IndexSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/IndexSearcher.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Abstract search service the request of which includes IndexName
-public class IndexSearcher<Service: SearchService>: AbstractSearcher<Service> where Service.Process == Operation, Service.Request: IndexNameProvider {
+open class IndexSearcher<Service: SearchService>: AbstractSearcher<Service> where Service.Process == Operation, Service.Request: IndexNameProvider {
 
   public override var request: Request {
     didSet {


### PR DESCRIPTION
**Summary**

The `IndexSearcher` might be open, so users can subclass it with a custom `SearchService` for backend search implementation.
The `AbstractSearcher` might be open as well as a superclass of `IndexSearcher`.   
