### PR TITLE
fix(HitsInteractor): Missing propagation of json decoder property to designated initializer

### DIFF
--- a/Sources/InstantSearchCore/Hits/HitsInteractor.swift
+++ b/Sources/InstantSearchCore/Hits/HitsInteractor.swift
@@ -60,12 +60,12 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
   /// JSONDecoder used for hits decoding from the search response
   public var jsonDecoder: JSONDecoder
 
-  convenience public init(infiniteScrolling: InfiniteScrolling = Constants.Defaults.infiniteScrolling,
+  public convenience init(infiniteScrolling: InfiniteScrolling = Constants.Defaults.infiniteScrolling,
                           showItemsOnEmptyQuery: Bool = Constants.Defaults.showItemsOnEmptyQuery,
                           jsonDecoder: JSONDecoder = JSONDecoder()) {
     let settings = Settings(infiniteScrolling: infiniteScrolling,
                             showItemsOnEmptyQuery: showItemsOnEmptyQuery)
-    self.init(settings: settings)
+    self.init(settings: settings, jsonDecoder: jsonDecoder)
   }
 
   public convenience init(settings: Settings? = nil,


### PR DESCRIPTION
**Summary**

Add missing propagation of the json decoder parameter from the convenient initialiser to designated initialiser. 