### PR TITLE
chore: remove unnecessary dependency statements

### DIFF
--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |ss|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.18'
-      ss.dependency 'Logging'
       ss.dependency 'InstantSearch/Insights'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.3'
       ss.ios.deployment_target = '14.0'
@@ -41,7 +40,6 @@ Pod::Spec.new do |s|
   s.subspec "UI" do |ss|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
-      ss.dependency 'Logging'
       ss.ios.deployment_target = '14.0'
       ss.osx.deployment_target = '11.0'
       ss.watchos.deployment_target = '7.0'
@@ -52,7 +50,6 @@ Pod::Spec.new do |s|
   s.subspec "SwiftUI" do |ss|
       ss.source_files = 'Sources/InstantSearchSwiftUI/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
-      ss.dependency 'Logging'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.3'
       ss.ios.deployment_target = '14.0'
       ss.osx.deployment_target = '11.0'


### PR DESCRIPTION
**Summary**

Quick PR to remove mentions of the `Logging` dependency in most subspecs, as it is indirectly available through Insights.