### PR TITLE
fix(insights): control auto sending events w/ `isAutoSendingHitsViewEvents`

### DIFF
--- a/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
@@ -137,7 +137,7 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
                           isAutoSendingHitsViewEvents: Bool = false,
                           requestOptions: RequestOptions? = nil) {
     let client = SearchClient(appID: appID, apiKey: apiKey)
-      self.init(client: client, indexName: indexName, query: query, isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents, requestOptions: requestOptions)
+    self.init(client: client, indexName: indexName, query: query, isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents, requestOptions: requestOptions)
     Telemetry.shared.trace(type: .hitsSearcher,
                            parameters: [
                              .appID,

--- a/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
@@ -134,10 +134,10 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
                           apiKey: APIKey,
                           indexName: IndexName,
                           query: Query = .init(),
-                          isAutoSendingHitsViewEvents: Bool = false,
-                          requestOptions: RequestOptions? = nil) {
+                          requestOptions: RequestOptions? = nil,
+                          isAutoSendingHitsViewEvents: Bool = false) {
     let client = SearchClient(appID: appID, apiKey: apiKey)
-    self.init(client: client, indexName: indexName, query: query, isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents, requestOptions: requestOptions)
+    self.init(client: client, indexName: indexName, query: query, requestOptions: requestOptions, isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents)
     Telemetry.shared.trace(type: .hitsSearcher,
                            parameters: [
                              .appID,
@@ -155,8 +155,8 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
   public init(client: SearchClient,
               indexName: IndexName,
               query: Query = .init(),
-              isAutoSendingHitsViewEvents: Bool = false,
-              requestOptions: RequestOptions? = nil) {
+              requestOptions: RequestOptions? = nil,
+              isAutoSendingHitsViewEvents: Bool = false) {
     let service = AlgoliaSearchService(client: client)
     let request = AlgoliaSearchService.Request(indexName: indexName, query: query, requestOptions: requestOptions)
     super.init(service: service, initialRequest: request)
@@ -177,13 +177,14 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
    */
   public convenience init(client: SearchClient,
                           indexQueryState: IndexQueryState,
-                          isAutoSendingHitsViewEvents: Bool = false,
-                          requestOptions: RequestOptions? = nil) {
+                          requestOptions: RequestOptions? = nil,
+                          isAutoSendingHitsViewEvents: Bool = false) {
     self.init(client: client,
               indexName: indexQueryState.indexName,
               query: indexQueryState.query,
-              isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents,
-              requestOptions: requestOptions)
+              requestOptions: requestOptions,
+              isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents
+    )
   }
 
   deinit {

--- a/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
@@ -163,7 +163,7 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
     Telemetry.shared.trace(type: .hitsSearcher,
                            parameters: .client)
     onResults.subscribe(with: self) { searcher, response in
-        if (isAutoSendingHitsViewEvents) {
+        if isAutoSendingHitsViewEvents {
             searcher.eventTracker.trackView(for: response.hits, eventName: "Hits Viewed")
         }
     }

--- a/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Hits/HitsSearcher.swift
@@ -127,15 +127,17 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
        - apiKey: API Key
        - indexName: Name of the index in which search will be performed
        - query: Instance of Query. By default a new empty instant of Query will be created.
+       - isAutoSendingHitsViewEvents: flag defining whether the automatic hits view Insights events sending is enabled
        - requestOptions: Custom request options. Default is `nil`.
    */
   public convenience init(appID: ApplicationID,
                           apiKey: APIKey,
                           indexName: IndexName,
                           query: Query = .init(),
+                          isAutoSendingHitsViewEvents: Bool = false,
                           requestOptions: RequestOptions? = nil) {
     let client = SearchClient(appID: appID, apiKey: apiKey)
-    self.init(client: client, indexName: indexName, query: query, requestOptions: requestOptions)
+      self.init(client: client, indexName: indexName, query: query, isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents, requestOptions: requestOptions)
     Telemetry.shared.trace(type: .hitsSearcher,
                            parameters: [
                              .appID,
@@ -147,11 +149,13 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
     - Parameters:
        - index: Index value in which search will be performed
        - query: Instance of Query. By default a new empty instant of Query will be created.
+       - isAutoSendingHitsViewEvents: flag defining whether the automatic hits view Insights events sending is enabled
        - requestOptions: Custom request options. Default is nil.
    */
   public init(client: SearchClient,
               indexName: IndexName,
               query: Query = .init(),
+              isAutoSendingHitsViewEvents: Bool = false,
               requestOptions: RequestOptions? = nil) {
     let service = AlgoliaSearchService(client: client)
     let request = AlgoliaSearchService.Request(indexName: indexName, query: query, requestOptions: requestOptions)
@@ -159,22 +163,26 @@ public final class HitsSearcher: IndexSearcher<AlgoliaSearchService> {
     Telemetry.shared.trace(type: .hitsSearcher,
                            parameters: .client)
     onResults.subscribe(with: self) { searcher, response in
-      searcher.eventTracker.trackView(for: response.hits,
-                                     eventName: "Hits Viewed")
+        if (isAutoSendingHitsViewEvents) {
+            searcher.eventTracker.trackView(for: response.hits, eventName: "Hits Viewed")
+        }
     }
   }
 
   /**
    - Parameters:
       - indexQueryState: Instance of `IndexQueryState` encapsulating index value in which search will be performed and a `Query` instance.
+      - isAutoSendingHitsViewEvents: flag defining whether the automatic hits view Insights events sending is enabled
       - requestOptions: Custom request options. Default is nil.
    */
   public convenience init(client: SearchClient,
                           indexQueryState: IndexQueryState,
+                          isAutoSendingHitsViewEvents: Bool = false,
                           requestOptions: RequestOptions? = nil) {
     self.init(client: client,
               indexName: indexQueryState.indexName,
               query: indexQueryState.query,
+              isAutoSendingHitsViewEvents: isAutoSendingHitsViewEvents,
               requestOptions: requestOptions)
   }
 


### PR DESCRIPTION
**Summary**

Add `isAutoSendingHitsViewEvents` to `HitsSearcher`. If set to `true` insights view events are automatically sent.
The parameter defaults to `false`.

FX-2875
