### PR TITLE
chore: bump protobuf

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "apple/swift-log" ~> 1.4
 github "algolia/algoliasearch-client-swift" ~> 8.18
-github "apple/swift-protobuf" == 1.20.0
+github "apple/swift-protobuf" == 1.22.0
 github "algolia/instantsearch-telemetry-native" ~> 0.1.3

--- a/InstantSearch.podspec
+++ b/InstantSearch.podspec
@@ -10,11 +10,11 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/algolia/instantsearch-ios.git', :tag => s.version }
 
   s.swift_version = "5.8"
-  
+
   s.default_subspec = 'UI'
-  
+
   s.resource_bundles = { 'InstantSearch' => ['Sources/PrivacyInfo.xcprivacy'] }
-  
+
   s.subspec "Insights" do |ss|
       ss.source_files = 'Sources/InstantSearchInsights/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.18'
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
       ss.watchos.deployment_target = '7.0'
       ss.tvos.deployment_target = '14.0'
   end
-  
+
   s.subspec "Core" do |ss|
       ss.source_files = 'Sources/InstantSearchCore/**/*.{swift}'
       ss.dependency 'AlgoliaSearchClient', '~> 8.18'
       ss.dependency 'Logging'
       ss.dependency 'InstantSearch/Insights'
-      ss.dependency 'SwiftProtobuf', '1.20.0'
+      ss.dependency 'SwiftProtobuf', '1.22.0'
       ss.dependency 'InstantSearchTelemetry', '~> 0.1.3'
       ss.ios.deployment_target = '14.0'
       ss.osx.deployment_target = '11.0'
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
       ss.tvos.deployment_target = '14.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
   end
-  
+
   s.subspec "UI" do |ss|
       ss.source_files = 'Sources/InstantSearch/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
       ss.tvos.deployment_target = '14.0'
       ss.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DInstantSearchCocoaPods' }
   end
-  
+
   s.subspec "SwiftUI" do |ss|
       ss.source_files = 'Sources/InstantSearchSwiftUI/**/*.{swift}'
       ss.dependency 'InstantSearch/Core'

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-log",
              from: "1.5.4"),
     .package(url: "https://github.com/apple/swift-protobuf",
-             .exact("1.20.0")),
+             .exact("1.22.0")),
     .package(name: "InstantSearchTelemetry",
              url: "https://github.com/algolia/instantsearch-telemetry-native",
              .exact("0.1.3"))


### PR DESCRIPTION
**Summary**

This PR bumps the pinned version of Protobuf to prevent incompatibility errors during cocoapods pre publishing checks.
