### PR TITLE
feat(HitsTracker): add automatic object ids chunking

### DIFF
--- a/Sources/InstantSearchCore/Tracker/HitsTracker.swift
+++ b/Sources/InstantSearchCore/Tracker/HitsTracker.swift
@@ -28,7 +28,7 @@ public class HitsTracker: InsightsTracker {
 
   /// An optional identifier for the search query.
   internal var queryID: QueryID?
-  
+
   /// Max object IDs per event
   private let maxObjectIDsCount = 20
 


### PR DESCRIPTION
**Summary**

If hits results page contains more than 20 hits, the hits view events automatically sent by the `HitsSearcher` are rejected by Insights. This PR adds an automatic chunking of the hits list into chunks of 20 objects to avoid this situation. 

**Result**

All the hits view events are correctly sent even if the page size is bigger than 20 hits. 