### PR TITLE
chore: update changelog to follow generated format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,9 @@
 
 ## [7.27.0](https://github.com/algolia/instantsearch-ios/compare/7.26.4...7.27.0) (2025-07-01)
 
-### Misc
+### Fix
 
-- Merge pull request #341 from algolia/fix/multi-query-headers ([51a0890](https://github.com/algolia/instantsearch-ios/commit/51a0890))
-- add deprecated init part 2 ([9c59db6](https://github.com/algolia/instantsearch-ios/commit/9c59db6))
-- add deprecated init ([614b4dc](https://github.com/algolia/instantsearch-ios/commit/614b4dc))
-- address comments ([55e38f7](https://github.com/algolia/instantsearch-ios/commit/55e38f7))
-- add request options to multisearcher ([5c4c8a5](https://github.com/algolia/instantsearch-ios/commit/5c4c8a5))
-
+- add `requestOptions` to `MultiSearcher` init (#341) ([51a0890](https://github.com/algolia/instantsearch-ios/commit/51a089052fa485519e1c15b68602b13d81190bcd))
 
 
 ## [7.26.4](https://github.com/algolia/instantsearch-ios/compare/7.26.3...7.26.4) (2025-02-19)


### PR DESCRIPTION
**Summary**
Last PR was merged without squashing causing the generated changelog for the latest version to be incorrect. This PR fixes it. Updated the corresponding release description as well.
