### PR TITLE
fix(core): percent-encode reserved sub-delimiters in `SearchParamsEncoder`

### DIFF
--- a/Sources/InstantSearchCore/Searcher/SearchService/SearchParamsEncoder.swift
+++ b/Sources/InstantSearchCore/Searcher/SearchService/SearchParamsEncoder.swift
@@ -7,14 +7,27 @@ import Foundation
 import AlgoliaSearch
 
 struct SearchParamsEncoder {
+  /// Character set safe for use inside an individual query key or value.
+  ///
+  /// `CharacterSet.urlQueryAllowed` leaves the sub-delimiters `& = + ? # ; / @` unescaped because they are legal
+  /// characters in the query component as a whole. When a value contains any of these (for example `&` inside a
+  /// `facetFilters` value like `"Dates & Dried Fruits"`), the resulting `params` string is misparsed on the server
+  /// and the content after the `&` is interpreted as a separate unknown parameter. We therefore strip those
+  /// characters from the allowed set so they get correctly percent-encoded.
+  private static let queryValueAllowed: CharacterSet = {
+    var allowed = CharacterSet.urlQueryAllowed
+    allowed.remove(charactersIn: "&=+?#;/@")
+    return allowed
+  }()
+
   static func encode(_ params: SearchSearchParamsObject) -> String? {
     guard let dictionary = params.asDictionary else { return nil }
     let items = dictionary
       .sorted(by: { $0.key < $1.key })
       .compactMap { key, value -> String? in
         guard let encodedValue = encodeValue(value) else { return nil }
-        guard let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
-        guard let encodedValueEscaped = encodedValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
+        guard let encodedKey = key.addingPercentEncoding(withAllowedCharacters: queryValueAllowed) else { return nil }
+        guard let encodedValueEscaped = encodedValue.addingPercentEncoding(withAllowedCharacters: queryValueAllowed) else { return nil }
         return "\(encodedKey)=\(encodedValueEscaped)"
       }
     return items.isEmpty ? nil : items.joined(separator: "&")

--- a/Tests/InstantSearchCoreTests/Unit/SearchParamsEncoderTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/SearchParamsEncoderTests.swift
@@ -75,4 +75,35 @@ final class SearchParamsEncoderTests: XCTestCase {
       )
     }
   }
+
+  /// Hierarchical / `FilterState` flows produce a SQL-like `filters` string. A facet value containing `&`
+  /// (e.g. `"Category & Name"`) must also be percent-encoded so the server doesn't split the `params`
+  /// query string in the middle of the `filters` value.
+  func testEncodingEscapesAmpersandInFiltersString() throws {
+    let originalFilters = #"( "hierarchicalCategories.lvl0":"Category & Name" )"#
+    var params = SearchSearchParamsObject()
+    params.filters = originalFilters
+
+    let encoded = try XCTUnwrap(SearchParamsEncoder.encode(params))
+
+    XCTAssertFalse(
+      encoded.contains("Category & Name"),
+      "Raw '&' in `filters` would break query-string parsing on the server; got: \(encoded)"
+    )
+
+    let pairs = encoded
+      .split(separator: "&")
+      .map { $0.split(separator: "=", maxSplits: 1).map(String.init) }
+    for pair in pairs {
+      XCTAssertEqual(pair.count, 2, "Every pair should split cleanly into key=value")
+    }
+
+    let filtersPair = try XCTUnwrap(pairs.first { $0.first == "filters" })
+    let decoded = try XCTUnwrap(filtersPair[1].removingPercentEncoding)
+    XCTAssertEqual(
+      decoded,
+      originalFilters,
+      "After percent-decoding the value should match the original filters string"
+    )
+  }
 }

--- a/Tests/InstantSearchCoreTests/Unit/SearchParamsEncoderTests.swift
+++ b/Tests/InstantSearchCoreTests/Unit/SearchParamsEncoderTests.swift
@@ -1,0 +1,78 @@
+//
+//  SearchParamsEncoderTests.swift
+//  InstantSearchCoreTests
+//
+
+import XCTest
+import AlgoliaSearch
+@testable import InstantSearchCore
+
+final class SearchParamsEncoderTests: XCTestCase {
+  /// Values containing `&` must be percent-encoded so that the resulting `params` string can be split on `&`
+  /// to recover the original `key=value` pairs. Otherwise the server interprets the tail as an unknown
+  /// parameter (see issue where `facetFilters` values like "Dates & Dried Fruits" caused HTTP 400
+  /// `Unknown parameter` errors).
+  func testEncodingEscapesAmpersandInFacetFilterValues() throws {
+    var params = SearchSearchParamsObject()
+    params.query = "Pepsi"
+    params.facetFilters = .arrayOfSearchFacetFilters([
+      .string("categoryEnglishPath:\"Turbomart>>Fruits>>Dates & Dried Fruits\""),
+    ])
+
+    let encoded = try XCTUnwrap(SearchParamsEncoder.encode(params))
+
+    XCTAssertFalse(
+      encoded.contains("Dates & Dried"),
+      "Raw '&' in a value would break query-string parsing on the server; got: \(encoded)"
+    )
+    XCTAssertTrue(
+      encoded.contains("%26"),
+      "Expected '&' to be percent-encoded as %26; got: \(encoded)"
+    )
+
+    let pairs = encoded
+      .split(separator: "&")
+      .map { $0.split(separator: "=", maxSplits: 1).map(String.init) }
+
+    for pair in pairs {
+      XCTAssertEqual(pair.count, 2, "Every pair should split cleanly into key=value")
+    }
+
+    let facetFiltersPair = try XCTUnwrap(pairs.first { $0.first == "facetFilters" })
+    let decodedValue = try XCTUnwrap(facetFiltersPair[1].removingPercentEncoding)
+    XCTAssertTrue(
+      decodedValue.contains("Dates & Dried Fruits"),
+      "After percent-decoding the value should match the original filter string; got: \(decodedValue)"
+    )
+  }
+
+  /// The sub-delimiters listed in RFC 3986 that could otherwise be mistaken for separators when the
+  /// server re-parses the `params` query string.
+  func testEncodingEscapesReservedSubDelimitersInValues() throws {
+    var params = SearchSearchParamsObject()
+    params.facetFilters = .arrayOfSearchFacetFilters([
+      .string("attr:a=b+c?d#e;f/g@h"),
+    ])
+
+    let encoded = try XCTUnwrap(SearchParamsEncoder.encode(params))
+    let facetPair = try XCTUnwrap(
+      encoded.split(separator: "&").first { $0.hasPrefix("facetFilters=") }
+    )
+    let value = facetPair.dropFirst("facetFilters=".count)
+
+    for reserved in ["=", "+", "?", "#", ";", "/", "@"] {
+      XCTAssertFalse(
+        value.contains(reserved),
+        "Expected reserved character '\(reserved)' to be percent-encoded; got: \(value)"
+      )
+    }
+
+    let decoded = try XCTUnwrap(String(value).removingPercentEncoding)
+    for reserved in ["=", "+", "?", "#", ";", "@"] {
+      XCTAssertTrue(
+        decoded.contains(reserved),
+        "Round-trip decoding should preserve reserved character '\(reserved)'; got: \(decoded)"
+      )
+    }
+  }
+}


### PR DESCRIPTION
**Summary**

Fixes: https://github.com/algolia/instantsearch-ios/issues/355

`SearchParamsEncoder` previously used `CharacterSet.urlQueryAllowed` to escape each key and value before joining them as `key=value&key=value`. That set leaves the sub-delimiters `& = + ? # ; / @` unescaped because they are legal in the query component as a whole, but they become delimiters once the server re-parses the `params` string. As a result, a `facetFilters` value containing `&` (e.g. `"Dates & Dried Fruits"`) was split on the server side and the tail was interpreted as an unknown parameter, producing:

Status code: 400 Message: Unknown parameter: 20Dried20Fruits5C22225D5D

This affected every search routed through the disjunctive-faceting path (the default), since that path serializes `SearchSearchParamsObject` into a URL-encoded `params` string for the multi-query endpoint.

Use a stricter character set derived from `.urlQueryAllowed` minus `& = + ? # ; / @` so reserved sub-delimiters inside values are correctly percent-encoded and survive a round trip through the server's query parser.

Adds `SearchParamsEncoderTests` covering the original `&` regression and the remaining reserved sub-delimiters.

