### PR TITLE
fix(sortby): properly map indices names

### DIFF
--- a/Sources/InstantSearchCore/SortBy/Connector/SortByConnector.swift
+++ b/Sources/InstantSearchCore/SortBy/Connector/SortByConnector.swift
@@ -77,7 +77,7 @@ public class SortByConnector {
                                                                                 selected: Int? = nil) {
     let enumeratedIndices = indicesNames
       .indices
-      .map { ($0, indicesNames[0]) }
+      .map { ($0, indicesNames[$0]) }
     let items = [Int: IndexName](uniqueKeysWithValues: enumeratedIndices)
     let interactor = SortByInteractor(items: items)
     interactor.selected = selected

--- a/Tests/InstantSearchCoreTests/Unit/Connectors/SortByConnectorTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/Connectors/SortByConnectorTests.swift
@@ -24,6 +24,10 @@ class SortByConnectorTests: XCTestCase {
                                 controller: controller)
   }
 
+  func testInitialIndicesNames() {
+    XCTAssertEqual(connector.indicesNames, ["Index1", "Index2", "Index3"])
+  }
+
   func testSetItemsInteractorToController() {
     let itemsChangedExpectation = expectation(description: "Items changed")
     controller.onItemsChanged = {


### PR DESCRIPTION
**Summary**

This PR fixes a regression that occurred in https://github.com/algolia/instantsearch-ios/pull/321 which resulted in `SortByConnector` improperly defining its indices array, attributing the first index name for all values of the array.

Fixes #327 