### PR TITLE
fix(multi-search): crash in case of requests-results count mismatch

### DIFF
--- a/Sources/InstantSearchCore/Helper/Array+Ranges.swift
+++ b/Sources/InstantSearchCore/Helper/Array+Ranges.swift
@@ -7,9 +7,8 @@
 
 import Foundation
 
-
 extension Array where Element: RandomAccessCollection, Element.Index == Int {
-  
+
   /// Maps the nested lists to the ranges corresponding to the positions of the nested list elements in the flatten list
   /// Example: [["a", "b", "c"], ["d", "e"], ["f", "g", "h"]] -> [0..<3, 3..<5, 5..<8]
   func flatRanges() -> [Range<Int>] {
@@ -23,5 +22,5 @@ extension Array where Element: RandomAccessCollection, Element.Index == Int {
     }
     return ranges
   }
-  
+
 }

--- a/Sources/InstantSearchCore/Helper/Array+Ranges.swift
+++ b/Sources/InstantSearchCore/Helper/Array+Ranges.swift
@@ -1,0 +1,27 @@
+//
+//  Array+Ranges.swift
+//  
+//
+//  Created by Vladislav Fitc on 26/10/2022.
+//
+
+import Foundation
+
+
+extension Array where Element: RandomAccessCollection, Element.Index == Int {
+  
+  /// Maps the nested lists to the ranges corresponding to the positions of the nested list elements in the flatten list
+  /// Example: [["a", "b", "c"], ["d", "e"], ["f", "g", "h"]] -> [0..<3, 3..<5, 5..<8]
+  func flatRanges() -> [Range<Int>] {
+    var ranges: [Range<Int>] = []
+    var offset: Int = 0
+    for sublist in self {
+      let nextOffset = offset+sublist.count
+      let range = offset..<nextOffset
+      ranges.append(range)
+      offset = nextOffset
+    }
+    return ranges
+  }
+  
+}

--- a/Sources/InstantSearchCore/Searcher/Multi/AbstractMultiSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Multi/AbstractMultiSearcher.swift
@@ -105,7 +105,7 @@ extension AbstractMultiSearcher: FiltersSettable {
 public enum MultiSearchError: LocalizedError {
   case rangeError(Range<Int>, Range<Int>)
   case serviceError(Error)
-  
+
   var localizedDescription: String {
     switch self {
     case .serviceError(let error):

--- a/Sources/InstantSearchCore/Searcher/Multi/AbstractMultiSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Multi/AbstractMultiSearcher.swift
@@ -53,7 +53,7 @@ extension AbstractMultiSearcher: MultiSearchComponent {
           guard
             range.lowerBound <= subresults.endIndex,
             range.upperBound <= subresults.endIndex else {
-            completion(.failure(MultiSearchError.rangeError(range, subresults.startIndex..<subresults.endIndex) ))
+            completion(.failure(MultiSearchError.resultsRangeMismatch(range, subresults.startIndex..<subresults.endIndex) ))
             return
           }
           completion(.success(Array(subresults[range])))
@@ -98,21 +98,6 @@ extension AbstractMultiSearcher: FiltersSettable {
       .forEach {
         $0.setFilters(filters)
       }
-  }
-
-}
-
-public enum MultiSearchError: LocalizedError {
-  case rangeError(Range<Int>, Range<Int>)
-  case serviceError(Error)
-
-  var localizedDescription: String {
-    switch self {
-    case .serviceError(let error):
-      return "Search service error: \(error.localizedDescription)"
-    case .rangeError(let subRange, let range):
-      return "The calculated results subrange \(subRange) can't be extracted from the results list with bounds \(range)"
-    }
   }
 
 }

--- a/Sources/InstantSearchCore/Searcher/Multi/MultiSearchError.swift
+++ b/Sources/InstantSearchCore/Searcher/Multi/MultiSearchError.swift
@@ -1,0 +1,23 @@
+//
+//  MultiSearchError.swift
+//  
+//
+//  Created by Vladislav Fitc on 02/11/2022.
+//
+
+import Foundation
+
+public enum MultiSearchError: LocalizedError {
+  case resultsRangeMismatch(Range<Int>, Range<Int>)
+  case serviceError(Error)
+
+  var localizedDescription: String {
+    switch self {
+    case .serviceError(let error):
+      return "Search service error: \(error.localizedDescription)"
+    case .resultsRangeMismatch(let subRange, let range):
+      return "The calculated results subrange \(subRange) can't be extracted from the results list with bounds \(range)"
+    }
+  }
+
+}

--- a/Tests/InstantSearchCoreTests/Unit/ArrayExtensions.swift
+++ b/Tests/InstantSearchCoreTests/Unit/ArrayExtensions.swift
@@ -1,0 +1,31 @@
+//
+//  ArrayExtensionsTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 26/10/2022.
+//
+
+import Foundation
+import XCTest
+@testable import InstantSearchCore
+
+class ArrayExtensionsTests: XCTestCase {
+  
+  func testFlatRanges() {
+    let input = [["a", "b", "c"], ["d", "e"], ["f", "g", "h"]]
+    let output = [0..<3, 3..<5, 5..<8]
+    XCTAssertEqual(input.flatRanges(), output)
+    
+    XCTAssertEqual([["a"], ["b"], ["c"]].flatRanges(), [0..<1, 1..<2, 2..<3])
+    XCTAssertEqual([["a"], ["b"], []].flatRanges(), [0..<1, 1..<2, 2..<2])
+    XCTAssertEqual([["a"], [], ["c"]].flatRanges(), [0..<1, 1..<1, 1..<2])
+    XCTAssertEqual([[], [], []].flatRanges(), [0..<0, 0..<0, 0..<0])
+    XCTAssertEqual([["a", "b"], ["c"], ["d"]].flatRanges(), [0..<2, 2..<3, 3..<4])
+    XCTAssertEqual([[String]]().flatRanges(), [])
+
+    
+    print(["a", "b", "c"][3..<3])
+  }
+  
+  
+}

--- a/Tests/InstantSearchCoreTests/Unit/Searcher/MultiSearcherTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Searcher/MultiSearcherTests.swift
@@ -1,0 +1,91 @@
+//
+//  MultiSearcherTests.swift
+//  
+//
+//  Created by Vladislav Fitc on 27/10/2022.
+//
+
+import Foundation
+import XCTest
+@testable import InstantSearchCore
+
+class MultiSearcherTests: XCTestCase {
+  
+  func testResultsDistribution() {
+    let service = TestMultiSearchService()
+    let searcher = AbstractMultiSearcher(service: service,
+                                         initialRequest: .init())
+    let subSearcher = TestMultiSearchComponent()
+    subSearcher.requests = ["req1", "req2"]
+    let anotherSubSearcher = TestMultiSearchComponent()
+    anotherSubSearcher.requests = ["req3", "req4", "req5"]
+    searcher.addSearcher(subSearcher)
+    searcher.addSearcher(anotherSubSearcher)
+    
+    
+    subSearcher.completion = { result in
+      switch result {
+      case .success(let results):
+        XCTAssertEqual(results, ["res1", "res2"])
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      }
+    }
+    
+    anotherSubSearcher.completion = { result in
+      switch result {
+      case .failure(MultiSearchError.rangeError(2..<5, 0..<4)):
+        break
+      case .failure(let error):
+        XCTFail("Unexpected error: \(error)")
+      case .success(let results):
+        XCTFail("Unexpected success \(results)")
+      }
+    }
+    
+    let (_, completion) = searcher.collect()
+    
+    completion(.success(["res1", "res2", "res3", "res4"]))
+  }
+  
+}
+
+struct TestMultiRequest: MultiRequest {
+var subRequests: [String]
+
+init(subRequests: [String] = []) {
+  self.subRequests = subRequests
+}
+}
+
+struct TestMultiResult: MultiResult {
+var subResults: [String]
+
+init(subResults: [String] = []) {
+  self.subResults = subResults
+}
+}
+
+class TestMultiSearchComponent: MultiSearchComponent {
+
+var requests: [String] = []
+var completion: (Result<[String], Error>) -> Void = { _ in }
+
+init() {
+}
+
+func collect() -> (requests: [String], completion: (Result<[String], Error>) -> Void) {
+  return (requests: requests, completion: completion)
+}
+
+}
+
+class TestMultiSearchService: MultiSearchService {
+
+func search(_ request: TestMultiRequest, completion: @escaping (Swift.Result<TestMultiResult, Error>) -> Void) -> Operation {
+  return Operation()
+}
+
+}
+
+

--- a/Tests/InstantSearchCoreTests/Unit/Searcher/MultiSearcherTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Searcher/MultiSearcherTests.swift
@@ -34,7 +34,7 @@ class MultiSearcherTests: XCTestCase {
     
     anotherSubSearcher.completion = { result in
       switch result {
-      case .failure(MultiSearchError.rangeError(2..<5, 0..<4)):
+      case .failure(MultiSearchError.resultsRangeMismatch(2..<5, 0..<4)):
         break
       case .failure(let error):
         XCTFail("Unexpected error: \(error)")


### PR DESCRIPTION
**Summary**

In `AbstractMultiSearcher` during the extraction of the subranges of the results, there is no check if the subrange bounds are compatible with the results size (index out of bounds exception). In some circumstances this can provoke [a crash](https://algolia.atlassian.net/browse/CR-2158?atlOrigin=eyJpIjoiOTRmYmI5NjI4OTRlNGYyOWJjYjMwYWUxNWFjOGE4M2EiLCJwIjoiaiJ9).

**Result**

The crash conditions are checked and an error `MultiSearchError.rangeError` is thrown to prevent it. 
