### PR TITLE
fix(insights): bound event package retries to prevent duplicate sends

### DIFF
--- a/Sources/InstantSearchInsights/Logic/EventProcessor.swift
+++ b/Sources/InstantSearchInsights/Logic/EventProcessor.swift
@@ -154,9 +154,10 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
 
     dispatchQueue.async { [weak self] in
       guard let processor = self else { return }
-      // Appending to a package awaiting a service response would change its identifier
-      // and make its removal on success impossible, leading to duplicate sends
-      processor.packager.pack(event, sealedPackageIDs: processor.inFlightPackageIDs)
+      // Appending to a package changes its identifier: for a package awaiting a service
+      // response this would make its removal on success impossible, leading to duplicate
+      // sends, and for a failed package it would reset its backoff and retry count
+      processor.packager.pack(event, sealedPackageIDs: processor.inFlightPackageIDs.union(processor.retryCounts.keys))
       let updatedPackages = processor.packager.packages
       do {
         try processor.storage?.store(updatedPackages)

--- a/Sources/InstantSearchInsights/Logic/EventProcessor.swift
+++ b/Sources/InstantSearchInsights/Logic/EventProcessor.swift
@@ -230,7 +230,7 @@ private extension EventProcessor {
 
         switch result {
         case .success:
-          processor.logger.info("package succesfully sent")
+          processor.logger.info("package successfully sent")
           processor.remove([eventsPackage])
 
         case let .failure(error) where !Service.isRetryable(error):

--- a/Sources/InstantSearchInsights/Logic/EventProcessor.swift
+++ b/Sources/InstantSearchInsights/Logic/EventProcessor.swift
@@ -58,6 +58,27 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
     }
   }
 
+  /// Maximal number of failed sync attempts for a package before it is dropped
+  let maxRetryCount: Int
+
+  /// Upper bound of the exponential backoff delay between sync attempts of a failed package
+  let maxRetryBackoff: TimeInterval
+
+  /// The delay after which a stored package is discarded without sending
+  let packageExpirationDelay: TimeInterval
+
+  /// Identifiers of the packages currently being synchronized with the service.
+  /// Must only be accessed from the dispatchQueue.
+  private var inFlightPackageIDs: Set<String> = []
+
+  /// Count of failed sync attempts per package identifier.
+  /// Must only be accessed from the dispatchQueue.
+  private var retryCounts: [String: Int] = [:]
+
+  /// Earliest allowed date of the next sync attempt per package identifier.
+  /// Must only be accessed from the dispatchQueue.
+  private var nextAttemptDates: [String: Date] = [:]
+
   /// The queue synchronizing the access to a packager
   private let dispatchQueue: DispatchQueue
 
@@ -69,6 +90,9 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
       - flushNotificationName: The name of the notification triggering the events flushing
       - flushDelay: The delay between recurrent events flushing
       - acceptEvent: Closure filttering events before synchronizing them with the service
+      - maxRetryCount: Maximal number of failed sync attempts for a package before it is dropped
+      - maxRetryBackoff: Upper bound of the exponential backoff delay between sync attempts of a failed package
+      - packageExpirationDelay: The delay after which a stored package is discarded without sending
       - logger: Logging component
       - dispatchQueue: The queue synchronizing the access to event packages
    */
@@ -78,8 +102,14 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
        flushNotificationName: Notification.Name?,
        flushDelay: TimeInterval,
        acceptEvent: @escaping (Event) -> Bool = { _ in true },
+       maxRetryCount: Int = Algolia.Insights.maxRetryCount,
+       maxRetryBackoff: TimeInterval = Algolia.Insights.maxRetryBackoff,
+       packageExpirationDelay: TimeInterval = Algolia.Insights.packageExpirationDelay,
        logger: Logger,
        dispatchQueue: DispatchQueue = .init(label: "insights.events", qos: .background)) {
+    self.maxRetryCount = maxRetryCount
+    self.maxRetryBackoff = maxRetryBackoff
+    self.packageExpirationDelay = packageExpirationDelay
     packager = .init(packageCapacity: packageCapacity)
     self.storage = storage
     self.logger = logger
@@ -124,7 +154,9 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
 
     dispatchQueue.async { [weak self] in
       guard let processor = self else { return }
-      processor.packager.pack(event)
+      // Appending to a package awaiting a service response would change its identifier
+      // and make its removal on success impossible, leading to duplicate sends
+      processor.packager.pack(event, sealedPackageIDs: processor.inFlightPackageIDs)
       let updatedPackages = processor.packager.packages
       do {
         try processor.storage?.store(updatedPackages)
@@ -141,11 +173,32 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
   @objc func flush() {
     dispatchQueue.async { [weak self] in
       guard let processor = self else { return }
-      let eventsPackages = processor.packager.packages
+
+      let now = Date()
+
+      let expiredPackages = processor.packager.packages.filter { package in
+        !processor.inFlightPackageIDs.contains(package.id) &&
+          now.timeIntervalSince(package.creationDate) > processor.packageExpirationDelay
+      }
+      if !expiredPackages.isEmpty {
+        processor.logger.error("dropping \(expiredPackages.count) event packages older than \(processor.packageExpirationDelay)s")
+        processor.remove(expiredPackages)
+      }
+
+      let eventsPackages = processor.packager.packages.filter { package in
+        guard !processor.inFlightPackageIDs.contains(package.id) else {
+          return false
+        }
+        guard let nextAttemptDate = processor.nextAttemptDates[package.id] else {
+          return true
+        }
+        return nextAttemptDate <= now
+      }
       if eventsPackages.isEmpty {
         processor.logger.info("no pending event packages, skip flushing")
       } else {
         processor.logger.info("flushing pending \(eventsPackages.count) event packages")
+        eventsPackages.forEach { processor.inFlightPackageIDs.insert($0.id) }
         eventsPackages.forEach(processor.sync)
       }
     }
@@ -153,6 +206,8 @@ class EventProcessor<Service: EventsService, PackageStorage: Storage>: Flushable
 }
 
 private extension EventProcessor {
+  /// Synchronize a package with the service. Must be called from the dispatchQueue,
+  /// with the package identifier already marked as in-flight.
   func sync(_ eventsPackage: Package<Event>) {
     logger.info("sending events package: \(eventsPackage.items)")
 
@@ -160,6 +215,8 @@ private extension EventProcessor {
 
     guard !eligibleEvents.isEmpty else {
       logger.info("all events in package were filtered out by the acceptance condition, no event will be sent")
+      inFlightPackageIDs.remove(eventsPackage.id)
+      remove([eventsPackage])
       return
     }
 
@@ -167,28 +224,46 @@ private extension EventProcessor {
 
       guard let processor = self else { return }
 
-      let shouldRemovePackage: Bool
-
-      switch result {
-      case .success:
-        processor.logger.info("package succesfully sent")
-        shouldRemovePackage = true
-      case let .failure(error):
-        processor.logger.error("package sending failed: \(error.localizedDescription)")
-        shouldRemovePackage = !Service.isRetryable(error)
-      }
-
-      guard shouldRemovePackage else { return }
-
       processor.dispatchQueue.async {
-        processor.packager.remove(eventsPackage)
-        let updatedPackages = processor.packager.packages
-        do {
-          try processor.storage?.store(updatedPackages)
-        } catch {
-          processor.logger.error("\(error.localizedDescription)")
+        processor.inFlightPackageIDs.remove(eventsPackage.id)
+
+        switch result {
+        case .success:
+          processor.logger.info("package succesfully sent")
+          processor.remove([eventsPackage])
+
+        case let .failure(error) where !Service.isRetryable(error):
+          processor.logger.error("package sending failed: \(error.localizedDescription), the package won't be retried")
+          processor.remove([eventsPackage])
+
+        case let .failure(error):
+          let retryCount = (processor.retryCounts[eventsPackage.id] ?? 0) + 1
+          guard retryCount < processor.maxRetryCount else {
+            processor.logger.error("package sending failed \(retryCount) times: \(error.localizedDescription), dropping the package")
+            processor.remove([eventsPackage])
+            return
+          }
+          processor.retryCounts[eventsPackage.id] = retryCount
+          let backoff = min(processor.flushDelay * pow(2, Double(retryCount - 1)), processor.maxRetryBackoff)
+          processor.nextAttemptDates[eventsPackage.id] = Date().addingTimeInterval(backoff)
+          processor.logger.error("package sending failed: \(error.localizedDescription), next attempt in \(backoff)s")
         }
       }
+    }
+  }
+
+  /// Remove packages and their retry bookkeeping. Must be called from the dispatchQueue.
+  func remove(_ eventsPackages: [Package<Event>]) {
+    for eventsPackage in eventsPackages {
+      packager.remove(eventsPackage)
+      retryCounts.removeValue(forKey: eventsPackage.id)
+      nextAttemptDates.removeValue(forKey: eventsPackage.id)
+    }
+    let updatedPackages = packager.packages
+    do {
+      try storage?.store(updatedPackages)
+    } catch {
+      logger.error("\(error.localizedDescription)")
     }
   }
 }

--- a/Sources/InstantSearchInsights/Models/Config.swift
+++ b/Sources/InstantSearchInsights/Models/Config.swift
@@ -28,5 +28,15 @@ struct Algolia {
 
     // Default events batch size
     static let minBatchSize = 10
+
+    /// Maximum number of sync attempts for an events package before it is dropped
+    static let maxRetryCount = 20
+
+    /// Upper bound of the exponential backoff delay between sync attempts of a failed package
+    static let maxRetryBackoff: TimeInterval = 15 * 60
+
+    /// The delay after which a stored events package is discarded without sending: 4 days,
+    /// matching the server-side event acceptance window
+    static let packageExpirationDelay: TimeInterval = 4 * 24 * 3600
   }
 }

--- a/Sources/InstantSearchInsights/Models/Package.swift
+++ b/Sources/InstantSearchInsights/Models/Package.swift
@@ -12,6 +12,7 @@ struct Package<Item: Codable> {
   let id: String
   let items: [Item]
   let capacity: Int
+  let creationDate: Date
 
   var isFull: Bool {
     return items.count == capacity
@@ -21,12 +22,14 @@ struct Package<Item: Codable> {
     id = UUID().uuidString
     items = []
     self.capacity = capacity
+    creationDate = Date()
   }
 
   init(item: Item, capacity: Int) {
     id = UUID().uuidString
     items = [item]
     self.capacity = capacity
+    creationDate = Date()
   }
 
   init(items: [Item], capacity: Int) throws {
@@ -36,6 +39,14 @@ struct Package<Item: Codable> {
     id = UUID().uuidString
     self.items = items
     self.capacity = capacity
+    creationDate = Date()
+  }
+
+  private init(items: [Item], capacity: Int, creationDate: Date) {
+    id = UUID().uuidString
+    self.items = items
+    self.capacity = capacity
+    self.creationDate = creationDate
   }
 
   func appending(_ item: Item) throws -> Package {
@@ -46,7 +57,7 @@ struct Package<Item: Codable> {
     guard items.count + self.items.count <= capacity else {
       throw Error.packageOverflow(capacity: capacity)
     }
-    return try Package(items: self.items + items, capacity: capacity)
+    return Package(items: self.items + items, capacity: capacity, creationDate: creationDate)
   }
 }
 
@@ -89,6 +100,7 @@ extension Package: Codable {
     case id
     case items
     case capacity
+    case creationDate
   }
 
   init(from decoder: Decoder) throws {
@@ -96,6 +108,8 @@ extension Package: Codable {
     id = try container.decode(String.self, forKey: .id)
     items = try container.decode([Item].self, forKey: .items)
     capacity = try container.decode(Int.self, forKey: .capacity)
+    // Packages stored by previous versions carry no creation date, consider them created at load time
+    creationDate = try container.decodeIfPresent(Date.self, forKey: .creationDate) ?? Date()
   }
 
   func encode(to encoder: Encoder) throws {
@@ -103,6 +117,7 @@ extension Package: Codable {
     try container.encode(id, forKey: .id)
     try container.encode(items, forKey: .items)
     try container.encode(capacity, forKey: .capacity)
+    try container.encode(creationDate, forKey: .creationDate)
   }
 }
 

--- a/Sources/InstantSearchInsights/Models/Packager.swift
+++ b/Sources/InstantSearchInsights/Models/Packager.swift
@@ -22,9 +22,15 @@ struct Packager<Item: Codable>: Packaging {
   }
 
   mutating func pack(_ item: Item) {
+    pack(item, sealedPackageIDs: [])
+  }
+
+  /// Packs an item, appending it to the last pending package unless that package is full
+  /// or its identifier is sealed (currently being synchronized), in which case a new package is started
+  mutating func pack(_ item: Item, sealedPackageIDs: Set<String>) {
     let package: Package<Item>
 
-    if let lastPackage = packages.last, !lastPackage.isFull {
+    if let lastPackage = packages.last, !lastPackage.isFull, !sealedPackageIDs.contains(lastPackage.id) {
       package = (try? packages.removeLast().appending(item)) ?? Package(item: item, capacity: packageCapacity)
     } else {
       package = Package(item: item, capacity: packageCapacity)

--- a/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
@@ -9,6 +9,53 @@
 @testable import InstantSearchInsights
 import XCTest
 
+private struct TestError: Error {}
+
+/// Service capturing completion handlers without invoking them, simulating in-flight requests
+private class HoldingEventService<Event>: EventsService {
+  var sentEvents: [[Event]] = []
+  var pendingCompletions: [(Result<Void, Error>) -> Void] = []
+
+  func sendEvents(_ events: [Event], completion: @escaping (Result<Void, Error>) -> Void) {
+    sentEvents.append(events)
+    pendingCompletions.append(completion)
+  }
+
+  static func isRetryable(_: Error) -> Bool {
+    return true
+  }
+}
+
+/// Service immediately failing with a retryable error
+private class FailingEventService<Event>: EventsService {
+  var sendCount = 0
+  var didSendEvents: ([Event]) -> Void = { _ in }
+
+  func sendEvents(_ events: [Event], completion: @escaping (Result<Void, Error>) -> Void) {
+    sendCount += 1
+    didSendEvents(events)
+    completion(.failure(TestError()))
+  }
+
+  static func isRetryable(_: Error) -> Bool {
+    return true
+  }
+}
+
+/// Service immediately failing with a non-retryable error
+private class NonRetryableFailingEventService<Event>: EventsService {
+  var sendCount = 0
+
+  func sendEvents(_: [Event], completion: @escaping (Result<Void, Error>) -> Void) {
+    sendCount += 1
+    completion(.failure(TestError()))
+  }
+
+  static func isRetryable(_: Error) -> Bool {
+    return false
+  }
+}
+
 class EventsProcessorTests: XCTestCase {
   var storage: TestPackageStorage<String> { return .init() }
 
@@ -248,5 +295,174 @@ class EventsProcessorTests: XCTestCase {
     eventsProcessor.flush()
 
     waitForExpectations(timeout: 10, handler: nil)
+  }
+
+  func testInFlightPackageIsNotResent() {
+    let service = HoldingEventService<String>()
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("Test event")
+    queue.sync {}
+
+    eventsProcessor.flush()
+    eventsProcessor.flush()
+    eventsProcessor.flush()
+    queue.sync {}
+
+    XCTAssertEqual(service.sentEvents.count, 1, "a package awaiting a service response must not be sent again")
+  }
+
+  func testEventProcessedDuringSyncIsNotAppendedToInFlightPackage() {
+    let service = HoldingEventService<String>()
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("first")
+    queue.sync {}
+    eventsProcessor.flush()
+    queue.sync {}
+
+    eventsProcessor.process("second")
+    queue.sync {}
+    XCTAssertEqual(eventsProcessor.packager.packages.count, 2, "an event tracked during a sync must start a new package")
+
+    service.pendingCompletions.first?(.success(()))
+    queue.sync {}
+    queue.sync {}
+
+    XCTAssertEqual(eventsProcessor.packager.packages.map(\.items), [["second"]], "the sent package must be removed, the new one kept")
+  }
+
+  func testRetryableFailureBacksOff() {
+    let service = FailingEventService<String>()
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("Test event")
+    queue.sync {}
+
+    eventsProcessor.flush()
+    queue.sync {}
+    queue.sync {}
+
+    eventsProcessor.flush()
+    queue.sync {}
+
+    XCTAssertEqual(service.sendCount, 1, "a failed package must not be retried before its backoff delay expires")
+    XCTAssertEqual(eventsProcessor.packager.packages.count, 1, "a retryable package must be kept")
+  }
+
+  func testPackageDroppedAfterMaxRetryCount() {
+    let exp = expectation(description: "two sync attempts")
+    exp.expectedFulfillmentCount = 2
+
+    let service = FailingEventService<String>()
+    service.didSendEvents = { _ in exp.fulfill() }
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 0.1,
+                                         maxRetryCount: 2,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("Test event")
+
+    waitForExpectations(timeout: 5, handler: nil)
+    queue.sync {}
+    XCTAssertTrue(eventsProcessor.packager.packages.isEmpty, "the package must be dropped once the retry count is exhausted")
+  }
+
+  func testNonRetryableFailureRemovesPackage() {
+    let service = NonRetryableFailingEventService<String>()
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("Test event")
+    queue.sync {}
+
+    eventsProcessor.flush()
+    queue.sync {}
+    queue.sync {}
+
+    eventsProcessor.flush()
+    queue.sync {}
+
+    XCTAssertEqual(service.sendCount, 1)
+    XCTAssertTrue(eventsProcessor.packager.packages.isEmpty)
+  }
+
+  func testFullyFilteredPackageIsRemoved() throws {
+    let service = HoldingEventService<Int>()
+    let queue = DispatchQueue(label: "test queue")
+
+    let storage = TestPackageStorage<Int>()
+    storage.store([try .init(items: [1, 3], capacity: 2)])
+
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         acceptEvent: { $0 % 2 == 0 },
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.flush()
+    queue.sync {}
+
+    XCTAssertTrue(service.sentEvents.isEmpty)
+    XCTAssertTrue(eventsProcessor.packager.packages.isEmpty, "a package whose events are all filtered out must be removed")
+  }
+
+  func testExpiredPackageIsDroppedWithoutSending() {
+    let service = HoldingEventService<String>()
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         packageExpirationDelay: 0.05,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("Test event")
+    queue.sync {}
+
+    Thread.sleep(forTimeInterval: 0.2)
+
+    eventsProcessor.flush()
+    queue.sync {}
+
+    XCTAssertTrue(service.sentEvents.isEmpty, "an expired package must not be sent")
+    XCTAssertTrue(eventsProcessor.packager.packages.isEmpty, "an expired package must be removed")
   }
 }

--- a/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/EventsProcessorTests.swift
@@ -371,6 +371,37 @@ class EventsProcessorTests: XCTestCase {
     XCTAssertEqual(eventsProcessor.packager.packages.count, 1, "a retryable package must be kept")
   }
 
+  func testEventProcessedAfterFailureDoesNotResetBackoff() {
+    let service = FailingEventService<String>()
+    let queue = DispatchQueue(label: "test queue")
+    let eventsProcessor = EventProcessor(service: service,
+                                         storage: storage,
+                                         packageCapacity: 10,
+                                         flushNotificationName: nil,
+                                         flushDelay: 1000,
+                                         logger: Logger(label: #function),
+                                         dispatchQueue: queue)
+
+    eventsProcessor.process("first")
+    queue.sync {}
+
+    eventsProcessor.flush()
+    queue.sync {}
+    queue.sync {}
+
+    eventsProcessor.process("second")
+    queue.sync {}
+
+    XCTAssertEqual(eventsProcessor.packager.packages.count, 2, "an event tracked after a failure must start a new package, not reset the failed one")
+
+    eventsProcessor.flush()
+    queue.sync {}
+    queue.sync {}
+
+    XCTAssertEqual(service.sendCount, 2, "only the new package may be sent while the failed one is backing off")
+    XCTAssertEqual(eventsProcessor.packager.packages.map(\.items), [["first"], ["second"]], "both packages must be kept for retry")
+  }
+
   func testPackageDroppedAfterMaxRetryCount() {
     let exp = expectation(description: "two sync attempts")
     exp.expectedFulfillmentCount = 2

--- a/Tests/InstantSearchInsightsTests/Unit/PackageTests.swift
+++ b/Tests/InstantSearchInsightsTests/Unit/PackageTests.swift
@@ -28,6 +28,7 @@ class PackageTests: XCTestCase {
     try AssertEncodeDecode(package, [
       "id": .init(package.id),
       "capacity": .init(Algolia.Insights.minBatchSize),
+      "creationDate": .init(package.creationDate.timeIntervalSinceReferenceDate),
       "items": [
         [
           "eventType": "clickedFilters",
@@ -114,9 +115,25 @@ class PackageTests: XCTestCase {
     let updatedPackage = try eventsPackage.appending(TestEvent.random)
 
     XCTAssertEqual(updatedPackage.items.count, eventsCount + 1)
+    XCTAssertEqual(updatedPackage.creationDate, eventsPackage.creationDate)
 
     let anotherUpdatedPackage = try eventsPackage.appending(events)
 
     XCTAssertEqual(anotherUpdatedPackage.items.count, events.count * 2)
+  }
+
+  func testDecodingLegacyPackageWithoutCreationDate() throws {
+    let legacyJSON = """
+    {
+      "id": "7DE20DED-380B-4381-9CC7-EB94B1E1E3F2",
+      "capacity": 2,
+      "items": ["a", "b"]
+    }
+    """
+    let package = try JSONDecoder().decode(Package<String>.self, from: Data(legacyJSON.utf8))
+
+    XCTAssertEqual(package.id, "7DE20DED-380B-4381-9CC7-EB94B1E1E3F2")
+    XCTAssertEqual(package.items, ["a", "b"])
+    XCTAssertEqual(package.creationDate.timeIntervalSinceNow, 0, accuracy: 10)
   }
 }


### PR DESCRIPTION
**Summary**

The Insights EventProcessor retries failed event packages forever: the 30 second flush timer re-sends every pending package with no in-flight tracking, no backoff, no retry limit and no expiration. On flaky networks where the request reaches the server but the response is lost, the same events are accepted and logged again on every retry, unbounded. This was reported in CR-11910, where a single userToken accumulated about 10M events in two weeks.

Changes:

- Flush skips packages that are still awaiting a service response, so a slow request is no longer re-sent concurrently every 30 seconds (`EventProcessor.swift:188-203`).
- New events start a new package instead of being appended to an in-flight one. Appending changes the package id, which broke the removal of the package after a successful send and re-sent already delivered events (`Packager.swift:24-43`, `EventProcessor.swift:155-169`).
- Retryable failures back off exponentially, capped at 15 minutes, and a package is dropped after 20 failed attempts (`EventProcessor.swift:239-249`, constants in `Config.swift:33-41`).
- A package waiting out its backoff is sealed like an in-flight one: a new event starts a new package instead of changing the failed package id, which would have reset its backoff and retry count (`EventProcessor.swift:157-160`, covered by `testEventProcessedAfterFailureDoesNotResetBackoff`).
- Stored packages are discarded after 4 days, the server-side event acceptance window. Before, packages with events created with `generateTimestamps: false` could live forever (`EventProcessor.swift:179-186`).
- Packages whose events are all filtered out by the acceptance condition are removed instead of being re-evaluated on every flush (`EventProcessor.swift:216-221`).
- `Package` now persists its creation date. Files stored by previous versions decode with the load date as a fallback (`Package.swift:94-116`, covered by `testDecodingLegacyPackageWithoutCreationDate`).

**Result**

- `swift build` passes locally with Swift 6.3.3.
- Eight new unit tests in `EventsProcessorTests.swift` cover the in-flight guard, the sealed packing, the backoff, the backoff surviving new events, the retry cap, the non-retryable removal, the filtered package cleanup and the expiration, plus the legacy decoding test in `PackageTests.swift`. They need the CI macOS runner to execute since XCTest is not available with Command Line Tools only, please check the Swift workflow run on this PR.
