### PR TITLE
fix: update platforms versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
   name: "InstantSearch",
   platforms: [
-    .iOS(.v9),
-    .macOS(.v10_11),
-    .watchOS(.v2),
-    .tvOS(.v9)
+    .iOS(.v14),
+    .macOS(.v11),
+    .watchOS(.v7),
+    .tvOS(.v14)
   ],
   products: [
     .library(


### PR DESCRIPTION
**Summary**

Update platform versions to match those of [swift client](https://github.com/algolia/algoliasearch-client-swift/blob/996d9e171fdf4692ba279ea2f8a29acfe077ab37/Package.swift#L33-L36).

**Result**

- iOS: v9 --> v14
- macOS: v10 --> v11
- watchOS: v2 --> v7
- tvOS: v9 --> v14