### PR TITLE
fix: align versions with api client

### DIFF
--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'InstantSearch'
   s.version = '7.26.1'
-  s.platforms = { :ios => "9.0", :osx => "10.11", :watchos => "2.0", :tvos => "9.0" }
+  s.platforms = { :ios => "14.0", :osx => "11.0", :watchos => "7.0", :tvos => "14.0" }
 
   s.license = { type: 'Apache 2.0', file: 'LICENSE.md' }
   s.summary = 'A library of widgets and helpers to build instant-search applications on iOS.'

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.subspec "Insights" do |ss|
       ss.source_files = 'Sources/InstantSearchInsights/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.18'
+      ss.dependency 'Logging'
       ss.ios.deployment_target = '14.0'
       ss.osx.deployment_target = '11.0'
       ss.watchos.deployment_target = '7.0'
@@ -40,6 +41,7 @@ Pod::Spec.new do |s|
   s.subspec "UI" do |ss|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
+      ss.dependency 'Logging'
       ss.ios.deployment_target = '14.0'
       ss.osx.deployment_target = '11.0'
       ss.watchos.deployment_target = '7.0'
@@ -50,6 +52,7 @@ Pod::Spec.new do |s|
   s.subspec "SwiftUI" do |ss|
       ss.source_files = 'Sources/InstantSearchSwiftUI/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
+      ss.dependency 'Logging'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.3'
       ss.ios.deployment_target = '14.0'
       ss.osx.deployment_target = '11.0'

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -18,31 +18,32 @@ Pod::Spec.new do |s|
   s.subspec "Insights" do |ss|
       ss.source_files = 'Sources/InstantSearchInsights/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.18'
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
-      ss.watchos.deployment_target = '2.0'
-      ss.tvos.deployment_target = '9.0'
+      ss.ios.deployment_target = '14.0'
+      ss.osx.deployment_target = '11.0'
+      ss.watchos.deployment_target = '7.0'
+      ss.tvos.deployment_target = '14.0'
   end
   
   s.subspec "Core" do |ss|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.18'
+      ss.dependency 'Logging'
       ss.dependency 'InstantSearch/Insights'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.3'
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.11'
-      ss.watchos.deployment_target = '2.0'
-      ss.tvos.deployment_target = '9.0'
+      ss.ios.deployment_target = '14.0'
+      ss.osx.deployment_target = '11.0'
+      ss.watchos.deployment_target = '7.0'
+      ss.tvos.deployment_target = '14.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
   end
   
   s.subspec "UI" do |ss|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.11'
-      ss.watchos.deployment_target = '2.0'
-      ss.tvos.deployment_target = '9.0'
+      ss.ios.deployment_target = '14.0'
+      ss.osx.deployment_target = '11.0'
+      ss.watchos.deployment_target = '7.0'
+      ss.tvos.deployment_target = '14.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
   end
   
@@ -50,10 +51,10 @@ Pod::Spec.new do |s|
       ss.source_files = 'Sources/InstantSearchSwiftUI/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.3'
-      ss.ios.deployment_target = '13.0'
-      ss.osx.deployment_target = '10.15'
-      ss.watchos.deployment_target = '6.0'
-      ss.tvos.deployment_target = '13.0'
+      ss.ios.deployment_target = '14.0'
+      ss.osx.deployment_target = '11.0'
+      ss.watchos.deployment_target = '7.0'
+      ss.tvos.deployment_target = '14.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
       ss.weak_frameworks = 'SwiftUI', 'Combine'
   end

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
   name: "InstantSearch",
   platforms: [
-    .iOS(.v9),
-    .macOS(.v10_11),
-    .watchOS(.v2),
-    .tvOS(.v9)
+    .iOS(.v14),
+    .macOS(.v11),
+    .watchOS(.v7),
+    .tvOS(.v14)
   ],
   products: [
     .library(
@@ -33,6 +33,8 @@ let package = Package(
     .package(name: "AlgoliaSearchClient",
              url: "https://github.com/algolia/algoliasearch-client-swift",
              from: "8.18.2"),
+    .package(url: "https://github.com/apple/swift-log",
+             from: "1.5.4"),
     .package(name: "InstantSearchTelemetry",
              url: "https://github.com/algolia/instantsearch-telemetry-native",
              from: "0.1.3")
@@ -50,7 +52,7 @@ let package = Package(
     ),
     .target(
       name: "InstantSearchCore",
-      dependencies: ["AlgoliaSearchClient", "InstantSearchInsights", .product(name: "InstantSearchTelemetry", package: "InstantSearchTelemetry")],
+      dependencies: ["AlgoliaSearchClient", "InstantSearchInsights", .product(name: "InstantSearchTelemetry", package: "InstantSearchTelemetry"), .product(name: "Logging", package: "swift-log")],
       resources: [.copy("../PrivacyInfo.xcprivacy")]
     ),
     .testTarget(


### PR DESCRIPTION
**Summary**

This PR updates minimum supported platform versions to resolve a compatibility issue with AlgoliaSearchClient.

**Result**

Platform are synced, and library can be built correctly with latest versions of AlgoliaSearchClient.