### PR TITLE
Feat: adds clear function to HitsSource

### DIFF
--- a/Sources/InstantSearchCore/Hits/HitsInteractor.swift
+++ b/Sources/InstantSearchCore/Hits/HitsInteractor.swift
@@ -154,7 +154,10 @@ public class HitsInteractor<Record: Codable>: AnyHitsInteractor {
 
     infiniteScrollingController.calculatePagesAndLoad(currentRow: rowIndex, offset: pageLoadOffset, pageMap: hitsPageMap)
   }
-
+  
+  public func clear() {
+    paginator.clear()
+  }
 }
 
 extension HitsInteractor {

--- a/Sources/InstantSearchCore/Hits/HitsSource.swift
+++ b/Sources/InstantSearchCore/Hits/HitsSource.swift
@@ -14,7 +14,7 @@ public protocol HitsSource: AnyObject {
 
   func numberOfHits() -> Int
   func hit(atIndex index: Int) -> Record?
-
+  func clear()
 }
 
 extension HitsInteractor: HitsSource {}

--- a/Sources/InstantSearchCore/Pagination/Paginator.swift
+++ b/Sources/InstantSearchCore/Pagination/Paginator.swift
@@ -39,4 +39,7 @@ class Paginator<Item> {
     isInvalidated = true
   }
 
+  public func clear() {
+    pageMap = nil
+  }
 }

--- a/Sources/InstantSearchSwiftUI/DataModel/HitsObservableController.swift
+++ b/Sources/InstantSearchSwiftUI/DataModel/HitsObservableController.swift
@@ -16,9 +16,15 @@ import SwiftUI
 /// HitsController implementation adapted for usage with SwiftUI views
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public class HitsObservableController<Hit: Codable>: ObservableObject, HitsController {
-
+  
   /// List of hits itemsto present
-  @Published public var hits: [Hit?]
+  @Published public var hits: [Hit?] {
+    didSet {
+      if hits.isEmpty {
+        hitsSource?.clear()
+      }
+    }
+  }
 
   /// The state ID to assign to the scrollview presenting the hits
   @Published public var scrollID: UUID

--- a/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Hits/HitsInteractorTests.swift
@@ -235,5 +235,31 @@ class HitsInteractorTests: XCTestCase {
     waitForExpectations(timeout: 5)
     
   }
+  
+  func testClearTriggering() throws {
+    let paginationController = Paginator<TestRecord<Int>>()
+    let infiniteScrollingController = TestInfiniteScrollingController()
+    
+    let hits = (0..<20).map(TestRecord.withValue)
+    let results = SearchResponse(hits: hits)
+    
+    let vm = HitsInteractor(
+      settings: .init(showItemsOnEmptyQuery: true),
+      paginationController: paginationController,
+      infiniteScrollingController: infiniteScrollingController
+    )
+    
+    let exp = expectation(description: "on results updated")
+    
+    vm.onResultsUpdated.subscribe(with: self) { (_, _) in
+      XCTAssertEqual(vm.numberOfHits(), hits.count)
+      exp.fulfill()
+    }
+    vm.update(results)
+    waitForExpectations(timeout: 3, handler: .none)
+    
+    vm.clear()
+    XCTAssertEqual(vm.numberOfHits(), 0)
+  }
 
 }

--- a/Tests/InstantSearchCoreTests/Unit/PaginatorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/PaginatorTests.swift
@@ -93,5 +93,15 @@ class PaginatorTests: XCTestCase {
     XCTAssertEqual(paginator.pageMap?.count, 3)
 
   }
+  
+  func testClear() {
+    let paginator = Paginator<String>()
+    let page = TestPageable(index: 0, items: ["i1", "i2", "i3"])
+    paginator.process(page)
+    XCTAssertEqual(paginator.pageMap?.count, 3)
+    
+    paginator.clear()
+    XCTAssertNil(paginator.pageMap)
+  }
 
 }

--- a/Tests/InstantSearchTests/TestHitsSource.swift
+++ b/Tests/InstantSearchTests/TestHitsSource.swift
@@ -13,7 +13,7 @@ class TestHitsSource: HitsSource {
   
   typealias Hit = String
   
-  let hits: [String]
+  var hits: [String]
   
   init(hits: [String]) {
     self.hits = hits
@@ -28,4 +28,7 @@ class TestHitsSource: HitsSource {
     return hits[index]
   }
   
+  func clear() {
+    hits = []
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
This PR adds a `clear()` function to `HitsSource` protocol that can be used to clear the data source's memory, if desired.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
Motivation:
`HitsObservableController` has a `@Published public var hits: [Hit?]` property that can be set empty to show an empty result list.
For instance, we can set it empty if we want to clear the results list for any reason, and not just when a query becomes empty by leveraging the `showItemsOnEmptyQuery` property of `HitsInteractor.Settings`.

**Result**
As a result we have a reduced memory consumption when we assign an empty array to `HitsObservableController`'s hits and whenever desired.
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

I also added a couple of tests that cover the new introduced code.

I hope this can be useful and the same result is not achievable in another way, otherwise, I apologize.

Please let me know if I missed something.

Thank you
