### PR TITLE
(feat): Add event subtype support to InstantSearch Insights

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,7 +10,7 @@ identifier_name:
     - or
     - id
 function_parameter_count:
-  warning: 8
+  warning: 9
   error: 10
   ignores_default_parameters: true
 function_body_length:

--- a/Sources/InstantSearchInsights/Logic/EventTracker.swift
+++ b/Sources/InstantSearchInsights/Logic/EventTracker.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Algolia. All rights reserved.
 //
 
+import AlgoliaInsights
 import Foundation
 
 /// Provides convenient functions for tracking events which can be used for search personalization.
@@ -153,6 +154,86 @@ class EventTracker: EventTrackable {
                                                             timestamp: effectiveTimestamp(for: timestamp)?.millisecondsSince1970,
                                                             queryID: queryID,
                                                             objectIDs: objectIDs)
+    eventProcessor.process(event)
+  }
+
+  func purchase(eventName: String,
+                indexName: String,
+                userToken: String? = .none,
+                timestamp: Date?,
+                objectIDs: [String],
+                objectData: [ObjectData]?,
+                currency: String?,
+                value: InsightsValue?) {
+    let event = InsightsEvent.purchasedObjectIDs(eventName: eventName,
+                                                 indexName: indexName,
+                                                 userToken: effectiveUserToken(withEventUserToken: userToken),
+                                                 timestamp: effectiveTimestamp(for: timestamp)?.millisecondsSince1970,
+                                                 objectIDs: objectIDs,
+                                                 objectData: objectData,
+                                                 currency: currency,
+                                                 value: value)
+    eventProcessor.process(event)
+  }
+
+  func purchase(eventName: String,
+                indexName: String,
+                userToken: String? = .none,
+                timestamp: Date?,
+                objectIDs: [String],
+                objectDataAfterSearch: [ObjectDataAfterSearch],
+                queryID: String,
+                currency: String?,
+                value: InsightsValue?) {
+    let event = InsightsEvent.purchasedObjectIDsAfterSearch(eventName: eventName,
+                                                            indexName: indexName,
+                                                            userToken: effectiveUserToken(withEventUserToken: userToken),
+                                                            timestamp: effectiveTimestamp(for: timestamp)?.millisecondsSince1970,
+                                                            queryID: queryID,
+                                                            objectIDs: objectIDs,
+                                                            objectDataAfterSearch: objectDataAfterSearch,
+                                                            currency: currency,
+                                                            value: value)
+    eventProcessor.process(event)
+  }
+
+  func addToCart(eventName: String,
+                 indexName: String,
+                 userToken: String? = .none,
+                 timestamp: Date?,
+                 objectIDs: [String],
+                 objectData: [ObjectData]?,
+                 currency: String?,
+                 value: InsightsValue?) {
+    let event = InsightsEvent.addedToCartObjectIDs(eventName: eventName,
+                                                   indexName: indexName,
+                                                   userToken: effectiveUserToken(withEventUserToken: userToken),
+                                                   timestamp: effectiveTimestamp(for: timestamp)?.millisecondsSince1970,
+                                                   objectIDs: objectIDs,
+                                                   objectData: objectData,
+                                                   currency: currency,
+                                                   value: value)
+    eventProcessor.process(event)
+  }
+
+  func addToCart(eventName: String,
+                 indexName: String,
+                 userToken: String? = .none,
+                 timestamp: Date?,
+                 objectIDs: [String],
+                 objectDataAfterSearch: [ObjectDataAfterSearch]?,
+                 queryID: String,
+                 currency: String?,
+                 value: InsightsValue?) {
+    let event = InsightsEvent.addedToCartObjectIDsAfterSearch(eventName: eventName,
+                                                              indexName: indexName,
+                                                              userToken: effectiveUserToken(withEventUserToken: userToken),
+                                                              timestamp: effectiveTimestamp(for: timestamp)?.millisecondsSince1970,
+                                                              queryID: queryID,
+                                                              objectIDs: objectIDs,
+                                                              objectDataAfterSearch: objectDataAfterSearch,
+                                                              currency: currency,
+                                                              value: value)
     eventProcessor.process(event)
   }
 

--- a/Sources/InstantSearchInsights/Logic/Insights+CommerceEventTracking.swift
+++ b/Sources/InstantSearchInsights/Logic/Insights+CommerceEventTracking.swift
@@ -1,0 +1,250 @@
+//
+//  Insights+CommerceEventTracking.swift
+//  InstantSearchInsights
+//
+
+import AlgoliaInsights
+import Foundation
+
+/// Tracking commerce events (purchase and add-to-cart)
+public extension Insights {
+  // MARK: - Purchase events
+
+  /// Track a purchase not related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter objectData: Extra information about the purchased items (price, quantity, discount)
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func purchased(eventName: String,
+                 indexName: String,
+                 objectIDs: [String],
+                 objectData: [ObjectData]? = nil,
+                 currency: String? = nil,
+                 value: InsightsValue? = nil,
+                 timestamp: Date? = .none,
+                 userToken: String? = .none) {
+    eventTracker.purchase(eventName: eventName,
+                          indexName: indexName,
+                          userToken: userToken,
+                          timestamp: timestamp,
+                          objectIDs: objectIDs,
+                          objectData: objectData,
+                          currency: currency,
+                          value: value)
+  }
+
+  /// Track a purchase not related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectID: Index objectID
+  /// - parameter objectData: Extra information about the purchased item (price, quantity, discount)
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func purchased(eventName: String,
+                 indexName: String,
+                 objectID: String,
+                 objectData: ObjectData? = nil,
+                 currency: String? = nil,
+                 value: InsightsValue? = nil,
+                 timestamp: Date? = .none,
+                 userToken: String? = .none) {
+    purchased(eventName: eventName,
+              indexName: indexName,
+              objectIDs: [objectID],
+              objectData: objectData.map { [$0] },
+              currency: currency,
+              value: value,
+              timestamp: timestamp,
+              userToken: userToken)
+  }
+
+  /// Track a purchase related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter objectData: Extra information about the purchased items (price, quantity, discount, queryID)
+  /// - parameter queryID: Algolia queryID
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func purchasedAfterSearch(eventName: String,
+                            indexName: String,
+                            objectIDs: [String],
+                            objectData: [ObjectDataAfterSearch],
+                            queryID: String,
+                            currency: String? = nil,
+                            value: InsightsValue? = nil,
+                            timestamp: Date? = .none,
+                            userToken: String? = .none) {
+    eventTracker.purchase(eventName: eventName,
+                          indexName: indexName,
+                          userToken: userToken,
+                          timestamp: timestamp,
+                          objectIDs: objectIDs,
+                          objectDataAfterSearch: objectData,
+                          queryID: queryID,
+                          currency: currency,
+                          value: value)
+  }
+
+  /// Track a purchase related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectID: Index objectID
+  /// - parameter objectData: Extra information about the purchased item (price, quantity, discount, queryID)
+  /// - parameter queryID: Algolia queryID
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func purchasedAfterSearch(eventName: String,
+                            indexName: String,
+                            objectID: String,
+                            objectData: ObjectDataAfterSearch,
+                            queryID: String,
+                            currency: String? = nil,
+                            value: InsightsValue? = nil,
+                            timestamp: Date? = .none,
+                            userToken: String? = .none) {
+    purchasedAfterSearch(eventName: eventName,
+                         indexName: indexName,
+                         objectIDs: [objectID],
+                         objectData: [objectData],
+                         queryID: queryID,
+                         currency: currency,
+                         value: value,
+                         timestamp: timestamp,
+                         userToken: userToken)
+  }
+
+  // MARK: - Add-to-cart events
+
+  /// Track an add-to-cart event not related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter objectData: Extra information about the items added to cart (price, quantity, discount)
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func addedToCart(eventName: String,
+                   indexName: String,
+                   objectIDs: [String],
+                   objectData: [ObjectData]? = nil,
+                   currency: String? = nil,
+                   value: InsightsValue? = nil,
+                   timestamp: Date? = .none,
+                   userToken: String? = .none) {
+    eventTracker.addToCart(eventName: eventName,
+                           indexName: indexName,
+                           userToken: userToken,
+                           timestamp: timestamp,
+                           objectIDs: objectIDs,
+                           objectData: objectData,
+                           currency: currency,
+                           value: value)
+  }
+
+  /// Track an add-to-cart event not related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectID: Index objectID
+  /// - parameter objectData: Extra information about the item added to cart (price, quantity, discount)
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func addedToCart(eventName: String,
+                   indexName: String,
+                   objectID: String,
+                   objectData: ObjectData? = nil,
+                   currency: String? = nil,
+                   value: InsightsValue? = nil,
+                   timestamp: Date? = .none,
+                   userToken: String? = .none) {
+    addedToCart(eventName: eventName,
+               indexName: indexName,
+               objectIDs: [objectID],
+               objectData: objectData.map { [$0] },
+               currency: currency,
+               value: value,
+               timestamp: timestamp,
+               userToken: userToken)
+  }
+
+  /// Track an add-to-cart event related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectIDs: An array of index objectID. Limited to 20 objects.
+  /// - parameter objectData: Extra information about the items added to cart (price, quantity, discount, queryID)
+  /// - parameter queryID: Algolia queryID
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func addedToCartAfterSearch(eventName: String,
+                              indexName: String,
+                              objectIDs: [String],
+                              objectData: [ObjectDataAfterSearch]? = nil,
+                              queryID: String,
+                              currency: String? = nil,
+                              value: InsightsValue? = nil,
+                              timestamp: Date? = .none,
+                              userToken: String? = .none) {
+    eventTracker.addToCart(eventName: eventName,
+                           indexName: indexName,
+                           userToken: userToken,
+                           timestamp: timestamp,
+                           objectIDs: objectIDs,
+                           objectDataAfterSearch: objectData,
+                           queryID: queryID,
+                           currency: currency,
+                           value: value)
+  }
+
+  /// Track an add-to-cart event related to search
+  /// - parameter eventName: A user-defined string used to categorize events
+  /// - parameter indexName: Name of the targeted index
+  /// - parameter objectID: Index objectID
+  /// - parameter objectData: Extra information about the item added to cart (price, quantity, discount, queryID)
+  /// - parameter queryID: Algolia queryID
+  /// - parameter currency: Three-letter ISO 4217 currency code
+  /// - parameter value: Total monetary value of the event
+  /// - parameter timestamp: Event timestamp
+  /// - parameter userToken: User identifier. Overrides application's user token if specified. Default value is nil.
+
+  func addedToCartAfterSearch(eventName: String,
+                              indexName: String,
+                              objectID: String,
+                              objectData: ObjectDataAfterSearch? = nil,
+                              queryID: String,
+                              currency: String? = nil,
+                              value: InsightsValue? = nil,
+                              timestamp: Date? = .none,
+                              userToken: String? = .none) {
+    addedToCartAfterSearch(eventName: eventName,
+                           indexName: indexName,
+                           objectIDs: [objectID],
+                           objectData: objectData.map { [$0] },
+                           queryID: queryID,
+                           currency: currency,
+                           value: value,
+                           timestamp: timestamp,
+                           userToken: userToken)
+  }
+}

--- a/Sources/InstantSearchInsights/Models/InsightsEvent.swift
+++ b/Sources/InstantSearchInsights/Models/InsightsEvent.swift
@@ -16,6 +16,10 @@ public struct InsightsEvent: Codable, Hashable {
     case viewedFilters
     case clickedFilters
     case convertedFilters
+    case purchasedObjectIDsAfterSearch
+    case purchasedObjectIDs
+    case addedToCartObjectIDsAfterSearch
+    case addedToCartObjectIDs
   }
 
   public let eventType: EventType
@@ -27,6 +31,10 @@ public struct InsightsEvent: Codable, Hashable {
   public let positions: [Int]?
   public let queryID: String?
   public let filters: [FilterFacet]?
+  public let currency: String?
+  public let objectData: [ObjectData]?
+  public let objectDataAfterSearch: [ObjectDataAfterSearch]?
+  public let value: InsightsValue?
 
   public init(eventType: EventType,
               eventName: String,
@@ -36,7 +44,11 @@ public struct InsightsEvent: Codable, Hashable {
               objectIDs: [String]? = nil,
               positions: [Int]? = nil,
               queryID: String? = nil,
-              filters: [FilterFacet]? = nil) {
+              filters: [FilterFacet]? = nil,
+              currency: String? = nil,
+              objectData: [ObjectData]? = nil,
+              objectDataAfterSearch: [ObjectDataAfterSearch]? = nil,
+              value: InsightsValue? = nil) {
     self.eventType = eventType
     self.eventName = eventName
     self.indexName = indexName
@@ -46,6 +58,10 @@ public struct InsightsEvent: Codable, Hashable {
     self.positions = positions
     self.queryID = queryID
     self.filters = filters
+    self.currency = currency
+    self.objectData = objectData
+    self.objectDataAfterSearch = objectDataAfterSearch
+    self.value = value
   }
 }
 
@@ -158,6 +174,84 @@ public extension InsightsEvent {
                  timestamp: timestamp,
                  filters: filters)
   }
+
+  static func purchasedObjectIDsAfterSearch(eventName: String,
+                                            indexName: String,
+                                            userToken: String,
+                                            timestamp: Int64?,
+                                            queryID: String,
+                                            objectIDs: [String],
+                                            objectDataAfterSearch: [ObjectDataAfterSearch],
+                                            currency: String? = nil,
+                                            value: InsightsValue? = nil) -> InsightsEvent {
+    return .init(eventType: .purchasedObjectIDsAfterSearch,
+                 eventName: eventName,
+                 indexName: indexName,
+                 userToken: userToken,
+                 timestamp: timestamp,
+                 objectIDs: objectIDs,
+                 queryID: queryID,
+                 objectDataAfterSearch: objectDataAfterSearch,
+                 value: value)
+  }
+
+  static func purchasedObjectIDs(eventName: String,
+                                 indexName: String,
+                                 userToken: String,
+                                 timestamp: Int64?,
+                                 objectIDs: [String],
+                                 objectData: [ObjectData]? = nil,
+                                 currency: String? = nil,
+                                 value: InsightsValue? = nil) -> InsightsEvent {
+    return .init(eventType: .purchasedObjectIDs,
+                 eventName: eventName,
+                 indexName: indexName,
+                 userToken: userToken,
+                 timestamp: timestamp,
+                 objectIDs: objectIDs,
+                 currency: currency,
+                 objectData: objectData,
+                 value: value)
+  }
+
+  static func addedToCartObjectIDsAfterSearch(eventName: String,
+                                              indexName: String,
+                                              userToken: String,
+                                              timestamp: Int64?,
+                                              queryID: String,
+                                              objectIDs: [String],
+                                              objectDataAfterSearch: [ObjectDataAfterSearch]? = nil,
+                                              currency: String? = nil,
+                                              value: InsightsValue? = nil) -> InsightsEvent {
+    return .init(eventType: .addedToCartObjectIDsAfterSearch,
+                 eventName: eventName,
+                 indexName: indexName,
+                 userToken: userToken,
+                 timestamp: timestamp,
+                 objectIDs: objectIDs,
+                 queryID: queryID,
+                 objectDataAfterSearch: objectDataAfterSearch,
+                 value: value)
+  }
+
+  static func addedToCartObjectIDs(eventName: String,
+                                   indexName: String,
+                                   userToken: String,
+                                   timestamp: Int64?,
+                                   objectIDs: [String],
+                                   objectData: [ObjectData]? = nil,
+                                   currency: String? = nil,
+                                   value: InsightsValue? = nil) -> InsightsEvent {
+    return .init(eventType: .addedToCartObjectIDs,
+                 eventName: eventName,
+                 indexName: indexName,
+                 userToken: userToken,
+                 timestamp: timestamp,
+                 objectIDs: objectIDs,
+                 currency: currency,
+                 objectData: objectData,
+                 value: value)
+  }
 }
 
 extension InsightsEvent {
@@ -208,6 +302,30 @@ extension InsightsEvent {
       return .convertedFilters(ConvertedFilters(
         eventName: eventName, eventType: .conversion, index: indexName,
         filters: filterStrings, userToken: userToken, timestamp: timestamp))
+    case .purchasedObjectIDsAfterSearch:
+      guard let objectIDs, let objectDataAfterSearch else { return nil }
+      return .purchasedObjectIDsAfterSearch(PurchasedObjectIDsAfterSearch(
+        eventName: eventName, eventType: .conversion, eventSubtype: .purchase, index: indexName,
+        objectIDs: objectIDs, userToken: userToken, currency: currency,
+        objectData: objectDataAfterSearch, timestamp: timestamp, value: value))
+    case .purchasedObjectIDs:
+      guard let objectIDs else { return nil }
+      return .purchasedObjectIDs(PurchasedObjectIDs(
+        eventName: eventName, eventType: .conversion, eventSubtype: .purchase, index: indexName,
+        objectIDs: objectIDs, userToken: userToken, currency: currency,
+        objectData: objectData, timestamp: timestamp, value: value))
+    case .addedToCartObjectIDsAfterSearch:
+      guard let objectIDs, let queryID else { return nil }
+      return .addedToCartObjectIDsAfterSearch(AddedToCartObjectIDsAfterSearch(
+        eventName: eventName, eventType: .conversion, eventSubtype: .addToCart, index: indexName,
+        queryID: queryID, objectIDs: objectIDs, userToken: userToken, currency: currency,
+        objectData: objectDataAfterSearch, timestamp: timestamp, value: value))
+    case .addedToCartObjectIDs:
+      guard let objectIDs else { return nil }
+      return .addedToCartObjectIDs(AddedToCartObjectIDs(
+        eventName: eventName, eventType: .conversion, eventSubtype: .addToCart, index: indexName,
+        objectIDs: objectIDs, userToken: userToken, currency: currency,
+        objectData: objectData, timestamp: timestamp, value: value))
     }
   }
 }

--- a/Sources/InstantSearchInsights/Models/InsightsEvent.swift
+++ b/Sources/InstantSearchInsights/Models/InsightsEvent.swift
@@ -191,6 +191,7 @@ public extension InsightsEvent {
                  timestamp: timestamp,
                  objectIDs: objectIDs,
                  queryID: queryID,
+                 currency: currency,
                  objectDataAfterSearch: objectDataAfterSearch,
                  value: value)
   }
@@ -230,6 +231,7 @@ public extension InsightsEvent {
                  timestamp: timestamp,
                  objectIDs: objectIDs,
                  queryID: queryID,
+                 currency: currency,
                  objectDataAfterSearch: objectDataAfterSearch,
                  value: value)
   }

--- a/Sources/InstantSearchInsights/Protocols/EventTrackable.swift
+++ b/Sources/InstantSearchInsights/Protocols/EventTrackable.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 Algolia. All rights reserved.
 //
 
+import AlgoliaInsights
 import Foundation
 
 protocol EventTrackable {
@@ -59,4 +60,42 @@ protocol EventTrackable {
                   userToken: String?,
                   timestamp: Date?,
                   filters: [String])
+
+  func purchase(eventName: String,
+                indexName: String,
+                userToken: String?,
+                timestamp: Date?,
+                objectIDs: [String],
+                objectData: [ObjectData]?,
+                currency: String?,
+                value: InsightsValue?)
+
+  func purchase(eventName: String,
+                indexName: String,
+                userToken: String?,
+                timestamp: Date?,
+                objectIDs: [String],
+                objectDataAfterSearch: [ObjectDataAfterSearch],
+                queryID: String,
+                currency: String?,
+                value: InsightsValue?)
+
+  func addToCart(eventName: String,
+                 indexName: String,
+                 userToken: String?,
+                 timestamp: Date?,
+                 objectIDs: [String],
+                 objectData: [ObjectData]?,
+                 currency: String?,
+                 value: InsightsValue?)
+
+  func addToCart(eventName: String,
+                 indexName: String,
+                 userToken: String?,
+                 timestamp: Date?,
+                 objectIDs: [String],
+                 objectDataAfterSearch: [ObjectDataAfterSearch]?,
+                 queryID: String,
+                 currency: String?,
+                 value: InsightsValue?)
 }

--- a/Tests/InstantSearchInsightsTests/Helpers/TestEvent.swift
+++ b/Tests/InstantSearchInsightsTests/Helpers/TestEvent.swift
@@ -5,6 +5,7 @@
 //  Created by Vladislav Fitc on 15/10/2020.
 //
 
+import AlgoliaInsights
 import Foundation
 @testable import InstantSearchInsights
 
@@ -79,6 +80,62 @@ struct TestEvent {
 
   static var conversion: InsightsEvent {
     [conversionWithObjects, conversionWithFilters].randomElement()!
+  }
+
+  static let objectDataItems: [ObjectData] = [
+    ObjectData(price: .double(9.99), quantity: 1),
+    ObjectData(price: .double(19.99), quantity: 2),
+    ObjectData(price: .double(29.99), quantity: 1)
+  ]
+
+  static let objectDataAfterSearchItems: [ObjectDataAfterSearch] = [
+    ObjectDataAfterSearch(queryID: queryID, price: .double(9.99), quantity: 1),
+    ObjectDataAfterSearch(queryID: queryID, price: .double(19.99), quantity: 2),
+    ObjectDataAfterSearch(queryID: queryID, price: .double(29.99), quantity: 1)
+  ]
+
+  static let currency: String = "USD"
+
+  static var purchasedWithObjects: InsightsEvent {
+    .purchasedObjectIDs(eventName: "purchase event name",
+                        indexName: indexName,
+                        userToken: userToken,
+                        timestamp: timeStamp.millisecondsSince1970,
+                        objectIDs: objectIDs,
+                        objectData: objectDataItems,
+                        currency: currency)
+  }
+
+  static var purchasedAfterSearch: InsightsEvent {
+    .purchasedObjectIDsAfterSearch(eventName: "purchase event name",
+                                   indexName: indexName,
+                                   userToken: userToken,
+                                   timestamp: timeStamp.millisecondsSince1970,
+                                   queryID: queryID,
+                                   objectIDs: objectIDs,
+                                   objectDataAfterSearch: objectDataAfterSearchItems,
+                                   currency: currency)
+  }
+
+  static var addedToCartWithObjects: InsightsEvent {
+    .addedToCartObjectIDs(eventName: "add to cart event name",
+                          indexName: indexName,
+                          userToken: userToken,
+                          timestamp: timeStamp.millisecondsSince1970,
+                          objectIDs: objectIDs,
+                          objectData: objectDataItems,
+                          currency: currency)
+  }
+
+  static var addedToCartAfterSearch: InsightsEvent {
+    .addedToCartObjectIDsAfterSearch(eventName: "add to cart event name",
+                                     indexName: indexName,
+                                     userToken: userToken,
+                                     timestamp: timeStamp.millisecondsSince1970,
+                                     queryID: queryID,
+                                     objectIDs: objectIDs,
+                                     objectDataAfterSearch: objectDataAfterSearchItems,
+                                     currency: currency)
   }
 
   static var random: InsightsEvent {

--- a/Tests/InstantSearchInsightsTests/Helpers/TestEventTracker.swift
+++ b/Tests/InstantSearchInsightsTests/Helpers/TestEventTracker.swift
@@ -5,6 +5,7 @@
 //  Created by Vladislav Fitc on 15/10/2020.
 //
 
+import AlgoliaInsights
 import Foundation
 @testable import InstantSearchInsights
 
@@ -17,6 +18,10 @@ class TestEventTracker: EventTrackable {
   var didConvertObjects: ((String, String, String?, Date?, [String]) -> Void)?
   var didConvertObjectsAfterSearch: ((String, String, String?, Date?, [String], String) -> Void)?
   var didConvertFilters: ((String, String, String?, Date?, [String]) -> Void)?
+  var didPurchaseObjects: ((String, String, String?, Date?, [String], [ObjectData]?, String?, InsightsValue?) -> Void)?
+  var didPurchaseObjectsAfterSearch: ((String, String, String?, Date?, [String], [ObjectDataAfterSearch], String, String?, InsightsValue?) -> Void)?
+  var didAddToCartObjects: ((String, String, String?, Date?, [String], [ObjectData]?, String?, InsightsValue?) -> Void)?
+  var didAddToCartObjectsAfterSearch: ((String, String, String?, Date?, [String], [ObjectDataAfterSearch]?, String, String?, InsightsValue?) -> Void)?
 
   func view(eventName: String, indexName: String, userToken: String?, timestamp: Date?, objectIDs: [String]) {
     didViewObjects?(eventName, indexName, userToken, timestamp, objectIDs)
@@ -48,5 +53,21 @@ class TestEventTracker: EventTrackable {
 
   func conversion(eventName: String, indexName: String, userToken: String?, timestamp: Date?, filters: [String]) {
     didConvertFilters?(eventName, indexName, userToken, timestamp, filters)
+  }
+
+  func purchase(eventName: String, indexName: String, userToken: String?, timestamp: Date?, objectIDs: [String], objectData: [ObjectData]?, currency: String?, value: InsightsValue?) {
+    didPurchaseObjects?(eventName, indexName, userToken, timestamp, objectIDs, objectData, currency, value)
+  }
+
+  func purchase(eventName: String, indexName: String, userToken: String?, timestamp: Date?, objectIDs: [String], objectDataAfterSearch: [ObjectDataAfterSearch], queryID: String, currency: String?, value: InsightsValue?) {
+    didPurchaseObjectsAfterSearch?(eventName, indexName, userToken, timestamp, objectIDs, objectDataAfterSearch, queryID, currency, value)
+  }
+
+  func addToCart(eventName: String, indexName: String, userToken: String?, timestamp: Date?, objectIDs: [String], objectData: [ObjectData]?, currency: String?, value: InsightsValue?) {
+    didAddToCartObjects?(eventName, indexName, userToken, timestamp, objectIDs, objectData, currency, value)
+  }
+
+  func addToCart(eventName: String, indexName: String, userToken: String?, timestamp: Date?, objectIDs: [String], objectDataAfterSearch: [ObjectDataAfterSearch]?, queryID: String, currency: String?, value: InsightsValue?) {
+    didAddToCartObjectsAfterSearch?(eventName, indexName, userToken, timestamp, objectIDs, objectDataAfterSearch, queryID, currency, value)
   }
 }

--- a/Tests/InstantSearchInsightsTests/Unit/InsightsTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/InsightsTests.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2018 Algolia. All rights reserved.
 //
 
+import AlgoliaInsights
 @testable import InstantSearchInsights
 import XCTest
 
@@ -417,6 +418,156 @@ class InsightsTests: XCTestCase {
                                 indexName: TestEvent.indexName,
                                 objectIDsWithPositions: TestEvent.objectIDsWithPositions,
                                 queryID: TestEvent.queryID)
+
+    waitForExpectations(timeout: 5, handler: nil)
+  }
+
+  func testPurchaseWithObjects() {
+    let exp = expectation(description: "callback expectation")
+    exp.expectedFulfillmentCount = 2
+
+    testEventTracker.didPurchaseObjects = { eventName, indexName, userToken, _, objectIDs, objectData, currency, _ in
+      exp.fulfill()
+      XCTAssertEqual(TestEvent.eventName, eventName)
+      XCTAssertEqual(TestEvent.userToken, userToken)
+      XCTAssertEqual(TestEvent.indexName, indexName)
+      XCTAssertEqual(TestEvent.currency, currency)
+      if objectIDs.count > 1 {
+        XCTAssertEqual(TestEvent.objectIDs, objectIDs)
+        XCTAssertEqual(objectData?.count, TestEvent.objectDataItems.count)
+      } else {
+        XCTAssertEqual(TestEvent.objectIDs.first, objectIDs.first)
+        XCTAssertEqual(objectData?.count, 1)
+      }
+    }
+
+    testInsights.purchased(eventName: TestEvent.eventName,
+                           indexName: TestEvent.indexName,
+                           objectIDs: TestEvent.objectIDs,
+                           objectData: TestEvent.objectDataItems,
+                           currency: TestEvent.currency,
+                           userToken: TestEvent.userToken)
+
+    testInsights.purchased(eventName: TestEvent.eventName,
+                           indexName: TestEvent.indexName,
+                           objectID: TestEvent.objectIDs.first!,
+                           objectData: TestEvent.objectDataItems.first!,
+                           currency: TestEvent.currency,
+                           userToken: TestEvent.userToken)
+
+    waitForExpectations(timeout: 5, handler: nil)
+  }
+
+  func testPurchaseAfterSearch() {
+    let exp = expectation(description: "callback expectation")
+    exp.expectedFulfillmentCount = 2
+
+    testEventTracker.didPurchaseObjectsAfterSearch = { eventName, indexName, userToken, _, objectIDs, objectData, queryID, currency, _ in
+      exp.fulfill()
+      XCTAssertEqual(TestEvent.eventName, eventName)
+      XCTAssertEqual(TestEvent.userToken, userToken)
+      XCTAssertEqual(TestEvent.indexName, indexName)
+      XCTAssertEqual(TestEvent.queryID, queryID)
+      XCTAssertEqual(TestEvent.currency, currency)
+      if objectIDs.count > 1 {
+        XCTAssertEqual(TestEvent.objectIDs, objectIDs)
+        XCTAssertEqual(objectData.count, TestEvent.objectDataAfterSearchItems.count)
+      } else {
+        XCTAssertEqual(TestEvent.objectIDs.first, objectIDs.first)
+        XCTAssertEqual(objectData.count, 1)
+      }
+    }
+
+    testInsights.purchasedAfterSearch(eventName: TestEvent.eventName,
+                                      indexName: TestEvent.indexName,
+                                      objectIDs: TestEvent.objectIDs,
+                                      objectData: TestEvent.objectDataAfterSearchItems,
+                                      queryID: TestEvent.queryID,
+                                      currency: TestEvent.currency,
+                                      userToken: TestEvent.userToken)
+
+    testInsights.purchasedAfterSearch(eventName: TestEvent.eventName,
+                                      indexName: TestEvent.indexName,
+                                      objectID: TestEvent.objectIDs.first!,
+                                      objectData: TestEvent.objectDataAfterSearchItems.first!,
+                                      queryID: TestEvent.queryID,
+                                      currency: TestEvent.currency,
+                                      userToken: TestEvent.userToken)
+
+    waitForExpectations(timeout: 5, handler: nil)
+  }
+
+  func testAddToCartWithObjects() {
+    let exp = expectation(description: "callback expectation")
+    exp.expectedFulfillmentCount = 2
+
+    testEventTracker.didAddToCartObjects = { eventName, indexName, userToken, _, objectIDs, objectData, currency, _ in
+      exp.fulfill()
+      XCTAssertEqual(TestEvent.eventName, eventName)
+      XCTAssertEqual(TestEvent.userToken, userToken)
+      XCTAssertEqual(TestEvent.indexName, indexName)
+      XCTAssertEqual(TestEvent.currency, currency)
+      if objectIDs.count > 1 {
+        XCTAssertEqual(TestEvent.objectIDs, objectIDs)
+        XCTAssertEqual(objectData?.count, TestEvent.objectDataItems.count)
+      } else {
+        XCTAssertEqual(TestEvent.objectIDs.first, objectIDs.first)
+        XCTAssertEqual(objectData?.count, 1)
+      }
+    }
+
+    testInsights.addedToCart(eventName: TestEvent.eventName,
+                            indexName: TestEvent.indexName,
+                            objectIDs: TestEvent.objectIDs,
+                            objectData: TestEvent.objectDataItems,
+                            currency: TestEvent.currency,
+                            userToken: TestEvent.userToken)
+
+    testInsights.addedToCart(eventName: TestEvent.eventName,
+                            indexName: TestEvent.indexName,
+                            objectID: TestEvent.objectIDs.first!,
+                            objectData: TestEvent.objectDataItems.first!,
+                            currency: TestEvent.currency,
+                            userToken: TestEvent.userToken)
+
+    waitForExpectations(timeout: 5, handler: nil)
+  }
+
+  func testAddToCartAfterSearch() {
+    let exp = expectation(description: "callback expectation")
+    exp.expectedFulfillmentCount = 2
+
+    testEventTracker.didAddToCartObjectsAfterSearch = { eventName, indexName, userToken, _, objectIDs, objectData, queryID, currency, _ in
+      exp.fulfill()
+      XCTAssertEqual(TestEvent.eventName, eventName)
+      XCTAssertEqual(TestEvent.userToken, userToken)
+      XCTAssertEqual(TestEvent.indexName, indexName)
+      XCTAssertEqual(TestEvent.queryID, queryID)
+      XCTAssertEqual(TestEvent.currency, currency)
+      if objectIDs.count > 1 {
+        XCTAssertEqual(TestEvent.objectIDs, objectIDs)
+        XCTAssertEqual(objectData?.count, TestEvent.objectDataAfterSearchItems.count)
+      } else {
+        XCTAssertEqual(TestEvent.objectIDs.first, objectIDs.first)
+        XCTAssertEqual(objectData?.count, 1)
+      }
+    }
+
+    testInsights.addedToCartAfterSearch(eventName: TestEvent.eventName,
+                                        indexName: TestEvent.indexName,
+                                        objectIDs: TestEvent.objectIDs,
+                                        objectData: TestEvent.objectDataAfterSearchItems,
+                                        queryID: TestEvent.queryID,
+                                        currency: TestEvent.currency,
+                                        userToken: TestEvent.userToken)
+
+    testInsights.addedToCartAfterSearch(eventName: TestEvent.eventName,
+                                        indexName: TestEvent.indexName,
+                                        objectID: TestEvent.objectIDs.first!,
+                                        objectData: TestEvent.objectDataAfterSearchItems.first!,
+                                        queryID: TestEvent.queryID,
+                                        currency: TestEvent.currency,
+                                        userToken: TestEvent.userToken)
 
     waitForExpectations(timeout: 5, handler: nil)
   }


### PR DESCRIPTION
**Summary**

The underlying AlgoliaInsights Swift API client already supports event subtypes (purchase, addToCart) via dedicated models like PurchasedObjectIDsAfterSearch, PurchasedObjectIDs, AddedToCartObjectIDsAfterSearch, and AddedToCartObjectIDs. However, the InstantSearch wrapper layer did not expose these, meaning users had no way to send events with subtypes through the convenience API.
This change threads the four new event types through the full pipeline:
- InsightsEvent model: Added 4 new EventType cases, 4 new optional properties (currency, objectData, objectDataAfterSearch, value), 4 static factory methods, and 4 eventsItem mapping cases that bridge to the AlgoliaInsights SDK models.
- EventTrackable protocol: Added purchase() and addToCart() method signatures, each with two overloads (with and without queryID for after-search vs standalone events).
- EventTracker: Implemented the 4 new protocol methods.
- Insights+CommerceEventTracking.swift (new file): Public API extension on Insights with purchased(), purchasedAfterSearch(), addedToCart(), and addedToCartAfterSearch() methods, plus single-objectID convenience overloads for each. Follows the naming convention of existing extensions (Insights+EventTracking, Insights+SearchEventTracking).
- Tests: Updated TestEventTracker, TestEvent, and InsightsTests with full coverage of all 4 new commerce event types.
All changes are purely additive with no breaking changes to existing APIs.
Types from AlgoliaInsights (ObjectData, ObjectDataAfterSearch, InsightsValue, Price, Discount) are used directly since the package is already a transitive dependency for consumers.
