### PR TITLE
ci: update actions runner to support released xcode 16

### DIFF
--- a/.github/workflows/carthage.yml
+++ b/.github/workflows/carthage.yml
@@ -2,10 +2,10 @@ name: Carthage
 on: [pull_request]
 jobs:
   check:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
      - name: Select Xcode version
-       run: sudo xcode-select -s '/Applications/Xcode_13.4.app/Contents/Developer'
+       run: sudo xcode-select -s '/Applications/Xcode_14.2.app/Contents/Developer'
      - name: Initialize Cartfile
        run: |
         tee Cartfile <<<"github \"algolia/instantsearch-ios\" \"${{ github.head_ref }}\""

--- a/.github/workflows/pods.yml
+++ b/.github/workflows/pods.yml
@@ -2,7 +2,7 @@ name: Cocoapods
 on: [pull_request]
 jobs:
   lint-Insights:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
      - uses: actions/checkout@v4
      - name: Select Xcode version
@@ -10,7 +10,7 @@ jobs:
      - name: lint Insights
        run: pod lib lint --subspec="Insights" --allow-warnings
   lint-Core:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
      - uses: actions/checkout@v4
      - name: Select Xcode version
@@ -18,7 +18,7 @@ jobs:
      - name: lint Core
        run: pod lib lint --subspec="Core" --allow-warnings
   lint-UI:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
      - uses: actions/checkout@v4
      - name: Select Xcode version
@@ -26,7 +26,7 @@ jobs:
      - name: lint UI
        run: pod lib lint --subspec="UI" --allow-warnings
   lint-SwiftUI:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
      - uses: actions/checkout@v4
      - name: Select Xcode version

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       ALGOLIA_APPLICATION_ID_1: ${{ secrets.ALGOLIA_APPLICATION_ID_1 }}
       ALGOLIA_ADMIN_KEY_1: ${{ secrets.ALGOLIA_ADMIN_KEY_1 }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run tests
         run: swift test
   test-xcode-16:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       ALGOLIA_APPLICATION_ID_1: ${{ secrets.ALGOLIA_APPLICATION_ID_1 }}
       ALGOLIA_ADMIN_KEY_1: ${{ secrets.ALGOLIA_ADMIN_KEY_1 }}

--- a/Tests/InstantSearchCoreTests/Unit/DecodingErrorPrettyPrinterTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/DecodingErrorPrettyPrinterTests.swift
@@ -38,7 +38,7 @@ class DecodingErrorPrettyPrinterTests: XCTestCase {
         prettyPrinter.description
           == "Decoding error: 'age': Expected Int value but found null instead."
           || prettyPrinter.description
-            == "Decoding error: 'age': Cannot get unkeyed decoding container -- found null value instead"
+            == "Decoding error: 'age': Cannot get value of type Int -- found null value instead"
       )
     }
   }


### PR DESCRIPTION
**Summary**

Since Xcode 16 release in September, the beta version cannot be found on the macos-14 GitHub runner image, but in the new macos-15 runner image.

This PR updates the reference to ensure tests are run and pass for Xcode 16.
