### PR TITLE
(feat): Add experimental InstantSearchAgent product for Agent Studio

### DIFF
--- a/Examples/Agent/AgentStudioDemoView.swift
+++ b/Examples/Agent/AgentStudioDemoView.swift
@@ -74,9 +74,25 @@ private struct ChatView: View {
           .padding(.horizontal)
       }
 
+      // Prompt suggestions ("what to ask next"). Shown only while idle, as
+      // tappable chips; tapping one sends it as a new user message — the same
+      // behavior as the web Chat widget.
+      if chat.status == .ready, !chat.suggestions.isEmpty {
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            ForEach(chat.suggestions, id: \.self) { suggestion in
+              SuggestionChip(text: suggestion) { chat.send(text: suggestion) }
+            }
+          }
+          .padding(.horizontal)
+        }
+      }
+
       HStack {
-        TextField("Ask anything…", text: $input, onCommit: send)
+        TextField("Ask anything…", text: $input)
           .textFieldStyle(.roundedBorder)
+          .submitLabel(.send)
+          .onSubmit(send)
         Button("Send", action: send)
           .disabled(input.isEmpty || chat.status != .ready)
         if chat.status == .streaming {
@@ -90,9 +106,31 @@ private struct ChatView: View {
 
   private func send() {
     let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    // Clear the field immediately so it never retains the sent text, even if the
+    // store rejects the message (e.g. while a request is already in flight).
+    input = ""
     guard !trimmed.isEmpty else { return }
     chat.send(text: trimmed)
-    input = ""
+  }
+}
+
+@available(iOS 15.0, *)
+private struct SuggestionChip: View {
+  let text: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Text(text)
+        .font(.subheadline)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+          Capsule().stroke(Color.accentColor.opacity(0.5), lineWidth: 1)
+        )
+    }
+    .buttonStyle(.plain)
+    .foregroundColor(.accentColor)
   }
 }
 

--- a/Examples/Agent/AgentStudioDemoView.swift
+++ b/Examples/Agent/AgentStudioDemoView.swift
@@ -6,8 +6,8 @@
 //
 //  Demonstrates the minimal flow: build an `AgentStudioTransport` from
 //  credentials, drive a `ChatStore`, and render its observable state in
-//  SwiftUI. The agent id is entered at runtime so the demo can run against any
-//  published Agent Studio agent without hardcoding one.
+//  SwiftUI. It reuses the Agent Studio showcase agent that ships with the
+//  InstantSearch web examples, so it works out of the box with no setup.
 //
 
 import InstantSearchAgent
@@ -15,40 +15,29 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct AgentStudioDemoView: View {
-  // Public demo credentials shared by the other examples.
+  // Same Agent Studio showcase config that ships with the InstantSearch web
+  // examples (`examples/js/showcase`), so the demo works out of the box.
   // In a real app pass a SEARCH-ONLY key — never an admin key.
   private static let appID = "latency"
-  private static let apiKey = "1f6fd3a6fb973cb08419fe7d288fa4db"
+  private static let apiKey = "6be0576ff61c053d5f9a3225e2a90f76"
+  private static let agentID = "eedef238-5468-470d-bc37-f99fa741bd25"
 
-  @State private var agentID: String = ""
   @State private var input: String = ""
   @StateObject private var holder = ChatStoreHolder()
 
   var body: some View {
     VStack(spacing: 0) {
-      TextField("Agent ID (alg_…)", text: $agentID)
-        .textFieldStyle(.roundedBorder)
-        .autocorrectionDisabled()
-        .textInputAutocapitalization(.never)
-        .padding(.horizontal)
-        .padding(.top, 8)
-        .onChange(of: agentID) { newValue in
-          holder.configure(appID: Self.appID,
-                           apiKey: Self.apiKey,
-                           agentID: newValue.trimmingCharacters(in: .whitespaces))
-        }
-
       if let chat = holder.store {
-        ChatView(chat: chat, input: $input, agentID: agentID)
+        ChatView(chat: chat, input: $input)
       } else {
-        Spacer()
-        Text("Enter an Agent ID to start chatting.")
-          .foregroundColor(.secondary)
-        Spacer()
+        ProgressView()
       }
     }
     .navigationTitle("Agent Studio")
     .navigationBarTitleDisplayMode(.inline)
+    .onAppear {
+      holder.configure(appID: Self.appID, apiKey: Self.apiKey, agentID: Self.agentID)
+    }
   }
 }
 
@@ -56,7 +45,6 @@ struct AgentStudioDemoView: View {
 private struct ChatView: View {
   @ObservedObject var chat: ChatStore
   @Binding var input: String
-  let agentID: String
 
   var body: some View {
     VStack {
@@ -90,7 +78,7 @@ private struct ChatView: View {
         TextField("Ask anything…", text: $input, onCommit: send)
           .textFieldStyle(.roundedBorder)
         Button("Send", action: send)
-          .disabled(input.isEmpty || agentID.isEmpty || chat.status != .ready)
+          .disabled(input.isEmpty || chat.status != .ready)
         if chat.status == .streaming {
           Button("Stop", action: chat.stop)
         }
@@ -102,7 +90,7 @@ private struct ChatView: View {
 
   private func send() {
     let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty, !agentID.isEmpty else { return }
+    guard !trimmed.isEmpty else { return }
     chat.send(text: trimmed)
     input = ""
   }
@@ -117,12 +105,12 @@ private struct MessageRow: View {
       Text(message.role == .user ? "You" : "Assistant")
         .font(.caption).bold()
         .foregroundColor(.secondary)
-      Text(message.plainText.isEmpty ? "…" : message.plainText)
-        .fixedSize(horizontal: false, vertical: true)
+      if !message.plainText.isEmpty {
+        Text(message.plainText)
+          .fixedSize(horizontal: false, vertical: true)
+      }
       ForEach(toolCalls, id: \.toolCallId) { tool in
-        Text("🔧 \(tool.toolName) • \(label(for: tool.state))")
-          .font(.caption)
-          .foregroundColor(.secondary)
+        ToolPartView(tool: tool)
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)
@@ -134,14 +122,124 @@ private struct MessageRow: View {
       return nil
     }
   }
+}
 
-  private func label(for state: ToolCallState) -> String {
-    switch state {
-    case .inputStreaming: return "preparing…"
-    case .inputAvailable: return "running…"
-    case .outputAvailable: return "done"
-    case let .outputError(_, errorText): return "error: \(errorText)"
+@available(iOS 15.0, *)
+private struct ToolPartView: View {
+  let tool: ToolUIPart
+
+  var body: some View {
+    switch tool.state {
+    case let .outputAvailable(_, output, _):
+      // Mirrors the web Chat widget: the `algolia_search_index` tool returns
+      // `output.hits`, which we render as a product carousel.
+      let products = Self.isSearchTool(tool.toolName) ? Self.products(from: output) : []
+      if products.isEmpty {
+        statusLabel("done")
+      } else {
+        ProductCarousel(products: products)
+      }
+    case let .outputError(_, errorText):
+      statusLabel("error: \(errorText)")
+    case .inputAvailable:
+      statusLabel("running…")
+    case .inputStreaming:
+      statusLabel("preparing…")
     }
+  }
+
+  private func statusLabel(_ status: String) -> some View {
+    Text("🔧 \(tool.toolName) • \(status)")
+      .font(.caption)
+      .foregroundColor(.secondary)
+  }
+
+  /// The web showcase treats `algolia_search_index` and `algolia_search_index_*`
+  /// (MCP) as product search.
+  static func isSearchTool(_ name: String) -> Bool {
+    name == "algolia_search_index" || name.hasPrefix("algolia_search_index_")
+  }
+
+  /// Reads `output.hits[]` from the search tool result, matching the web widget.
+  static func products(from output: Data) -> [AgentProduct] {
+    guard let root = try? JSONSerialization.jsonObject(with: output) as? [String: Any],
+          let hits = root["hits"] as? [[String: Any]] else {
+      return []
+    }
+    return hits.compactMap { hit in
+      guard let objectID = hit["objectID"] as? String else { return nil }
+      let name = (hit["name"] as? String) ?? (hit["title"] as? String) ?? objectID
+      let imageURL = (hit["image"] as? String) ?? (hit["image_url"] as? String) ?? (hit["thumbnailUrl"] as? String)
+      let price: String? = {
+        if let value = hit["price"] as? Double { return "$\(value)" }
+        if let value = hit["price"] as? Int { return "$\(value)" }
+        return nil
+      }()
+      return AgentProduct(objectID: objectID, name: name, imageURL: imageURL.flatMap(URL.init(string:)), price: price)
+    }
+  }
+}
+
+private struct AgentProduct: Identifiable, Equatable {
+  let objectID: String
+  let name: String
+  let imageURL: URL?
+  let price: String?
+
+  var id: String { objectID }
+}
+
+@available(iOS 15.0, *)
+private struct ProductCarousel: View {
+  let products: [AgentProduct]
+
+  var body: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(alignment: .top, spacing: 8) {
+        ForEach(products) { ProductCard(product: $0) }
+      }
+      .padding(.vertical, 8)
+    }
+  }
+}
+
+@available(iOS 15.0, *)
+private struct ProductCard: View {
+  let product: AgentProduct
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ZStack {
+        Color(.secondarySystemBackground)
+        if let url = product.imageURL {
+          AsyncImage(url: url) { image in
+            image.resizable().scaledToFit()
+          } placeholder: {
+            ProgressView()
+          }
+        } else {
+          Text("🛍️").font(.largeTitle)
+        }
+      }
+      .frame(width: 140, height: 120)
+      .clipped()
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(product.name)
+          .font(.caption).bold()
+          .lineLimit(2)
+        if let price = product.price {
+          Text(price)
+            .font(.caption)
+            .foregroundColor(.accentColor)
+        }
+      }
+      .padding(8)
+      .frame(width: 140, alignment: .leading)
+    }
+    .background(Color(.systemBackground))
+    .cornerRadius(8)
+    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color(.separator), lineWidth: 0.5))
   }
 }
 

--- a/Examples/Agent/AgentStudioDemoView.swift
+++ b/Examples/Agent/AgentStudioDemoView.swift
@@ -1,0 +1,168 @@
+//
+//  AgentStudioDemoView.swift
+//  Examples
+//
+//  Showcase for the experimental, standalone `InstantSearchAgent` package.
+//
+//  Demonstrates the minimal flow: build an `AgentStudioTransport` from
+//  credentials, drive a `ChatStore`, and render its observable state in
+//  SwiftUI. The agent id is entered at runtime so the demo can run against any
+//  published Agent Studio agent without hardcoding one.
+//
+
+import InstantSearchAgent
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct AgentStudioDemoView: View {
+  // Public demo credentials shared by the other examples.
+  // In a real app pass a SEARCH-ONLY key — never an admin key.
+  private static let appID = "latency"
+  private static let apiKey = "1f6fd3a6fb973cb08419fe7d288fa4db"
+
+  @State private var agentID: String = ""
+  @State private var input: String = ""
+  @StateObject private var holder = ChatStoreHolder()
+
+  var body: some View {
+    VStack(spacing: 0) {
+      TextField("Agent ID (alg_…)", text: $agentID)
+        .textFieldStyle(.roundedBorder)
+        .autocorrectionDisabled()
+        .textInputAutocapitalization(.never)
+        .padding(.horizontal)
+        .padding(.top, 8)
+        .onChange(of: agentID) { newValue in
+          holder.configure(appID: Self.appID,
+                           apiKey: Self.apiKey,
+                           agentID: newValue.trimmingCharacters(in: .whitespaces))
+        }
+
+      if let chat = holder.store {
+        ChatView(chat: chat, input: $input, agentID: agentID)
+      } else {
+        Spacer()
+        Text("Enter an Agent ID to start chatting.")
+          .foregroundColor(.secondary)
+        Spacer()
+      }
+    }
+    .navigationTitle("Agent Studio")
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}
+
+@available(iOS 15.0, *)
+private struct ChatView: View {
+  @ObservedObject var chat: ChatStore
+  @Binding var input: String
+  let agentID: String
+
+  var body: some View {
+    VStack {
+      ScrollViewReader { proxy in
+        ScrollView {
+          LazyVStack(alignment: .leading, spacing: 12) {
+            ForEach(chat.messages) { message in
+              MessageRow(message: message).id(message.id)
+            }
+            if chat.status == .submitted || chat.status == .streaming {
+              ProgressView().padding(.vertical, 4)
+            }
+          }
+          .padding()
+        }
+        .onChange(of: chat.messages.count) { _ in
+          if let last = chat.messages.last {
+            withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+          }
+        }
+      }
+
+      if let error = chat.error {
+        Text(String(describing: error))
+          .font(.caption)
+          .foregroundColor(.red)
+          .padding(.horizontal)
+      }
+
+      HStack {
+        TextField("Ask anything…", text: $input, onCommit: send)
+          .textFieldStyle(.roundedBorder)
+        Button("Send", action: send)
+          .disabled(input.isEmpty || agentID.isEmpty || chat.status != .ready)
+        if chat.status == .streaming {
+          Button("Stop", action: chat.stop)
+        }
+      }
+      .padding(.horizontal)
+      .padding(.bottom, 8)
+    }
+  }
+
+  private func send() {
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, !agentID.isEmpty else { return }
+    chat.send(text: trimmed)
+    input = ""
+  }
+}
+
+@available(iOS 15.0, *)
+private struct MessageRow: View {
+  let message: UIMessage<EmptyMetadata>
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(message.role == .user ? "You" : "Assistant")
+        .font(.caption).bold()
+        .foregroundColor(.secondary)
+      Text(message.plainText.isEmpty ? "…" : message.plainText)
+        .fixedSize(horizontal: false, vertical: true)
+      ForEach(toolCalls, id: \.toolCallId) { tool in
+        Text("🔧 \(tool.toolName) • \(label(for: tool.state))")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var toolCalls: [ToolUIPart] {
+    message.parts.compactMap { part in
+      if case let .tool(tool) = part { return tool }
+      return nil
+    }
+  }
+
+  private func label(for state: ToolCallState) -> String {
+    switch state {
+    case .inputStreaming: return "preparing…"
+    case .inputAvailable: return "running…"
+    case .outputAvailable: return "done"
+    case let .outputError(_, errorText): return "error: \(errorText)"
+    }
+  }
+}
+
+/// Holds the `ChatStore` so it can be rebuilt when the agent id changes while
+/// keeping a stable `@StateObject` identity for the screen.
+@available(iOS 15.0, *)
+@MainActor
+private final class ChatStoreHolder: ObservableObject {
+  @Published var store: ChatStore?
+  private var currentAgentID: String?
+
+  func configure(appID: String, apiKey: String, agentID: String) {
+    guard !agentID.isEmpty else {
+      store = nil
+      currentAgentID = nil
+      return
+    }
+    guard agentID != currentAgentID else { return }
+    currentAgentID = agentID
+    store?.stop()
+    let transport = AgentStudioTransport(appID: appID, apiKey: apiKey, agentID: agentID)
+    store = ChatStore(transport: transport)
+  }
+}

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -675,6 +675,7 @@
 		AF50CED327FC53230036F549 /* UIView+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF50CCBE27FAE6AA0036F549 /* UIView+Layout.swift */; };
 		AF7FEB89272CAC5D0003BE62 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7FEB88272CAC5D0003BE62 /* AppDelegate.swift */; };
 		AF7FEB8B272CAC5D0003BE62 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7FEB8A272CAC5D0003BE62 /* SceneDelegate.swift */; };
+		A6E47A0400000040000AAA04 /* AgentStudioDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E47A0300000030000AAA03 /* AgentStudioDemoView.swift */; };
 		AF7FEB92272CAC5E0003BE62 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF7FEB91272CAC5E0003BE62 /* Assets.xcassets */; };
 		AF7FEB95272CAC5E0003BE62 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AF7FEB93272CAC5E0003BE62 /* LaunchScreen.storyboard */; };
 		AF8311FC27FC7CD200509DF5 /* InstantSearch in Frameworks */ = {isa = PBXBuildFile; productRef = AF8311FB27FC7CD200509DF5 /* InstantSearch */; };
@@ -789,6 +790,7 @@
 		AFEFEF9227F47F8300B47F7F /* ProductTableViewCell+ProductHit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEFEF8B27F47F8300B47F7F /* ProductTableViewCell+ProductHit.swift */; };
 		AFEFEF9327F47F8300B47F7F /* ProductTableViewCell+ProductHit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEFEF8B27F47F8300B47F7F /* ProductTableViewCell+ProductHit.swift */; };
 		AFEFEF9C27F48EC200B47F7F /* InstantSearch in Frameworks */ = {isa = PBXBuildFile; productRef = AFEFEF9B27F48EC200B47F7F /* InstantSearch */; };
+		A6E47A0100000010000AAA01 /* InstantSearchAgent in Frameworks */ = {isa = PBXBuildFile; productRef = A6E47A0200000020000AAA02 /* InstantSearchAgent */; };
 		AFEFEF9E27F48ECA00B47F7F /* InstantSearch in Frameworks */ = {isa = PBXBuildFile; productRef = AFEFEF9D27F48ECA00B47F7F /* InstantSearch */; };
 		AFEFEFA027F48EE100B47F7F /* InstantSearch in Frameworks */ = {isa = PBXBuildFile; productRef = AFEFEF9F27F48EE100B47F7F /* InstantSearch */; };
 		AFEFEFA227F48EE500B47F7F /* InstantSearch in Frameworks */ = {isa = PBXBuildFile; productRef = AFEFEFA127F48EE500B47F7F /* InstantSearch */; };
@@ -1084,6 +1086,7 @@
 		AF7FEB85272CAC5D0003BE62 /* Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Examples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF7FEB88272CAC5D0003BE62 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AF7FEB8A272CAC5D0003BE62 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		A6E47A0300000030000AAA03 /* AgentStudioDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStudioDemoView.swift; sourceTree = "<group>"; };
 		AF7FEB91272CAC5E0003BE62 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AF7FEB94272CAC5E0003BE62 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AF7FEB96272CAC5E0003BE62 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1402,6 +1405,7 @@
 			files = (
 				AF50CA2127F6FB220036F549 /* InstantSearchSwiftUI in Frameworks */,
 				AFEFEF9C27F48EC200B47F7F /* InstantSearch in Frameworks */,
+				A6E47A0100000010000AAA01 /* InstantSearchAgent in Frameworks */,
 				AF508A042766D08200F30F18 /* SDWebImage in Frameworks */,
 				AFEFEFAB27F48F3300B47F7F /* InstantSearchVoiceOverlay in Frameworks */,
 			);
@@ -1989,6 +1993,7 @@
 				4022E866280EE07C00D71D66 /* Showcase */,
 				AFEFEF9527F48ABB00B47F7F /* Packages */,
 				AF50CD8827FB27CE0036F549 /* Shared */,
+				A6E47A0500000050000AAA05 /* Agent */,
 				AF7FEB87272CAC5D0003BE62 /* Examples */,
 				AF46A7572747EF9D004E86F3 /* CategoriesHits */,
 				AFAE55372733E09300B52A43 /* MultiIndex */,
@@ -2042,6 +2047,14 @@
 				40718B4C282923E80061DC87 /* MediaDemo.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		A6E47A0500000050000AAA05 /* Agent */ = {
+			isa = PBXGroup;
+			children = (
+				A6E47A0300000030000AAA03 /* AgentStudioDemoView.swift */,
+			);
+			path = Agent;
 			sourceTree = "<group>";
 		};
 		AF7FEB87272CAC5D0003BE62 /* Examples */ = {
@@ -2756,6 +2769,7 @@
 			packageProductDependencies = (
 				AF508A032766D08200F30F18 /* SDWebImage */,
 				AFEFEF9B27F48EC200B47F7F /* InstantSearch */,
+				A6E47A0200000020000AAA02 /* InstantSearchAgent */,
 				AFEFEFAA27F48F3300B47F7F /* InstantSearchVoiceOverlay */,
 				AF50CA2027F6FB220036F549 /* InstantSearchSwiftUI */,
 			);
@@ -4086,6 +4100,7 @@
 				AFE7BE1D27FF07C8003CAC71 /* DynamicFacetList.swift in Sources */,
 				404C4112280C991000EC9FEB /* SortByDemoSwiftUI.swift in Sources */,
 				4034B6F32810078B00F4A303 /* ProductRow+StoreItem.swift in Sources */,
+				A6E47A0400000040000AAA04 /* AgentStudioDemoView.swift in Sources */,
 				AF7FEB8B272CAC5D0003BE62 /* SceneDelegate.swift in Sources */,
 				404C40D1280C95A000EC9FEB /* CurrentFiltersDemoViewController.swift in Sources */,
 				AFB181A627FC8FF3000AA57B /* ToggleFilterDemoController.swift in Sources */,
@@ -7036,6 +7051,10 @@
 		AFEFEF9B27F48EC200B47F7F /* InstantSearch */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = InstantSearch;
+		};
+		A6E47A0200000020000AAA02 /* InstantSearchAgent */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = InstantSearchAgent;
 		};
 		AFEFEF9D27F48ECA00B47F7F /* InstantSearch */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/Examples/Demo.swift
+++ b/Examples/Examples/Demo.swift
@@ -33,6 +33,13 @@ struct Demo: Codable, DemoProtocol {
     case codexQuerySuggestions = "codex_query_suggestions"
     case codexMultipleIndex = "codex_multiple_index"
     case codexCategoriesHits = "codex_categories_hits"
+    case agenticExperience = "experimental_agentic_experience"
   }
   // swiftlint:enable type_name
+
+  /// Static entries that are not backed by the `mobile_demos` Algolia index.
+  /// Appended after the index-driven demos so they always render last.
+  static let experimental: [Demo] = [
+    Demo(objectID: ID.agenticExperience.rawValue, name: "Agentic Experience", type: "Experimental"),
+  ]
 }

--- a/Examples/Examples/DemoListViewController.swift
+++ b/Examples/Examples/DemoListViewController.swift
@@ -23,6 +23,10 @@ final class DemoListViewController<Demo: DemoProtocol & Codable>: UITableViewCon
   private let cellIdentifier = "cellID"
   var groupedDemos: [(groupName: String, demos: [Demo])]
 
+  /// Static sections appended after the index-driven demos (e.g. experimental
+  /// entries that have no backing Algolia record). Always rendered last.
+  var extraSections: [(groupName: String, demos: [Demo])] = []
+
   init(indexName: String) {
     searcher = HitsSearcher(client: .instantSearch, indexName: indexName)
     filterState = .init()
@@ -69,6 +73,7 @@ final class DemoListViewController<Demo: DemoProtocol & Codable>: UITableViewCon
     groupedDemos = demosPerType
       .sorted { $0.key < $1.key }
       .map { ($0.key, $0.value.sorted { $0.name < $1.name }) }
+      + extraSections
     DispatchQueue.main.async {
       self.tableView.reloadData()
     }

--- a/Examples/Examples/DemoViewControllerFactory.swift
+++ b/Examples/Examples/DemoViewControllerFactory.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 import UIKit
 // swiftlint:disable cyclomatic_complexity
 class DemoViewControllerFactory: ViewControllerFactory {
@@ -68,6 +69,12 @@ class DemoViewControllerFactory: ViewControllerFactory {
       viewController.didSelect = pusher.callAsFunction(_:)
       viewController.title = "Declarative UI"
       return viewController
+
+    case .agenticExperience:
+      guard #available(iOS 15.0, *) else { return .none }
+      let hostingController = UIHostingController(rootView: AgentStudioDemoView())
+      hostingController.title = "Agentic Experience"
+      return hostingController
     }
   }
 }

--- a/Examples/Examples/SceneDelegate.swift
+++ b/Examples/Examples/SceneDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by Vladislav Fitc on 30/10/2021.
 //
 
+import SwiftUI
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -16,6 +17,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let pusher = ViewControllerPusher(factory: DemoViewControllerFactory(),
                                       sourceViewController: demoListViewController)
     demoListViewController.didSelect = pusher.callAsFunction
+
+    // Persistent entry point for the experimental InstantSearchAgent demo.
+    // It's surfaced here (rather than via the Algolia-driven demo list) so it
+    // works without a backing demo record.
+    if #available(iOS 15.0, *) {
+      demoListViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(
+        title: "Agent Studio",
+        style: .plain,
+        target: self,
+        action: #selector(openAgentStudioDemo)
+      )
+    }
+
     setMain(demoListViewController, for: scene)
+  }
+
+  @available(iOS 15.0, *)
+  @objc private func openAgentStudioDemo() {
+    let hostingController = UIHostingController(rootView: AgentStudioDemoView())
+    hostingController.title = "Agent Studio"
+    (window?.rootViewController as? UINavigationController)?
+      .pushViewController(hostingController, animated: true)
   }
 }

--- a/Examples/Examples/SceneDelegate.swift
+++ b/Examples/Examples/SceneDelegate.swift
@@ -5,7 +5,6 @@
 //  Created by Vladislav Fitc on 30/10/2021.
 //
 
-import SwiftUI
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -14,30 +13,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
     let demoListViewController = DemoListViewController<Demo>(indexName: "mobile_demos")
     demoListViewController.title = "Examples"
+    // Surface the experimental InstantSearchAgent demo as the last section of
+    // the demo list. It's a static entry (no backing Algolia record).
+    demoListViewController.extraSections = [(groupName: "Experimental", demos: Demo.experimental)]
     let pusher = ViewControllerPusher(factory: DemoViewControllerFactory(),
                                       sourceViewController: demoListViewController)
     demoListViewController.didSelect = pusher.callAsFunction
 
-    // Persistent entry point for the experimental InstantSearchAgent demo.
-    // It's surfaced here (rather than via the Algolia-driven demo list) so it
-    // works without a backing demo record.
-    if #available(iOS 15.0, *) {
-      demoListViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(
-        title: "Agent Studio",
-        style: .plain,
-        target: self,
-        action: #selector(openAgentStudioDemo)
-      )
-    }
-
     setMain(demoListViewController, for: scene)
-  }
-
-  @available(iOS 15.0, *)
-  @objc private func openAgentStudioDemo() {
-    let hostingController = UIHostingController(rootView: AgentStudioDemoView())
-    hostingController.title = "Agent Studio"
-    (window?.rootViewController as? UINavigationController)?
-      .pushViewController(hostingController, animated: true)
   }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,10 @@ let package = Package(
     .library(
       name: "InstantSearchSwiftUI",
       targets: ["InstantSearchSwiftUI"]
+    ),
+    .library(
+      name: "InstantSearchAgent",
+      targets: ["InstantSearchAgent"]
     )
   ],
   dependencies: [
@@ -104,6 +108,16 @@ let package = Package(
     .testTarget(
       name: "InstantSearchSwiftUITests",
       dependencies: ["InstantSearchSwiftUI"]
+    ),
+    .target(
+      name: "InstantSearchAgent",
+      dependencies: [],
+      exclude: ["README.md"],
+      resources: [.copy("../PrivacyInfo.xcprivacy")]
+    ),
+    .testTarget(
+      name: "InstantSearchAgentTests",
+      dependencies: ["InstantSearchAgent"]
     )
   ]
 )

--- a/Sources/InstantSearchAgent/Chat/ChatStore+Reducer.swift
+++ b/Sources/InstantSearchAgent/Chat/ChatStore+Reducer.swift
@@ -11,6 +11,10 @@
 import Foundation
 
 enum ChunkReducer {
+  // One exhaustive `switch` over every chunk type; the high complexity and
+  // length are inherent to a flat dispatch and splitting it would only scatter
+  // the reducer logic.
+  // swiftlint:disable cyclomatic_complexity function_body_length
   /// Apply `chunk` to `message` in place. Returns whether the chunk produced a
   /// visible change (used to debounce UI updates).
   @discardableResult
@@ -167,6 +171,7 @@ enum ChunkReducer {
       return false
     }
   }
+  // swiftlint:enable cyclomatic_complexity function_body_length
 
   // MARK: - helpers
 

--- a/Sources/InstantSearchAgent/Chat/ChatStore+Reducer.swift
+++ b/Sources/InstantSearchAgent/Chat/ChatStore+Reducer.swift
@@ -1,0 +1,189 @@
+//
+//  ChatStore+Reducer.swift
+//  InstantSearchAgent
+//
+//  Reduces a `UIMessageChunk` onto an existing assistant `UIMessage`.
+//
+//  This is the native equivalent of the chunk-handling switch inside
+//  `AbstractChat.processStreamChunk` in `instantsearch.js/src/lib/ai-lite/abstract-chat.ts`.
+//
+
+import Foundation
+
+enum ChunkReducer {
+  /// Apply `chunk` to `message` in place. Returns whether the chunk produced a
+  /// visible change (used to debounce UI updates).
+  @discardableResult
+  static func apply(_ chunk: UIMessageChunk, to message: inout UIMessage<EmptyMetadata>) -> Bool {
+    switch chunk {
+    case .start:
+      return false
+
+    case .startStep:
+      message.parts.append(.stepStart)
+      return true
+
+    case .finishStep, .finish, .abort:
+      // Mark any still-streaming text/reasoning as done.
+      message.parts = message.parts.map { part in
+        switch part {
+        case let .text(id, text, .streaming):
+          return .text(id: id, text: text, state: .done)
+        case let .reasoning(id, text, .streaming):
+          return .reasoning(id: id, text: text, state: .done)
+        default:
+          return part
+        }
+      }
+      return true
+
+    case let .textStart(id):
+      message.parts.append(.text(id: id, text: "", state: .streaming))
+      return true
+
+    case let .textDelta(id, delta):
+      if let index = lastTextIndex(in: message, withId: id) {
+        if case let .text(partId, current, _) = message.parts[index] {
+          message.parts[index] = .text(id: partId, text: current + delta, state: .streaming)
+          return true
+        }
+      } else {
+        message.parts.append(.text(id: id, text: delta, state: .streaming))
+        return true
+      }
+      return false
+
+    case let .textEnd(id):
+      if let index = lastTextIndex(in: message, withId: id),
+         case let .text(partId, text, _) = message.parts[index] {
+        message.parts[index] = .text(id: partId, text: text, state: .done)
+        return true
+      }
+      return false
+
+    case let .reasoningStart(id):
+      message.parts.append(.reasoning(id: id, text: "", state: .streaming))
+      return true
+
+    case let .reasoningDelta(id, delta):
+      if let index = lastReasoningIndex(in: message, withId: id),
+         case let .reasoning(partId, current, _) = message.parts[index] {
+        message.parts[index] = .reasoning(id: partId, text: current + delta, state: .streaming)
+        return true
+      } else {
+        message.parts.append(.reasoning(id: id, text: delta, state: .streaming))
+        return true
+      }
+
+    case let .reasoningEnd(id):
+      if let index = lastReasoningIndex(in: message, withId: id),
+         case let .reasoning(partId, text, _) = message.parts[index] {
+        message.parts[index] = .reasoning(id: partId, text: text, state: .done)
+        return true
+      }
+      return false
+
+    case let .toolInputStart(name, cid):
+      upsertTool(in: &message, toolCallId: cid) {
+        ToolUIPart(toolName: name, toolCallId: cid, state: .inputStreaming(partial: nil))
+      } update: { existing in
+        existing.state = .inputStreaming(partial: nil)
+      }
+      return true
+
+    case let .toolInputDelta(name, cid, _):
+      // We don't reconstruct the partial JSON in v0.1 — the JS lib does this
+      // to support `streamInput` tools, which we'll add in v0.2.
+      upsertTool(in: &message, toolCallId: cid) {
+        ToolUIPart(toolName: name, toolCallId: cid, state: .inputStreaming(partial: nil))
+      } update: { _ in }
+      return false
+
+    case let .toolInputAvailable(name, cid, input):
+      upsertTool(in: &message, toolCallId: cid) {
+        ToolUIPart(toolName: name, toolCallId: cid, state: .inputAvailable(input: input))
+      } update: { existing in
+        existing.state = .inputAvailable(input: input)
+      }
+      return true
+
+    case let .toolOutputAvailable(name, cid, output, preliminary):
+      upsertTool(in: &message, toolCallId: cid) {
+        ToolUIPart(toolName: name, toolCallId: cid,
+                   state: .outputAvailable(input: Data("null".utf8), output: output, preliminary: preliminary))
+      } update: { existing in
+        let input: Data = {
+          if case let .inputAvailable(input) = existing.state { return input }
+          if case let .outputAvailable(input, _, _) = existing.state { return input }
+          return Data("null".utf8)
+        }()
+        existing.state = .outputAvailable(input: input, output: output, preliminary: preliminary)
+      }
+      return true
+
+    case let .toolError(name, cid, errorText, input):
+      upsertTool(in: &message, toolCallId: cid) {
+        ToolUIPart(toolName: name, toolCallId: cid, state: .outputError(input: input, errorText: errorText))
+      } update: { existing in
+        existing.state = .outputError(input: input, errorText: errorText)
+      }
+      return true
+
+    case let .sourceURL(sid, url, title):
+      message.parts.append(.sourceURL(sourceId: sid, url: url, title: title))
+      return true
+
+    case let .file(url, mediaType):
+      message.parts.append(.file(mediaType: mediaType, url: url, filename: nil))
+      return true
+
+    case let .data(name, id, json):
+      message.parts.append(.data(name: name, id: id, json: json))
+      return true
+
+    case .error:
+      // Surfaced through ChatStore.error, not as a part.
+      return false
+
+    case let .unknown(typeIdentifier, json):
+      message.parts.append(.unknown(typeIdentifier: typeIdentifier, json: json))
+      return false
+    }
+  }
+
+  // MARK: - helpers
+
+  private static func lastTextIndex(in message: UIMessage<EmptyMetadata>, withId id: String) -> Int? {
+    for index in stride(from: message.parts.count - 1, through: 0, by: -1) {
+      if case let .text(partId, _, _) = message.parts[index], partId == id {
+        return index
+      }
+    }
+    return nil
+  }
+
+  private static func lastReasoningIndex(in message: UIMessage<EmptyMetadata>, withId id: String) -> Int? {
+    for index in stride(from: message.parts.count - 1, through: 0, by: -1) {
+      if case let .reasoning(partId, _, _) = message.parts[index], partId == id {
+        return index
+      }
+    }
+    return nil
+  }
+
+  private static func upsertTool(
+    in message: inout UIMessage<EmptyMetadata>,
+    toolCallId: String,
+    insert: () -> ToolUIPart,
+    update: (inout ToolUIPart) -> Void
+  ) {
+    for index in 0..<message.parts.count {
+      if case var .tool(part) = message.parts[index], part.toolCallId == toolCallId {
+        update(&part)
+        message.parts[index] = .tool(part)
+        return
+      }
+    }
+    message.parts.append(.tool(insert()))
+  }
+}

--- a/Sources/InstantSearchAgent/Chat/ChatStore+Reducer.swift
+++ b/Sources/InstantSearchAgent/Chat/ChatStore+Reducer.swift
@@ -95,7 +95,7 @@ enum ChunkReducer {
       // We don't reconstruct the partial JSON in v0.1 — the JS lib does this
       // to support `streamInput` tools, which we'll add in v0.2.
       upsertTool(in: &message, toolCallId: cid) {
-        ToolUIPart(toolName: name, toolCallId: cid, state: .inputStreaming(partial: nil))
+        ToolUIPart(toolName: name ?? "", toolCallId: cid, state: .inputStreaming(partial: nil))
       } update: { _ in }
       return false
 
@@ -109,7 +109,7 @@ enum ChunkReducer {
 
     case let .toolOutputAvailable(name, cid, output, preliminary):
       upsertTool(in: &message, toolCallId: cid) {
-        ToolUIPart(toolName: name, toolCallId: cid,
+        ToolUIPart(toolName: name ?? "", toolCallId: cid,
                    state: .outputAvailable(input: Data("null".utf8), output: output, preliminary: preliminary))
       } update: { existing in
         let input: Data = {
@@ -123,9 +123,26 @@ enum ChunkReducer {
 
     case let .toolError(name, cid, errorText, input):
       upsertTool(in: &message, toolCallId: cid) {
-        ToolUIPart(toolName: name, toolCallId: cid, state: .outputError(input: input, errorText: errorText))
+        ToolUIPart(toolName: name ?? "", toolCallId: cid, state: .outputError(input: input, errorText: errorText))
       } update: { existing in
         existing.state = .outputError(input: input, errorText: errorText)
+      }
+      return true
+
+    case let .toolOutputDelta(cid, name, delta):
+      upsertTool(in: &message, toolCallId: cid) {
+        var part = ToolUIPart(toolName: name ?? "", toolCallId: cid,
+                              state: .inputAvailable(input: Data("null".utf8)), rawOutput: delta)
+        part.state = Self.toolState(fromRawOutput: delta, previousInput: Data("null".utf8))
+        return part
+      } update: { existing in
+        let previousInput: Data = {
+          if case let .inputAvailable(input) = existing.state { return input }
+          if case let .outputAvailable(input, _, _) = existing.state { return input }
+          return Data("null".utf8)
+        }()
+        existing.rawOutput += delta
+        existing.state = Self.toolState(fromRawOutput: existing.rawOutput, previousInput: previousInput)
       }
       return true
 
@@ -152,6 +169,17 @@ enum ChunkReducer {
   }
 
   // MARK: - helpers
+
+  /// Parse accumulated `data-tool-output-delta` text into a preliminary
+  /// `.outputAvailable`. While the JSON is still incomplete we keep the part in
+  /// `.inputAvailable` so the UI shows a running state.
+  private static func toolState(fromRawOutput raw: String, previousInput: Data) -> ToolCallState {
+    guard let data = raw.data(using: .utf8),
+          (try? JSONSerialization.jsonObject(with: data, options: [])) != nil else {
+      return .inputAvailable(input: previousInput)
+    }
+    return .outputAvailable(input: previousInput, output: data, preliminary: true)
+  }
 
   private static func lastTextIndex(in message: UIMessage<EmptyMetadata>, withId id: String) -> Int? {
     for index in stride(from: message.parts.count - 1, through: 0, by: -1) {

--- a/Sources/InstantSearchAgent/Chat/ChatStore.swift
+++ b/Sources/InstantSearchAgent/Chat/ChatStore.swift
@@ -30,6 +30,23 @@ public final class ChatStore: ObservableObject {
   @Published public private(set) var status: ChatStatus = .ready
   @Published public private(set) var error: AgentStudioError?
 
+  /// Prompt suggestions ("what to ask next") streamed by the agent as a
+  /// `data-suggestions` part. Derived from the last assistant message, matching
+  /// the web `connectChat` behavior. Present only once that message exists;
+  /// hosts typically show these as tappable chips while `status == .ready`.
+  public var suggestions: [String] {
+    guard let message = messages.last(where: { $0.role == .assistant }) else { return [] }
+    for part in message.parts {
+      if case let .data(name, _, json) = part, name == "suggestions" {
+        struct Payload: Decodable { let suggestions: [String] }
+        if let payload = try? JSONDecoder().decode(Payload.self, from: json) {
+          return payload.suggestions
+        }
+      }
+    }
+    return []
+  }
+
   // MARK: - Configuration
 
   public let conversationID: String

--- a/Sources/InstantSearchAgent/Chat/ChatStore.swift
+++ b/Sources/InstantSearchAgent/Chat/ChatStore.swift
@@ -1,0 +1,190 @@
+//
+//  ChatStore.swift
+//  InstantSearchAgent
+//
+//  Native counterpart of the JS `Chat` class
+//  (`instantsearch.js/src/lib/chat/chat.ts`). Aggregates streamed
+//  `UIMessageChunk`s into a list of `UIMessage<EmptyMetadata>` and exposes the
+//  result as `@Published` so SwiftUI views can observe it.
+//
+
+import Foundation
+#if canImport(Combine)
+  import Combine
+#endif
+
+/// A `@Published`-backed chat state container for Algolia Agent Studio.
+///
+/// - Warning: **Experimental.** `InstantSearchAgent` is a standalone,
+///   early-stage library versioned independently (`0.x`) from the main
+///   InstantSearch library. Its API can change in source- and binary-
+///   incompatible ways — including being renamed or removed — before a stable
+///   `1.0` release. It is a beta feature per Algolia's Terms of Service
+///   ("Beta Services").
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+public final class ChatStore: ObservableObject {
+  // MARK: - Published state
+
+  @Published public private(set) var messages: [UIMessage<EmptyMetadata>] = []
+  @Published public private(set) var status: ChatStatus = .ready
+  @Published public private(set) var error: AgentStudioError?
+
+  // MARK: - Configuration
+
+  public let conversationID: String
+  private let transport: AgentStudioTransport
+  private let idGenerator: () -> String
+
+  // MARK: - Internal state
+
+  private var streamingTask: Task<Void, Never>?
+  private var assistantMessageIndex: Int?
+
+  // MARK: - Init
+
+  /// - Parameters:
+  ///   - transport: configured `AgentStudioTransport`. The simplest way to
+  ///     build one is `AgentStudioTransport(endpoint:apiKey:)` with credentials
+  ///     pulled from your existing Algolia `SearchClient`.
+  ///   - conversationID: pass a stable id (prefixed `alg_cnv_` per Algolia
+  ///     conventions) to enable server-side conversation persistence; pass
+  ///     `nil` to let the store generate one.
+  ///   - initialMessages: messages to restore at startup (e.g. from your own
+  ///     persistence layer). Pass `[]` for a fresh chat.
+  ///   - idGenerator: pluggable id factory. Defaults to UUID.
+  public init(
+    transport: AgentStudioTransport,
+    conversationID: String? = nil,
+    initialMessages: [UIMessage<EmptyMetadata>] = [],
+    idGenerator: @escaping () -> String = { "alg_msg_" + UUID().uuidString }
+  ) {
+    self.transport = transport
+    self.conversationID = conversationID ?? "alg_cnv_" + UUID().uuidString
+    self.idGenerator = idGenerator
+    self.messages = initialMessages
+  }
+
+  // MARK: - Public API
+
+  /// Send a user text message and start streaming the assistant response.
+  /// If a request is already in flight it is cancelled and replaced.
+  public func send(text: String) {
+    let userMessage = UIMessage<EmptyMetadata>(
+      id: idGenerator(),
+      role: .user,
+      parts: [.text(id: nil, text: text, state: .done)]
+    )
+    messages.append(userMessage)
+    startStream(trigger: .submitMessage)
+  }
+
+  /// Re-issue the last user message, replacing the trailing assistant message
+  /// (if any).
+  public func regenerate() {
+    guard let last = messages.last else { return }
+    if last.role == .assistant {
+      messages.removeLast()
+    }
+    startStream(trigger: .regenerateMessage)
+  }
+
+  /// Cancel any in-flight streaming request. Status returns to `.ready`.
+  public func stop() {
+    streamingTask?.cancel()
+    streamingTask = nil
+    assistantMessageIndex = nil
+    if status != .error {
+      status = .ready
+    }
+  }
+
+  /// Wipe local conversation state. Does not call any server endpoint.
+  public func clear() {
+    stop()
+    messages = []
+    error = nil
+    status = .ready
+  }
+
+  /// Clears any error state without touching the messages.
+  public func clearError() {
+    error = nil
+    if status == .error {
+      status = .ready
+    }
+  }
+
+  // MARK: - Streaming
+
+  private func startStream(trigger: AgentStudioRequest.Trigger) {
+    streamingTask?.cancel()
+    error = nil
+    status = .submitted
+    assistantMessageIndex = nil
+
+    let wireMessages: [AgentStudioRequest.WireMessage] = messages.compactMap { msg in
+      let text = msg.plainText
+      guard !text.isEmpty else { return nil }
+      return AgentStudioRequest.WireMessage(id: msg.id, role: msg.role, text: text)
+    }
+
+    let request = AgentStudioRequest(
+      conversationID: conversationID,
+      messages: wireMessages,
+      trigger: trigger
+    )
+
+    let conversationID = self.conversationID
+    let idGenerator = self.idGenerator
+
+    streamingTask = Task { [weak self] in
+      guard let self else { return }
+      do {
+        let stream = try await self.transport.sendMessages(request)
+        for try await chunk in stream {
+          if Task.isCancelled { break }
+          await self.handle(chunk: chunk, conversationID: conversationID, idGenerator: idGenerator)
+        }
+        if !Task.isCancelled {
+          self.status = .ready
+        }
+      } catch {
+        if Task.isCancelled { return }
+        self.status = .error
+        self.error = (error as? AgentStudioError) ?? .underlying(String(describing: error))
+      }
+    }
+  }
+
+  private func handle(chunk: UIMessageChunk,
+                      conversationID: String,
+                      idGenerator: () -> String) async {
+    switch chunk {
+    case let .start(messageId):
+      let id = messageId ?? idGenerator()
+      let assistant = UIMessage<EmptyMetadata>(id: id, role: .assistant)
+      messages.append(assistant)
+      assistantMessageIndex = messages.count - 1
+      status = .streaming
+    case let .error(text):
+      status = .error
+      error = .underlying(text)
+    default:
+      ensureAssistantMessage(idGenerator: idGenerator)
+      guard let index = assistantMessageIndex else { return }
+      var msg = messages[index]
+      ChunkReducer.apply(chunk, to: &msg)
+      messages[index] = msg
+      if status == .submitted { status = .streaming }
+    }
+  }
+
+  private func ensureAssistantMessage(idGenerator: () -> String) {
+    if assistantMessageIndex == nil {
+      let assistant = UIMessage<EmptyMetadata>(id: idGenerator(), role: .assistant)
+      messages.append(assistant)
+      assistantMessageIndex = messages.count - 1
+    }
+  }
+}

--- a/Sources/InstantSearchAgent/Integration/SearchClient+AgentStudio.swift
+++ b/Sources/InstantSearchAgent/Integration/SearchClient+AgentStudio.swift
@@ -1,0 +1,35 @@
+//
+//  SearchClient+AgentStudio.swift
+//  InstantSearchAgent
+//
+//  Convenience constructor that builds an `AgentStudioTransport` from your
+//  existing Algolia application credentials. Accepts raw strings to stay
+//  independent of any specific Algolia client version — pass them from
+//  whatever `SearchClient`/`Configuration` you already have:
+//
+//      let transport = AgentStudioTransport(
+//          appID: searchClient.applicationID.rawValue,
+//          apiKey: searchClient.apiKey.rawValue,
+//          agentID: "my-agent")
+//
+
+import Foundation
+
+public extension AgentStudioTransport {
+  /// Build a transport for `agentID` using application-level credentials.
+  ///
+  /// - Important: use a **search-only** API key. Never embed admin keys in a
+  ///   shipping app.
+  convenience init(appID: String,
+                   apiKey: String,
+                   agentID: String,
+                   userAgent: String? = nil,
+                   session: URLSession = .shared) {
+    self.init(
+      endpoint: AgentStudioEndpoint(appID: appID, agentID: agentID),
+      apiKey: apiKey,
+      userAgent: userAgent,
+      session: session
+    )
+  }
+}

--- a/Sources/InstantSearchAgent/Models/ChatStatus.swift
+++ b/Sources/InstantSearchAgent/Models/ChatStatus.swift
@@ -1,0 +1,20 @@
+//
+//  ChatStatus.swift
+//  InstantSearchAgent
+//
+
+import Foundation
+
+/// State of the chat lifecycle, mirroring `ChatStatus` from
+/// `instantsearch.js/src/lib/ai-lite/types.ts`.
+///
+/// - `submitted`: request sent, awaiting first chunk.
+/// - `streaming`: chunks are currently being received.
+/// - `ready`: response complete (or chat is idle).
+/// - `error`: request failed; inspect `ChatStore.error`.
+public enum ChatStatus: String, Sendable, Equatable {
+  case submitted
+  case streaming
+  case ready
+  case error
+}

--- a/Sources/InstantSearchAgent/Models/UIMessage.swift
+++ b/Sources/InstantSearchAgent/Models/UIMessage.swift
@@ -56,11 +56,16 @@ public struct ToolUIPart: Sendable, Equatable {
   public let toolName: String
   public let toolCallId: String
   public var state: ToolCallState
+  /// Raw, possibly-incomplete tool output accumulated from
+  /// `data-tool-output-delta` chunks before the final `tool-output-available`
+  /// arrives. Internal bookkeeping; the parsed result lives in `state`.
+  public var rawOutput: String
 
-  public init(toolName: String, toolCallId: String, state: ToolCallState) {
+  public init(toolName: String, toolCallId: String, state: ToolCallState, rawOutput: String = "") {
     self.toolName = toolName
     self.toolCallId = toolCallId
     self.state = state
+    self.rawOutput = rawOutput
   }
 }
 

--- a/Sources/InstantSearchAgent/Models/UIMessage.swift
+++ b/Sources/InstantSearchAgent/Models/UIMessage.swift
@@ -1,0 +1,102 @@
+//
+//  UIMessage.swift
+//  InstantSearchAgent
+//
+//  Native counterpart of the AI SDK 5 `UIMessage` shape used by
+//  `instantsearch.js/src/lib/ai-lite/types.ts`.
+//
+
+import Foundation
+
+/// Role of a message in an Agent Studio conversation.
+public enum MessageRole: String, Codable, Sendable {
+  case system
+  case user
+  case assistant
+}
+
+/// State of a streaming part (text, reasoning, …) inside a message.
+public enum PartState: String, Codable, Sendable {
+  case streaming
+  case done
+}
+
+/// A single part of an assembled `UIMessage`.
+///
+/// Mirrors the `UIMessagePart` discriminated union in
+/// `instantsearch-ui-components/src/components/chat/types.ts`. We model it as
+/// a Swift enum with a `case unknown` fallback so newly-introduced variants
+/// don't crash old clients.
+public enum UIMessagePart: Sendable, Equatable {
+  case text(id: String?, text: String, state: PartState?)
+  case reasoning(id: String?, text: String, state: PartState?)
+  case sourceURL(sourceId: String, url: URL, title: String?)
+  case file(mediaType: String, url: URL, filename: String?)
+  case stepStart
+  /// A tool invocation, keyed by `toolCallId`.
+  case tool(ToolUIPart)
+  /// A custom `data-<name>` part. The payload is kept as raw JSON so callers
+  /// can decode it into their own type.
+  case data(name: String, id: String?, json: Data)
+  /// Forward-compat fallback for chunk types we don't know yet.
+  case unknown(typeIdentifier: String, json: Data)
+}
+
+/// Lifecycle of a tool call as it transitions through the AI SDK 5
+/// `tool-input-*` / `tool-output-*` chunks.
+public enum ToolCallState: Sendable, Equatable {
+  case inputStreaming(partial: Data?)
+  case inputAvailable(input: Data)
+  case outputAvailable(input: Data, output: Data, preliminary: Bool)
+  case outputError(input: Data?, errorText: String)
+}
+
+/// A single tool invocation embedded in an assistant message.
+public struct ToolUIPart: Sendable, Equatable {
+  public let toolName: String
+  public let toolCallId: String
+  public var state: ToolCallState
+
+  public init(toolName: String, toolCallId: String, state: ToolCallState) {
+    self.toolName = toolName
+    self.toolCallId = toolCallId
+    self.state = state
+  }
+}
+
+/// An assembled message ready to be rendered by the host app.
+///
+/// `Metadata` mirrors the generic `METADATA` parameter of the JS `UIMessage`
+/// — pass `EmptyMetadata` if your agent doesn't return any.
+public struct UIMessage<Metadata: Codable & Sendable>: Sendable, Identifiable {
+  public let id: String
+  public let role: MessageRole
+  public var parts: [UIMessagePart]
+  public var metadata: Metadata?
+
+  public init(id: String, role: MessageRole, parts: [UIMessagePart] = [], metadata: Metadata? = nil) {
+    self.id = id
+    self.role = role
+    self.parts = parts
+    self.metadata = metadata
+  }
+}
+
+/// Default `Metadata` placeholder when the host app doesn't care about it.
+public struct EmptyMetadata: Codable, Sendable, Equatable {
+  public init() {}
+}
+
+// MARK: - Convenience
+
+public extension UIMessage {
+  /// Concatenated text from every `.text` part (streaming or done). Useful for
+  /// quickly rendering an assistant response without walking the parts array.
+  var plainText: String {
+    parts.reduce(into: "") { acc, part in
+      if case let .text(_, text, _) = part {
+        acc += text
+      }
+    }
+  }
+}

--- a/Sources/InstantSearchAgent/Models/UIMessageChunk.swift
+++ b/Sources/InstantSearchAgent/Models/UIMessageChunk.swift
@@ -31,12 +31,18 @@ public enum UIMessageChunk: Sendable, Equatable {
   case reasoningDelta(id: String, delta: String)
   case reasoningEnd(id: String)
 
-  // Tools (AI SDK 5 names)
+  // Tools (AI SDK 5 names). `toolName` is optional on the chunks that reference
+  // an already-started call by `toolCallId` — Agent Studio's ai-sdk-5 stream
+  // omits it there, and requiring it would silently drop the chunk.
   case toolInputStart(toolName: String, toolCallId: String)
-  case toolInputDelta(toolName: String, toolCallId: String, inputTextDelta: String)
+  case toolInputDelta(toolName: String?, toolCallId: String, inputTextDelta: String)
   case toolInputAvailable(toolName: String, toolCallId: String, input: Data)
-  case toolOutputAvailable(toolName: String, toolCallId: String, output: Data, preliminary: Bool)
-  case toolError(toolName: String, toolCallId: String, errorText: String, input: Data?)
+  case toolOutputAvailable(toolName: String?, toolCallId: String, output: Data, preliminary: Bool)
+  case toolError(toolName: String?, toolCallId: String, errorText: String, input: Data?)
+  /// Incremental tool output, streamed as `data-tool-output-delta`. Fragments
+  /// must be concatenated and parsed once complete (used by
+  /// `algolia_display_results` and some search agents).
+  case toolOutputDelta(toolCallId: String, toolName: String?, delta: String)
 
   // Sources / files
   case sourceURL(sourceId: String, url: URL, title: String?)
@@ -105,22 +111,22 @@ extension UIMessageChunk {
       guard let name = string("toolName"), let cid = string("toolCallId") else { throw AgentStudioError.malformedChunk }
       return .toolInputStart(toolName: name, toolCallId: cid)
     case "tool-input-delta":
-      guard let name = string("toolName"), let cid = string("toolCallId"),
+      guard let cid = string("toolCallId"),
             let delta = string("inputTextDelta") else { throw AgentStudioError.malformedChunk }
-      return .toolInputDelta(toolName: name, toolCallId: cid, inputTextDelta: delta)
+      return .toolInputDelta(toolName: string("toolName"), toolCallId: cid, inputTextDelta: delta)
     case "tool-input-available":
       guard let name = string("toolName"), let cid = string("toolCallId"),
             let input = subdata("input") else { throw AgentStudioError.malformedChunk }
       return .toolInputAvailable(toolName: name, toolCallId: cid, input: input)
     case "tool-output-available":
-      guard let name = string("toolName"), let cid = string("toolCallId"),
+      guard let cid = string("toolCallId"),
             let output = subdata("output") else { throw AgentStudioError.malformedChunk }
-      return .toolOutputAvailable(toolName: name, toolCallId: cid, output: output,
+      return .toolOutputAvailable(toolName: string("toolName"), toolCallId: cid, output: output,
                                    preliminary: bool("preliminary") ?? false)
     case "tool-error":
-      guard let name = string("toolName"), let cid = string("toolCallId"),
+      guard let cid = string("toolCallId"),
             let err = string("errorText") else { throw AgentStudioError.malformedChunk }
-      return .toolError(toolName: name, toolCallId: cid, errorText: err, input: subdata("input"))
+      return .toolError(toolName: string("toolName"), toolCallId: cid, errorText: err, input: subdata("input"))
     case "source-url":
       guard let sid = string("sourceId"), let urlStr = string("url"), let url = URL(string: urlStr) else {
         throw AgentStudioError.malformedChunk
@@ -132,6 +138,12 @@ extension UIMessageChunk {
       return .file(url: url, mediaType: media)
     case "error":
       return .error(errorText: string("errorText") ?? "Unknown error")
+    case "data-tool-output-delta":
+      guard let data = raw["data"] as? [String: Any],
+            let cid = data["toolCallId"] as? String else { throw AgentStudioError.malformedChunk }
+      return .toolOutputDelta(toolCallId: cid,
+                              toolName: data["toolName"] as? String,
+                              delta: data["delta"] as? String ?? "")
     default:
       if type.hasPrefix("data-") {
         let name = String(type.dropFirst("data-".count))

--- a/Sources/InstantSearchAgent/Models/UIMessageChunk.swift
+++ b/Sources/InstantSearchAgent/Models/UIMessageChunk.swift
@@ -59,6 +59,10 @@ public enum UIMessageChunk: Sendable, Equatable {
 }
 
 extension UIMessageChunk {
+  // One exhaustive `switch` over every AI SDK 5 chunk type; the high complexity
+  // and length are inherent to a flat dispatch and splitting it would only
+  // scatter the wire-format mapping.
+  // swiftlint:disable cyclomatic_complexity function_body_length
   /// Decode a single SSE payload (the JSON after `data:`).
   ///
   /// Returns `nil` for the SSE termination sentinel (`[DONE]`). Throws if the
@@ -153,6 +157,7 @@ extension UIMessageChunk {
       return .unknown(typeIdentifier: type, json: payload)
     }
   }
+  // swiftlint:enable cyclomatic_complexity function_body_length
 }
 
 /// Errors surfaced by the agent studio client.

--- a/Sources/InstantSearchAgent/Models/UIMessageChunk.swift
+++ b/Sources/InstantSearchAgent/Models/UIMessageChunk.swift
@@ -1,0 +1,153 @@
+//
+//  UIMessageChunk.swift
+//  InstantSearchAgent
+//
+//  AI SDK 5 streaming chunks. One JSON object per `data:` line in the SSE
+//  response. Mirror of `UIMessageChunk` from
+//  `instantsearch.js/src/lib/ai-lite/types.ts`.
+//
+
+import Foundation
+
+/// One frame parsed from the SSE stream.
+///
+/// We model the closed set of chunks we currently aggregate, plus a
+/// `case unknown(Data)` fallback so backend additions don't break parsing.
+public enum UIMessageChunk: Sendable, Equatable {
+  // Lifecycle
+  case start(messageId: String?)
+  case startStep
+  case finishStep
+  case finish
+  case abort
+
+  // Streaming text
+  case textStart(id: String)
+  case textDelta(id: String, delta: String)
+  case textEnd(id: String)
+
+  // Streaming reasoning
+  case reasoningStart(id: String)
+  case reasoningDelta(id: String, delta: String)
+  case reasoningEnd(id: String)
+
+  // Tools (AI SDK 5 names)
+  case toolInputStart(toolName: String, toolCallId: String)
+  case toolInputDelta(toolName: String, toolCallId: String, inputTextDelta: String)
+  case toolInputAvailable(toolName: String, toolCallId: String, input: Data)
+  case toolOutputAvailable(toolName: String, toolCallId: String, output: Data, preliminary: Bool)
+  case toolError(toolName: String, toolCallId: String, errorText: String, input: Data?)
+
+  // Sources / files
+  case sourceURL(sourceId: String, url: URL, title: String?)
+  case file(url: URL, mediaType: String)
+
+  // Custom data-<name> chunks
+  case data(name: String, id: String?, json: Data)
+
+  // Errors
+  case error(errorText: String)
+
+  // Anything we don't yet model
+  case unknown(typeIdentifier: String, json: Data)
+}
+
+extension UIMessageChunk {
+  /// Decode a single SSE payload (the JSON after `data:`).
+  ///
+  /// Returns `nil` for the SSE termination sentinel (`[DONE]`). Throws if the
+  /// payload is not valid JSON or doesn't contain a `type` field.
+  static func decode(payload: Data) throws -> UIMessageChunk? {
+    guard let raw = try JSONSerialization.jsonObject(with: payload, options: []) as? [String: Any] else {
+      throw AgentStudioError.malformedChunk
+    }
+    guard let type = raw["type"] as? String else {
+      throw AgentStudioError.malformedChunk
+    }
+
+    func subdata(_ key: String) -> Data? {
+      guard let value = raw[key] else { return nil }
+      return try? JSONSerialization.data(withJSONObject: value, options: [])
+    }
+    func string(_ key: String) -> String? { raw[key] as? String }
+    func bool(_ key: String) -> Bool? { raw[key] as? Bool }
+
+    switch type {
+    case "start":
+      return .start(messageId: string("messageId"))
+    case "start-step":
+      return .startStep
+    case "finish-step":
+      return .finishStep
+    case "finish":
+      return .finish
+    case "abort":
+      return .abort
+    case "text-start":
+      guard let id = string("id") else { throw AgentStudioError.malformedChunk }
+      return .textStart(id: id)
+    case "text-delta":
+      guard let id = string("id"), let delta = string("delta") else { throw AgentStudioError.malformedChunk }
+      return .textDelta(id: id, delta: delta)
+    case "text-end":
+      guard let id = string("id") else { throw AgentStudioError.malformedChunk }
+      return .textEnd(id: id)
+    case "reasoning-start":
+      guard let id = string("id") else { throw AgentStudioError.malformedChunk }
+      return .reasoningStart(id: id)
+    case "reasoning-delta":
+      guard let id = string("id"), let delta = string("delta") else { throw AgentStudioError.malformedChunk }
+      return .reasoningDelta(id: id, delta: delta)
+    case "reasoning-end":
+      guard let id = string("id") else { throw AgentStudioError.malformedChunk }
+      return .reasoningEnd(id: id)
+    case "tool-input-start":
+      guard let name = string("toolName"), let cid = string("toolCallId") else { throw AgentStudioError.malformedChunk }
+      return .toolInputStart(toolName: name, toolCallId: cid)
+    case "tool-input-delta":
+      guard let name = string("toolName"), let cid = string("toolCallId"),
+            let delta = string("inputTextDelta") else { throw AgentStudioError.malformedChunk }
+      return .toolInputDelta(toolName: name, toolCallId: cid, inputTextDelta: delta)
+    case "tool-input-available":
+      guard let name = string("toolName"), let cid = string("toolCallId"),
+            let input = subdata("input") else { throw AgentStudioError.malformedChunk }
+      return .toolInputAvailable(toolName: name, toolCallId: cid, input: input)
+    case "tool-output-available":
+      guard let name = string("toolName"), let cid = string("toolCallId"),
+            let output = subdata("output") else { throw AgentStudioError.malformedChunk }
+      return .toolOutputAvailable(toolName: name, toolCallId: cid, output: output,
+                                   preliminary: bool("preliminary") ?? false)
+    case "tool-error":
+      guard let name = string("toolName"), let cid = string("toolCallId"),
+            let err = string("errorText") else { throw AgentStudioError.malformedChunk }
+      return .toolError(toolName: name, toolCallId: cid, errorText: err, input: subdata("input"))
+    case "source-url":
+      guard let sid = string("sourceId"), let urlStr = string("url"), let url = URL(string: urlStr) else {
+        throw AgentStudioError.malformedChunk
+      }
+      return .sourceURL(sourceId: sid, url: url, title: string("title"))
+    case "file":
+      guard let urlStr = string("url"), let url = URL(string: urlStr),
+            let media = string("mediaType") else { throw AgentStudioError.malformedChunk }
+      return .file(url: url, mediaType: media)
+    case "error":
+      return .error(errorText: string("errorText") ?? "Unknown error")
+    default:
+      if type.hasPrefix("data-") {
+        let name = String(type.dropFirst("data-".count))
+        let payloadJson = subdata("data") ?? Data("null".utf8)
+        return .data(name: name, id: string("id"), json: payloadJson)
+      }
+      return .unknown(typeIdentifier: type, json: payload)
+    }
+  }
+}
+
+/// Errors surfaced by the agent studio client.
+public enum AgentStudioError: Error, Sendable, Equatable {
+  case malformedChunk
+  case http(status: Int, body: String?)
+  case missingCredentials
+  case streamClosed
+  case underlying(String)
+}

--- a/Sources/InstantSearchAgent/README.md
+++ b/Sources/InstantSearchAgent/README.md
@@ -1,0 +1,157 @@
+# InstantSearchAgent
+
+> [!WARNING]
+> **Experimental.** This is a standalone, early-stage library versioned
+> independently (`0.x`) from the main InstantSearch iOS library. Its public API
+> is marked experimental in each type's documentation and can change in source-
+> and binary-incompatible ways — including being renamed or removed — before a
+> stable `1.0` release. It is a *beta feature* per
+> [Algolia's Terms of Service ("Beta Services")](https://www.algolia.com/policies/terms/).
+
+Minimal native client for [Algolia Agent Studio][1]. Mirrors the AI SDK 5 wire
+format used by `react-instantsearch`'s `<Chat>` widget — without bundling any
+chat UI. Bring-your-own SwiftUI / UIKit views.
+
+Full documentation: see the [InstantSearch Agent guide][2] on the Algolia docs.
+
+## Install (SwiftPM)
+
+```swift
+.product(name: "InstantSearchAgent", package: "InstantSearch")
+```
+
+The library has no third-party dependencies; it talks to the Agent Studio
+endpoint with `URLSession` only.
+
+## Quick start (SwiftUI)
+
+```swift
+import SwiftUI
+import InstantSearchAgent
+
+@available(iOS 15.0, *)
+struct AgentChatView: View {
+  @StateObject private var chat = ChatStore(
+    transport: AgentStudioTransport(
+      appID: "YOUR_APP_ID",
+      apiKey: "YOUR_SEARCH_ONLY_API_KEY",
+      agentID: "YOUR_AGENT_ID"
+    )
+  )
+  @State private var input: String = ""
+
+  var body: some View {
+    VStack {
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 12) {
+          ForEach(chat.messages) { message in
+            MessageRow(message: message)
+          }
+          if chat.status == .submitted || chat.status == .streaming {
+            ProgressView().padding(.vertical, 4)
+          }
+        }
+        .padding()
+      }
+
+      HStack {
+        TextField("Ask anything…", text: $input, onCommit: send)
+          .textFieldStyle(.roundedBorder)
+        Button("Send", action: send)
+          .disabled(input.isEmpty || chat.status != .ready)
+        if chat.status == .streaming {
+          Button("Stop", action: chat.stop)
+        }
+      }
+      .padding(.horizontal)
+    }
+    .alert("Error", isPresented: .constant(chat.error != nil), actions: {
+      Button("OK", action: chat.clearError)
+    }, message: {
+      Text(String(describing: chat.error ?? .underlying("Unknown")))
+    })
+  }
+
+  private func send() {
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    chat.send(text: trimmed)
+    input = ""
+  }
+}
+
+private struct MessageRow: View {
+  let message: UIMessage<EmptyMetadata>
+  var body: some View {
+    HStack(alignment: .top) {
+      Text(message.role == .user ? "🧑" : "🤖")
+      VStack(alignment: .leading, spacing: 4) {
+        Text(message.plainText).fixedSize(horizontal: false, vertical: true)
+        ForEach(toolCalls, id: \.toolCallId) { tool in
+          ToolCallChip(part: tool)
+        }
+      }
+    }
+  }
+
+  private var toolCalls: [ToolUIPart] {
+    message.parts.compactMap { part in
+      if case let .tool(t) = part { return t }
+      return nil
+    }
+  }
+}
+
+private struct ToolCallChip: View {
+  let part: ToolUIPart
+  var body: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "wrench.and.screwdriver")
+      Text(part.toolName).font(.caption.monospaced())
+      switch part.state {
+      case .inputStreaming:    Text("preparing…").font(.caption)
+      case .inputAvailable:    Text("running…").font(.caption)
+      case .outputAvailable:   Text("done").font(.caption).foregroundColor(.green)
+      case .outputError(_, let err): Text(err).font(.caption).foregroundColor(.red)
+      }
+    }
+    .padding(6)
+    .background(Color.secondary.opacity(0.1))
+    .cornerRadius(6)
+  }
+}
+```
+
+## What's in v0.1
+
+| | |
+|---|---|
+| `AgentStudioEndpoint` | Builds the `agent-studio/1/agents/{id}/completions?compatibilityMode=ai-sdk-5` URL. |
+| `AgentStudioTransport` | `URLSession`-backed POST + SSE response. |
+| `SSEStreamParser` | `AsyncSequence` of `UIMessageChunk` from `URLSession.AsyncBytes`. |
+| `ChatStore` | `ObservableObject` aggregating chunks into `UIMessage`s, exposing `messages`, `status`, `error`, plus `send`/`regenerate`/`stop`/`clear`. |
+
+## What's not yet here (planned)
+
+- Drop-in SwiftUI chat view.
+- Client-side tool execution (`onToolCall`).
+- Conversation persistence.
+- Suggestion data parts surfaced as a typed property.
+- Feedback (👍 / 👎) endpoint.
+
+## Versioning
+
+This library has its **own version line** (`0.x`), independent of the main
+InstantSearch iOS library, so it can iterate quickly while experimental.
+Breaking changes can land in any `0.x` release.
+
+### Changelog
+
+#### 0.1.0
+
+- Initial experimental release: `AgentStudioEndpoint`, `AgentStudioTransport`,
+  `SSEStreamParser`, and `ChatStore` with AI SDK 5 streaming support.
+
+[1]: https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/integration
+[2]: https://www.algolia.com/doc/guides/algolia-ai/agent-studio/how-to/instantsearch-agent-ios
+

--- a/Sources/InstantSearchAgent/Transport/AgentStudioEndpoint.swift
+++ b/Sources/InstantSearchAgent/Transport/AgentStudioEndpoint.swift
@@ -1,0 +1,49 @@
+//
+//  AgentStudioEndpoint.swift
+//  InstantSearchAgent
+//
+
+import Foundation
+
+/// Builds the Agent Studio completions URL for a given Algolia application
+/// and agent. The shape is the one consumed by
+/// `connectChat` in `instantsearch.js`:
+///
+///     https://{appId}.algolia.net/agent-studio/1/agents/{agentId}/completions
+///
+/// We always request `compatibilityMode=ai-sdk-5`. Streaming is opt-in through
+/// `stream=true` (the default for `ChatStore`).
+public struct AgentStudioEndpoint: Sendable, Equatable {
+  public let appID: String
+  public let agentID: String
+  public let host: String
+
+  public init(appID: String, agentID: String, host: String? = nil) {
+    self.appID = appID
+    self.agentID = agentID
+    self.host = host ?? "\(appID).algolia.net"
+  }
+
+  /// - Parameters:
+  ///   - stream: when `true`, the server streams chunks as SSE.
+  ///   - cache: when `false`, bypasses any server-side cache (used by
+  ///     `regenerate-message`).
+  public func completionsURL(stream: Bool = true, cache: Bool = true) -> URL {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = host
+    components.path = "/agent-studio/1/agents/\(agentID)/completions"
+    var query = [
+      URLQueryItem(name: "compatibilityMode", value: "ai-sdk-5"),
+      URLQueryItem(name: "stream", value: stream ? "true" : "false"),
+    ]
+    if !cache {
+      query.append(URLQueryItem(name: "cache", value: "false"))
+    }
+    components.queryItems = query
+    guard let url = components.url else {
+      preconditionFailure("Failed to assemble Agent Studio completions URL")
+    }
+    return url
+  }
+}

--- a/Sources/InstantSearchAgent/Transport/AgentStudioEndpoint.swift
+++ b/Sources/InstantSearchAgent/Transport/AgentStudioEndpoint.swift
@@ -35,7 +35,7 @@ public struct AgentStudioEndpoint: Sendable, Equatable {
     components.path = "/agent-studio/1/agents/\(agentID)/completions"
     var query = [
       URLQueryItem(name: "compatibilityMode", value: "ai-sdk-5"),
-      URLQueryItem(name: "stream", value: stream ? "true" : "false"),
+      URLQueryItem(name: "stream", value: stream ? "true" : "false")
     ]
     if !cache {
       query.append(URLQueryItem(name: "cache", value: "false"))

--- a/Sources/InstantSearchAgent/Transport/AgentStudioTransport.swift
+++ b/Sources/InstantSearchAgent/Transport/AgentStudioTransport.swift
@@ -123,7 +123,7 @@ public final class AgentStudioTransport: @unchecked Sendable {
   static func encodeBody(_ request: AgentStudioRequest) throws -> Data {
     var dict: [String: Any] = [
       "messages": try request.messages.map { try Self.encodeJSON($0) as Any },
-      "trigger": request.trigger.rawValue,
+      "trigger": request.trigger.rawValue
     ]
     if let id = request.conversationID {
       dict["id"] = id

--- a/Sources/InstantSearchAgent/Transport/AgentStudioTransport.swift
+++ b/Sources/InstantSearchAgent/Transport/AgentStudioTransport.swift
@@ -1,0 +1,141 @@
+//
+//  AgentStudioTransport.swift
+//  InstantSearchAgent
+//
+//  Thin HTTP transport over `URLSession`. Sends the AI SDK 5 completions
+//  request body and exposes the parsed SSE chunk stream as an `AsyncSequence`.
+//
+//  Mirrors `DefaultChatTransport` from `instantsearch.js/src/lib/ai-lite/transport.ts`.
+//
+
+import Foundation
+
+/// What we send in the request body. Kept intentionally minimal for v0.1; the
+/// `extra` dictionary lets callers pass through any additional top-level
+/// fields the backend supports (e.g. `algolia.searchParameters`).
+public struct AgentStudioRequest: Sendable {
+  public let conversationID: String?
+  public let messages: [WireMessage]
+  public let trigger: Trigger
+  public let extra: [String: AnyEncodable]
+
+  public init(conversationID: String?,
+              messages: [WireMessage],
+              trigger: Trigger = .submitMessage,
+              extra: [String: AnyEncodable] = [:]) {
+    self.conversationID = conversationID
+    self.messages = messages
+    self.trigger = trigger
+    self.extra = extra
+  }
+
+  public enum Trigger: String, Sendable, Codable {
+    case submitMessage = "submit-message"
+    case regenerateMessage = "regenerate-message"
+  }
+
+  /// On-the-wire shape of a message. We don't reuse `UIMessage<Metadata>`
+  /// directly because the wire format has a fixed shape (`text`-only parts on
+  /// the user side) and we want to avoid generic propagation through the
+  /// transport.
+  public struct WireMessage: Sendable, Codable {
+    public let id: String
+    public let role: MessageRole
+    public let parts: [TextPart]
+
+    public init(id: String, role: MessageRole, text: String) {
+      self.id = id
+      self.role = role
+      self.parts = [TextPart(text: text)]
+    }
+  }
+
+  public struct TextPart: Sendable, Codable {
+    public let type: String
+    public let text: String
+    public init(text: String) { self.type = "text"; self.text = text }
+  }
+}
+
+/// Type-erased `Encodable` for the `extra` bag.
+public struct AnyEncodable: Encodable, @unchecked Sendable {
+  private let _encode: (Encoder) throws -> Void
+  public init<T: Encodable>(_ value: T) {
+    self._encode = value.encode
+  }
+  public func encode(to encoder: Encoder) throws { try _encode(encoder) }
+}
+
+/// HTTP transport for the Agent Studio completions endpoint.
+///
+/// - Warning: **Experimental.** Part of the standalone `InstantSearchAgent`
+///   `0.x` library; its API can change incompatibly before `1.0`.
+public final class AgentStudioTransport: @unchecked Sendable {
+  public let endpoint: AgentStudioEndpoint
+  private let apiKey: String
+  private let userAgent: String?
+  private let session: URLSession
+
+  public init(endpoint: AgentStudioEndpoint,
+              apiKey: String,
+              userAgent: String? = nil,
+              session: URLSession = .shared) {
+    self.endpoint = endpoint
+    self.apiKey = apiKey
+    self.userAgent = userAgent
+    self.session = session
+  }
+
+  /// Send a completion request and return an async sequence of streamed chunks.
+  ///
+  /// The returned `AsyncStream` finishes when the server emits the SSE
+  /// `[DONE]` sentinel, when the underlying URL session task ends, or when the
+  /// caller cancels its enclosing `Task`.
+  @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+  public func sendMessages(_ request: AgentStudioRequest) async throws -> SSEStreamParser {
+    let url = endpoint.completionsURL(
+      stream: true,
+      cache: request.trigger != .regenerateMessage
+    )
+    var urlRequest = URLRequest(url: url)
+    urlRequest.httpMethod = "POST"
+    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+    urlRequest.setValue(endpoint.appID, forHTTPHeaderField: "x-algolia-application-id")
+    urlRequest.setValue(apiKey, forHTTPHeaderField: "x-algolia-api-key")
+    if let userAgent {
+      urlRequest.setValue(userAgent, forHTTPHeaderField: "x-algolia-agent")
+    }
+    urlRequest.httpBody = try Self.encodeBody(request)
+
+    let (bytes, response) = try await session.bytes(for: urlRequest)
+
+    guard let http = response as? HTTPURLResponse else {
+      throw AgentStudioError.underlying("Non-HTTP response")
+    }
+    guard (200..<300).contains(http.statusCode) else {
+      throw AgentStudioError.http(status: http.statusCode, body: nil)
+    }
+
+    return SSEStreamParser(bytes: bytes)
+  }
+
+  static func encodeBody(_ request: AgentStudioRequest) throws -> Data {
+    var dict: [String: Any] = [
+      "messages": try request.messages.map { try Self.encodeJSON($0) as Any },
+      "trigger": request.trigger.rawValue,
+    ]
+    if let id = request.conversationID {
+      dict["id"] = id
+    }
+    for (key, value) in request.extra {
+      dict[key] = try Self.encodeJSON(value)
+    }
+    return try JSONSerialization.data(withJSONObject: dict, options: [])
+  }
+
+  private static func encodeJSON<T: Encodable>(_ value: T) throws -> Any {
+    let data = try JSONEncoder().encode(value)
+    return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+  }
+}

--- a/Sources/InstantSearchAgent/Transport/SSEStreamParser.swift
+++ b/Sources/InstantSearchAgent/Transport/SSEStreamParser.swift
@@ -1,0 +1,64 @@
+//
+//  SSEStreamParser.swift
+//  InstantSearchAgent
+//
+//  Async-iterator over the AI SDK 5 SSE stream returned by the Agent Studio
+//  completions endpoint. Each line is either:
+//      data: <json>           // a UIMessageChunk
+//      data: [DONE]           // end-of-stream sentinel
+//      <empty>                // SSE keep-alive
+//      event: ... / id: ...   // ignored
+//
+//  Mirrors `parseJsonEventStream` in
+//  `instantsearch.js/src/lib/ai-lite/stream-parser.ts`.
+//
+
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct SSEStreamParser: AsyncSequence, Sendable {
+  public typealias Element = UIMessageChunk
+
+  private let lines: AsyncLineSequence<URLSession.AsyncBytes>
+
+  public init(bytes: URLSession.AsyncBytes) {
+    self.lines = bytes.lines
+  }
+
+  public func makeAsyncIterator() -> AsyncIterator {
+    AsyncIterator(lineIterator: lines.makeAsyncIterator())
+  }
+
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    var lineIterator: AsyncLineSequence<URLSession.AsyncBytes>.AsyncIterator
+
+    public mutating func next() async throws -> UIMessageChunk? {
+      while let line = try await lineIterator.next() {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+        if trimmed.isEmpty { continue }
+
+        guard let payload = Self.extractJsonPayload(from: trimmed) else {
+          continue
+        }
+        if payload == "[DONE]" { return nil }
+
+        guard let data = payload.data(using: .utf8) else { continue }
+
+        if let chunk = try? UIMessageChunk.decode(payload: data) {
+          return chunk
+        }
+        // Malformed individual chunks are skipped, matching JS behavior.
+      }
+      return nil
+    }
+
+    static func extractJsonPayload(from line: String) -> String? {
+      if line.hasPrefix("data:") {
+        return String(line.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces)
+      }
+      if line.hasPrefix("{") { return line }
+      return nil
+    }
+  }
+}

--- a/Sources/InstantSearchCore/Common/SearchClientTypealiases.swift
+++ b/Sources/InstantSearchCore/Common/SearchClientTypealiases.swift
@@ -13,7 +13,10 @@ extension SearchResult where T == SearchHit {
     switch self {
     case let .searchResponse(response):
       return response
-    case .searchForFacetValuesResponse:
+    case .searchForFacetValuesResponse,
+         .searchResponsePartial:
+      return nil
+    @unknown default:
       return nil
     }
   }

--- a/Sources/InstantSearchCore/MultiIndexHits/MultiIndexHitsInteractor+Searcher.swift
+++ b/Sources/InstantSearchCore/MultiIndexHits/MultiIndexHitsInteractor+Searcher.swift
@@ -27,7 +27,10 @@ public extension MultiIndexHitsInteractor {
           switch result {
           case let .searchResponse(response):
             return response
-          case .searchForFacetValuesResponse:
+          case .searchForFacetValuesResponse,
+               .searchResponsePartial:
+            return nil
+          @unknown default:
             return nil
           }
         }

--- a/Sources/InstantSearchCore/Searcher/Facet/FacetSearcher.swift
+++ b/Sources/InstantSearchCore/Searcher/Facet/FacetSearcher.swift
@@ -112,7 +112,10 @@ extension FacetSearcher: MultiSearchComponent {
         switch response {
         case let .searchForFacetValuesResponse(facetResponse):
           searcher.onResults.fire(facetResponse)
-        case .searchResponse:
+        case .searchResponse,
+             .searchResponsePartial:
+          break
+        @unknown default:
           break
         }
       }

--- a/Sources/InstantSearchCore/Searcher/SearchService/AlgoliaSearchService.swift
+++ b/Sources/InstantSearchCore/Searcher/SearchService/AlgoliaSearchService.swift
@@ -85,7 +85,10 @@ extension AlgoliaSearchService {
           switch result {
           case let .searchResponse(response):
             return response
-          case .searchForFacetValuesResponse:
+          case .searchForFacetValuesResponse,
+               .searchResponsePartial:
+            throw MultiSearchError.unexpectedFacetResponse
+          @unknown default:
             throw MultiSearchError.unexpectedFacetResponse
           }
         }
@@ -100,7 +103,10 @@ extension AlgoliaSearchService {
         switch first {
         case let .searchResponse(response):
           return response
-        case .searchForFacetValuesResponse:
+        case .searchForFacetValuesResponse,
+             .searchResponsePartial:
+          throw MultiSearchError.unexpectedFacetResponse
+        @unknown default:
           throw MultiSearchError.unexpectedFacetResponse
         }
       }

--- a/Sources/InstantSearchCore/Searcher/SearchService/AlgoliaSearchService.swift
+++ b/Sources/InstantSearchCore/Searcher/SearchService/AlgoliaSearchService.swift
@@ -81,17 +81,7 @@ extension AlgoliaSearchService {
       queriesBuilder.keepSelectedEmptyFacets = keepSelectedEmptyFacets
       queries = queriesBuilder.build().map { IndexedQuery(indexName: request.indexName, query: $0) }
       transform = { results in
-        let responses = try results.map { result -> SearchResponse<SearchHit> in
-          switch result {
-          case let .searchResponse(response):
-            return response
-          case .searchForFacetValuesResponse,
-               .searchResponsePartial:
-            throw MultiSearchError.unexpectedFacetResponse
-          @unknown default:
-            throw MultiSearchError.unexpectedFacetResponse
-          }
-        }
+        let responses = try results.map(Self.fullResponse)
         return try queriesBuilder.aggregate(responses)
       }
     } else {
@@ -100,15 +90,7 @@ extension AlgoliaSearchService {
         guard let first = results.first else {
           throw MultiSearchError.emptyResults
         }
-        switch first {
-        case let .searchResponse(response):
-          return response
-        case .searchForFacetValuesResponse,
-             .searchResponsePartial:
-          throw MultiSearchError.unexpectedFacetResponse
-        @unknown default:
-          throw MultiSearchError.unexpectedFacetResponse
-        }
+        return try Self.fullResponse(from: first)
       }
     }
     let searchQueries = queries.asSearchQueries()
@@ -125,6 +107,18 @@ extension AlgoliaSearchService {
       }
     }
     return (searchQueries, multiCompletion)
+  }
+
+  private static func fullResponse(from result: SearchResult<SearchHit>) throws -> SearchResponse<SearchHit> {
+    switch result {
+    case let .searchResponse(response):
+      return response
+    case .searchForFacetValuesResponse,
+         .searchResponsePartial:
+      throw MultiSearchError.unexpectedFacetResponse
+    @unknown default:
+      throw MultiSearchError.unexpectedFacetResponse
+    }
   }
 }
 

--- a/Tests/InstantSearchAgentTests/ChunkReducerTests.swift
+++ b/Tests/InstantSearchAgentTests/ChunkReducerTests.swift
@@ -103,6 +103,25 @@ final class ChunkReducerTests: XCTestCase {
     XCTAssertTrue(preliminary)
   }
 
+  func testDataSuggestionsChunkBecomesDataPart() throws {
+    // `data-suggestions` (prompt chips) is stored as a generic data part so the
+    // ChatStore can derive the suggestions list from it.
+    let payload = Data(#"{"type":"data-suggestions","data":{"suggestions":["How can I do X?","What about Y?"]}}"#.utf8)
+    let chunk = try XCTUnwrap(UIMessageChunk.decode(payload: payload))
+    guard case let .data(name, _, _) = chunk else {
+      return XCTFail("expected data chunk, got \(chunk)")
+    }
+    XCTAssertEqual(name, "suggestions")
+
+    var msg = UIMessage<EmptyMetadata>(id: "alg_msg_5", role: .assistant)
+    ChunkReducer.apply(chunk, to: &msg)
+    let dataPart = msg.parts.compactMap { part -> (String, Data)? in
+      if case let .data(name, _, json) = part { return (name, json) }
+      return nil
+    }.first
+    XCTAssertEqual(dataPart?.0, "suggestions")
+  }
+
   func testSseExtractionIgnoresKeepalivesAndDoneSentinel() {
     XCTAssertEqual(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "data: {\"type\":\"finish\"}"), "{\"type\":\"finish\"}")
     XCTAssertEqual(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "data: [DONE]"), "[DONE]")

--- a/Tests/InstantSearchAgentTests/ChunkReducerTests.swift
+++ b/Tests/InstantSearchAgentTests/ChunkReducerTests.swift
@@ -1,0 +1,68 @@
+//
+//  ChunkReducerTests.swift
+//  InstantSearchAgentTests
+//
+
+import XCTest
+@testable import InstantSearchAgent
+
+final class ChunkReducerTests: XCTestCase {
+  func testTextStreamProducesConcatenatedPart() {
+    var msg = UIMessage<EmptyMetadata>(id: "alg_msg_1", role: .assistant)
+    let chunks: [UIMessageChunk] = [
+      .startStep,
+      .textStart(id: "t-1"),
+      .textDelta(id: "t-1", delta: "Hello "),
+      .textDelta(id: "t-1", delta: "world"),
+      .textEnd(id: "t-1"),
+      .finishStep,
+      .finish,
+    ]
+    for chunk in chunks {
+      ChunkReducer.apply(chunk, to: &msg)
+    }
+    XCTAssertEqual(msg.plainText, "Hello world")
+    if case let .text(_, _, state) = msg.parts.first(where: { if case .text = $0 { return true }; return false }) {
+      XCTAssertEqual(state, .done)
+    } else {
+      XCTFail("expected a text part")
+    }
+  }
+
+  func testToolLifecycleEndsWithOutputAvailable() throws {
+    var msg = UIMessage<EmptyMetadata>(id: "alg_msg_2", role: .assistant)
+    let inputJson = Data(#"{"query":"red shoes"}"#.utf8)
+    let outputJson = Data(#"{"hits":[]}"#.utf8)
+    let chunks: [UIMessageChunk] = [
+      .toolInputStart(toolName: "algolia_search_index", toolCallId: "c-1"),
+      .toolInputAvailable(toolName: "algolia_search_index", toolCallId: "c-1", input: inputJson),
+      .toolOutputAvailable(toolName: "algolia_search_index", toolCallId: "c-1", output: outputJson, preliminary: false),
+    ]
+    for chunk in chunks { ChunkReducer.apply(chunk, to: &msg) }
+
+    let part = msg.parts.compactMap { p -> ToolUIPart? in
+      if case let .tool(t) = p { return t }
+      return nil
+    }.first
+    XCTAssertNotNil(part)
+    if case let .outputAvailable(_, output, _) = part?.state {
+      XCTAssertEqual(output, outputJson)
+    } else {
+      XCTFail("expected outputAvailable")
+    }
+  }
+
+  func testSseExtractionIgnoresKeepalivesAndDoneSentinel() {
+    XCTAssertEqual(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "data: {\"type\":\"finish\"}"), "{\"type\":\"finish\"}")
+    XCTAssertEqual(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "data: [DONE]"), "[DONE]")
+    XCTAssertNil(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "event: ping"))
+    XCTAssertNil(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "id: 123"))
+  }
+
+  func testEndpointBuildsExpectedUrl() {
+    let endpoint = AgentStudioEndpoint(appID: "ABC123", agentID: "shopping-assistant")
+    let url = endpoint.completionsURL(stream: true, cache: true)
+    XCTAssertEqual(url.absoluteString,
+                   "https://ABC123.algolia.net/agent-studio/1/agents/shopping-assistant/completions?compatibilityMode=ai-sdk-5&stream=true")
+  }
+}

--- a/Tests/InstantSearchAgentTests/ChunkReducerTests.swift
+++ b/Tests/InstantSearchAgentTests/ChunkReducerTests.swift
@@ -52,6 +52,57 @@ final class ChunkReducerTests: XCTestCase {
     }
   }
 
+  func testToolOutputAvailableWithoutToolNameIsNotDropped() throws {
+    // Agent Studio's ai-sdk-5 stream omits `toolName` on `tool-output-available`
+    // (the call is already identified by `toolCallId`). Decoding must not drop it.
+    let payload = Data(#"{"type":"tool-output-available","toolCallId":"c-1","output":{"hits":[{"objectID":"1","name":"Laptop"}]}}"#.utf8)
+    let chunk = try XCTUnwrap(UIMessageChunk.decode(payload: payload))
+    guard case let .toolOutputAvailable(name, cid, _, _) = chunk else {
+      return XCTFail("expected toolOutputAvailable, got \(chunk)")
+    }
+    XCTAssertNil(name)
+    XCTAssertEqual(cid, "c-1")
+  }
+
+  func testToolOutputPreservesNameFromInputStartWhenOutputOmitsIt() {
+    var msg = UIMessage<EmptyMetadata>(id: "alg_msg_3", role: .assistant)
+    let outputJson = Data(#"{"hits":[{"objectID":"1","name":"Laptop"}]}"#.utf8)
+    let chunks: [UIMessageChunk] = [
+      .toolInputStart(toolName: "algolia_search_index", toolCallId: "c-1"),
+      // `toolName` absent on the wire -> decoded as nil
+      .toolOutputAvailable(toolName: nil, toolCallId: "c-1", output: outputJson, preliminary: false),
+    ]
+    for chunk in chunks { ChunkReducer.apply(chunk, to: &msg) }
+
+    let part = msg.parts.compactMap { p -> ToolUIPart? in
+      if case let .tool(t) = p { return t }
+      return nil
+    }.first
+    XCTAssertEqual(part?.toolName, "algolia_search_index")
+    if case .outputAvailable = part?.state {} else {
+      XCTFail("expected outputAvailable")
+    }
+  }
+
+  func testToolOutputDeltaAccumulatesAndParses() {
+    var msg = UIMessage<EmptyMetadata>(id: "alg_msg_4", role: .assistant)
+    let chunks: [UIMessageChunk] = [
+      .toolInputStart(toolName: "algolia_display_results", toolCallId: "c-9"),
+      .toolOutputDelta(toolCallId: "c-9", toolName: "algolia_display_results", delta: #"{"intro":"curated""#),
+      .toolOutputDelta(toolCallId: "c-9", toolName: "algolia_display_results", delta: #","groups":[]}"#),
+    ]
+    for chunk in chunks { ChunkReducer.apply(chunk, to: &msg) }
+
+    let part = msg.parts.compactMap { p -> ToolUIPart? in
+      if case let .tool(t) = p { return t }
+      return nil
+    }.first
+    guard case let .outputAvailable(_, _, preliminary) = part?.state else {
+      return XCTFail("expected outputAvailable, got \(String(describing: part?.state))")
+    }
+    XCTAssertTrue(preliminary)
+  }
+
   func testSseExtractionIgnoresKeepalivesAndDoneSentinel() {
     XCTAssertEqual(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "data: {\"type\":\"finish\"}"), "{\"type\":\"finish\"}")
     XCTAssertEqual(SSEStreamParser.AsyncIterator.extractJsonPayload(from: "data: [DONE]"), "[DONE]")


### PR DESCRIPTION
Add `InstantSearchAgent`, a new standalone SwiftPM product that provides a minimal native client for Algolia Agent Studio. It ships the transport, an SSE streaming parser, and an ObservableObject chat state container (`ChatStore`) for building agentic (conversational AI) search experiences, with no bundled UI.

The library is experimental and versioned independently from the main InstantSearch line:

- Maintained on its own 0.x line, decoupled from the 8.x library.
- Public types are documented as experimental and can change in source- and binary-incompatible ways before a stable 1.0.
- Added as an additive `InstantSearchAgent` library + target plus an `InstantSearchAgentTests` test target in Package.swift; no existing products or targets are touched.

https://algolia.atlassian.net/browse/FX-3827