### PR TITLE
fix: send empty events packages if all non statisfying condition

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format
+name: SwiftFormat
 on:
   push:
     branches: [master]

--- a/Sources/InstantSearchInsights/Logic/EventProcessor.swift
+++ b/Sources/InstantSearchInsights/Logic/EventProcessor.swift
@@ -158,6 +158,11 @@ private extension EventProcessor {
     logger.info("sending events package: \(eventsPackage.items)")
 
     let eligibleEvents = eventsPackage.items.filter(acceptEvent)
+    
+    guard !eligibleEvents.isEmpty else {
+      logger.info("all events in package were filtered out by the acceptance condition, no event will be sent")
+      return
+    }
 
     service.sendEvents(eligibleEvents) { [weak self] result in
 

--- a/Sources/InstantSearchInsights/Logic/EventProcessor.swift
+++ b/Sources/InstantSearchInsights/Logic/EventProcessor.swift
@@ -158,7 +158,7 @@ private extension EventProcessor {
     logger.info("sending events package: \(eventsPackage.items)")
 
     let eligibleEvents = eventsPackage.items.filter(acceptEvent)
-    
+
     guard !eligibleEvents.isEmpty else {
       logger.info("all events in package were filtered out by the acceptance condition, no event will be sent")
       return

--- a/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
@@ -218,18 +218,17 @@ class EventsProcessorTests: XCTestCase {
 
     waitForExpectations(timeout: 10, handler: nil)
   }
-  
+
   func testEventsFilteringException() throws {
     let mockService = MockEventService<Int>()
     let packageCapacity = 10
     let queue = DispatchQueue(label: "test queue")
-    
+
     let storage = TestPackageStorage<Int>()
     storage.store([try .init(items: [1, 2], capacity: 2), try .init(items: [3, 4], capacity: 2)])
 
     let acceptEvent: (Int) -> Bool = { _ in false }
-    
-    
+
     let eventsProcessor = EventProcessor(service: mockService,
                                          storage: storage,
                                          packageCapacity: packageCapacity,
@@ -241,15 +240,14 @@ class EventsProcessorTests: XCTestCase {
 
     let exp = expectation(description: "send events")
     exp.isInverted = true
-    
+
     mockService.didSendEvents = { events in
       XCTAssertTrue(events.allSatisfy(acceptEvent))
       exp.fulfill()
     }
-    
+
     eventsProcessor.flush()
-    
+
     waitForExpectations(timeout: 10, handler: nil)
   }
-  
 }

--- a/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
@@ -218,4 +218,38 @@ class EventsProcessorTests: XCTestCase {
 
     waitForExpectations(timeout: 10, handler: nil)
   }
+  
+  func testEventsFilteringException() throws {
+    let mockService = MockEventService<Int>()
+    let packageCapacity = 10
+    let queue = DispatchQueue(label: "test queue")
+    
+    let storage = TestPackageStorage<Int>()
+    storage.store([try .init(items: [1, 2], capacity: 2), try .init(items: [3, 4], capacity: 2)])
+
+    let acceptEvent: (Int) -> Bool = { _ in false }
+    
+    
+    let eventsProcessor = EventProcessor(service: mockService,
+                                         storage: storage,
+                                         packageCapacity: packageCapacity,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         acceptEvent: acceptEvent,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    let exp = expectation(description: "send events")
+    exp.isInverted = true
+    
+    mockService.didSendEvents = { events in
+      XCTAssertTrue(events.allSatisfy(acceptEvent))
+      exp.fulfill()
+    }
+    
+    eventsProcessor.flush()
+    
+    waitForExpectations(timeout: 10, handler: nil)
+  }
+  
 }


### PR DESCRIPTION
**Summary**

`EventsProcessor` of `Insights` package filters out event in package by acceptance condition (event was captured not longer than 4 days ago). 
If all events in the package don't satisfy this condition, an empty payload will be sent. 
This PR adds a check to avoid useless network calls in this case.

**Result**

No network call happens if no event satisfy the acceptance criteria