### PR TITLE
fix: update contributing doc to specific required components for cocoapods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,8 @@ pod trunk add-owner InstantSearch user@algolia.com
 
 **Publishing a new version** manually:
 
+> Note: macOS, iOS, watchOS and tvOS component platforms need to be downloaded and installed via Xcode prior to running this command
+
 ```sh
 pod trunk push --allow-warnings
 ```


### PR DESCRIPTION
**Summary**
Adds a note to specify the platform components needed for a manual CocoaPods deployment from a local machine.
