### PR TITLE
fix: update `orderedFacets` of `DynamicFacetListInteractor` ignores `disjunctiveFacets`

### DIFF
--- a/Sources/InstantSearchCore/DynamicFacets/AttributedFacets.swift
+++ b/Sources/InstantSearchCore/DynamicFacets/AttributedFacets.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// List of ordered facets with their attribute.
-public struct AttributedFacets: Codable {
+public struct AttributedFacets: Codable, Equatable {
 
   /// Facet attribute
   public let attribute: Attribute

--- a/Sources/InstantSearchCore/DynamicFacets/DynamicFacetListInteractor+Searcher.swift
+++ b/Sources/InstantSearchCore/DynamicFacets/DynamicFacetListInteractor+Searcher.swift
@@ -58,7 +58,7 @@ public extension DynamicFacetListInteractor {
 }
 
 extension DynamicFacetListInteractor {
-  
+
   /// Update `orderedFacets` property with `renderingContent` and
   /// `facets`/`disjunctiveFacets` received of the `SearchResponse` instance
   public func update(with searchResponse: SearchResponse) {
@@ -68,8 +68,8 @@ extension DynamicFacetListInteractor {
     }
     let commonFacets = searchResponse.facets ?? [:]
     let disjunctiveFacets = searchResponse.disjunctiveFacets ?? [:]
-    let facets = disjunctiveFacets.merging(commonFacets, uniquingKeysWith: { df, cf in df })
+    let facets = disjunctiveFacets.merging(commonFacets, uniquingKeysWith: { df, _ in df })
     orderedFacets = FacetsOrderer(facetOrder: facetOrdering, facets: facets)()
   }
-  
+
 }

--- a/Sources/InstantSearchCore/DynamicFacets/DynamicFacetListInteractor+Searcher.swift
+++ b/Sources/InstantSearchCore/DynamicFacets/DynamicFacetListInteractor+Searcher.swift
@@ -68,7 +68,7 @@ extension DynamicFacetListInteractor {
     }
     let commonFacets = searchResponse.facets ?? [:]
     let disjunctiveFacets = searchResponse.disjunctiveFacets ?? [:]
-    let facets = disjunctiveFacets.merging(commonFacets, uniquingKeysWith: { df, _ in df })
+    let facets = disjunctiveFacets.merging(commonFacets, uniquingKeysWith: { disjunctiveFacets, _ in disjunctiveFacets })
     orderedFacets = FacetsOrderer(facetOrder: facetOrdering, facets: facets)()
   }
 

--- a/Tests/InstantSearchCoreTests/Unit/DynamicFacets/DynamicFacetListInteractorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/DynamicFacets/DynamicFacetListInteractorTests.swift
@@ -1,0 +1,55 @@
+//
+//  DynamicFacetListInteractorTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 12/10/2022.
+//
+
+import Foundation
+@testable import InstantSearchCore
+import XCTest
+
+class DynamicFacetListInteractorTests: XCTestCase {
+  
+  func testDisjunctiveFacetsPropagation() {
+    let interactor = DynamicFacetListInteractor()
+    
+    func facets(of raw: (String, Int)...) -> [Facet] {
+      raw.map { Facet(value: $0.0, count: $0.1) }
+    }
+    
+    var response = SearchResponse()
+        
+    response.facets = [
+      "size": facets(of: ("s", 10)),
+      "brand": facets(of: ("samsung", 5), ("sony", 4), ("philips", 12)),
+    ]
+    response.disjunctiveFacets = [
+      "size": facets(of: ("s", 10), ("m", 20), ("l", 30), ("xl", 40)),
+      "color": facets(of: ("red", 5), ("green", 10), ("blue", 15))
+    ]
+    response.renderingContent = try! RenderingContent(json: [
+      "facetOrdering": [
+        "facets": [
+          "order": [
+            "color",
+            "size",
+            "brand",
+          ],
+        ],
+      ],
+    ])
+    
+    interactor.update(with: response)
+    
+    XCTAssertEqual(interactor.orderedFacets.count, 3)
+    XCTAssertTrue(interactor.orderedFacets.contains(AttributedFacets(attribute: "size",
+                                                                     facets: facets(of: ("s", 10), ("m", 20), ("l", 30), ("xl", 40)))))
+    XCTAssertTrue(interactor.orderedFacets.contains(AttributedFacets(attribute: "brand",
+                                                                     facets: facets(of: ("samsung", 5), ("sony", 4), ("philips", 12)))))
+    XCTAssertTrue(interactor.orderedFacets.contains(AttributedFacets(attribute: "color",
+                                                                     facets: facets(of: ("red", 5), ("green", 10), ("blue", 15)))))
+
+  }
+  
+}


### PR DESCRIPTION
**Summary**

The disjunctive faceting doesn't work correctly with `DynamicFacetList` properly configured for disjunctive faceting. 
This happens due to ignoring the `disjunctiveFacets` property of the `SearchResponse` which contains the proper facet values when disjunctive faceting applied. 


**Result**

The disjunctive faceting with `DynamicFacetList` works correctly. 
Backed by unit test.
